### PR TITLE
trace: display stripped vlans

### DIFF
--- a/modules/infra/datapath/eth_input.c
+++ b/modules/infra/datapath/eth_input.c
@@ -56,11 +56,7 @@ eth_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 		eth_type = eth->ether_type;
 		vlan_id = 0;
 
-		if (m->ol_flags & RTE_MBUF_F_RX_VLAN) {
-			if (!(m->ol_flags & RTE_MBUF_F_RX_VLAN_STRIPPED)) {
-				vlan = rte_pktmbuf_mtod(m, struct rte_vlan_hdr *);
-				rte_pktmbuf_adj(m, sizeof(*vlan));
-			}
+		if (m->ol_flags & RTE_MBUF_F_RX_VLAN_STRIPPED) {
 			vlan_id = m->vlan_tci & 0xfff;
 		} else if (eth_type == RTE_BE16(RTE_ETHER_TYPE_VLAN)) {
 			vlan = rte_pktmbuf_mtod(m, struct rte_vlan_hdr *);

--- a/modules/infra/datapath/trace.c
+++ b/modules/infra/datapath/trace.c
@@ -44,7 +44,10 @@ void trace_packet(const char *node, const char *iface, const struct rte_mbuf *m)
 		ETH_ADDR_SPLIT(&eth->dst_addr)
 	);
 
-	if (ether_type == RTE_ETHER_TYPE_VLAN) {
+	if (m->ol_flags & RTE_MBUF_F_RX_VLAN_STRIPPED) {
+		uint16_t vlan_id = m->vlan_tci & 0xfff;
+		n += snprintf(buf + n, sizeof(buf) - n, " / VLAN id=%u", vlan_id);
+	} else if (ether_type == RTE_ETHER_TYPE_VLAN) {
 		const struct rte_vlan_hdr *vlan;
 		uint16_t vlan_id;
 


### PR DESCRIPTION
When the NIC is able to strip the vlan tag, the vlan id is available in the mbuf metadata. Use that information to display the vlan header even if it was stripped from the packet buffer.