### PR TITLE
vlan: implement multicast ethernet filtering

### DIFF
--- a/modules/infra/control/gr_iface.h
+++ b/modules/infra/control/gr_iface.h
@@ -79,8 +79,8 @@ struct iface *iface_from_id(uint16_t ifid);
 void iface_add_subinterface(struct iface *parent, const struct iface *sub);
 void iface_del_subinterface(struct iface *parent, const struct iface *sub);
 int iface_get_eth_addr(uint16_t ifid, struct rte_ether_addr *);
-int iface_add_eth_addr(uint16_t ifid, struct rte_ether_addr *);
-int iface_del_eth_addr(uint16_t ifid, struct rte_ether_addr *);
+int iface_add_eth_addr(uint16_t ifid, const struct rte_ether_addr *);
+int iface_del_eth_addr(uint16_t ifid, const struct rte_ether_addr *);
 uint16_t ifaces_count(uint16_t type_id);
 struct iface *iface_next(uint16_t type_id, const struct iface *prev);
 

--- a/modules/infra/control/iface.c
+++ b/modules/infra/control/iface.c
@@ -219,7 +219,7 @@ void iface_del_subinterface(struct iface *parent, const struct iface *sub) {
 	}
 }
 
-int iface_add_eth_addr(uint16_t ifid, struct rte_ether_addr *mac) {
+int iface_add_eth_addr(uint16_t ifid, const struct rte_ether_addr *mac) {
 	struct iface *iface = iface_from_id(ifid);
 	struct iface_type *type;
 
@@ -234,7 +234,7 @@ int iface_add_eth_addr(uint16_t ifid, struct rte_ether_addr *mac) {
 	return type->add_eth_addr(iface, mac);
 }
 
-int iface_del_eth_addr(uint16_t ifid, struct rte_ether_addr *mac) {
+int iface_del_eth_addr(uint16_t ifid, const struct rte_ether_addr *mac) {
 	struct iface *iface = iface_from_id(ifid);
 	struct iface_type *type;
 

--- a/modules/infra/control/vlan.c
+++ b/modules/infra/control/vlan.c
@@ -181,6 +181,24 @@ static int iface_vlan_get_eth_addr(const struct iface *iface, struct rte_ether_a
 	return 0;
 }
 
+static int iface_vlan_add_eth_addr(struct iface *iface, const struct rte_ether_addr *mac) {
+	const struct iface_info_vlan *vlan = (const struct iface_info_vlan *)iface->info;
+
+	if (mac == NULL || !rte_is_multicast_ether_addr(mac))
+		return errno_set(EINVAL);
+
+	return iface_add_eth_addr(vlan->parent_id, mac);
+}
+
+static int iface_vlan_del_eth_addr(struct iface *iface, const struct rte_ether_addr *mac) {
+	const struct iface_info_vlan *vlan = (const struct iface_info_vlan *)iface->info;
+
+	if (mac == NULL || !rte_is_multicast_ether_addr(mac))
+		return errno_set(EINVAL);
+
+	return iface_del_eth_addr(vlan->parent_id, mac);
+}
+
 static void vlan_to_api(void *info, const struct iface *iface) {
 	const struct iface_info_vlan *vlan = (const struct iface_info_vlan *)iface->info;
 	struct gr_iface_info_vlan *api = info;
@@ -198,6 +216,8 @@ static struct iface_type iface_type_vlan = {
 	.reconfig = iface_vlan_reconfig,
 	.fini = iface_vlan_fini,
 	.get_eth_addr = iface_vlan_get_eth_addr,
+	.add_eth_addr = iface_vlan_add_eth_addr,
+	.del_eth_addr = iface_vlan_del_eth_addr,
 	.to_api = vlan_to_api,
 };
 


### PR DESCRIPTION
Allow vlan interfaces to ask their parent port to allow certain multicast ethernet addresses related to their IPv6 addresses.