### PR TITLE
treewide: homogenize how unused parameters are identified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       MESON_EXTRA_OPTS: "-Ddpdk:platform=generic"
       DEBIAN_FRONTEND: noninteractive
       NEEDRESTART_MODE: l
+      CC: gcc-14
     steps:
       - name: install system dependencies
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,6 +257,62 @@ The code can be automatically formatted by running `gmake format`.
 
 If `gmake lint` accepts your code, it is most likely properly formatted.
 
+### Unused function parameters
+
+When a function definition has unused parameters because the implementation
+does not make any use of them, the compiler will produce warnings.
+
+The whole grout code base is compiled with `--std=gnu2x` which allows unnamed
+parameters even in function definitions. Make use of that to indicate unused
+parameters.
+
+When the parameter type is explicit (e.g. `struct rte_graph *`), simply remove
+the parameter name which is usually redundant, e.g.:
+
+```c
+void foo(struct rte_graph *, struct rte_node *node, void *priv) {
+        bar(node, priv);
+}
+```
+
+When the type is not explicit (e.g. `int` or `void *`), keep the parameter
+wrapped in a "block" style comment, e.g.:
+
+```c
+void foo(struct rte_graph *, struct rte_node *node, void * /*priv*/) {
+        baz(node);
+}
+```
+
+Do NOT use inline `(void)arg;` statements:
+
+```c
+void foo(struct rte_graph *graph, struct rte_node *node, void *priv) {
+        (void)graph;
+        (void)priv;
+        baz(node);
+}
+```
+
+Since it can be confusing in long functions and does not convey any meaning
+about the variables being unused parameters or local variables. Also, even if
+the parameters would become used in the future, the compiler will not warn
+about a useless warning suppression.
+
+Also AVOID `__attribute__((unused))` (or any macro wrapping it):
+
+```c
+void foo(
+        struct rte_graph *graph __attribute__((unused)),
+        struct rte_node *node,
+        void * priv __rte_unused
+) {
+        baz(node);
+}
+```
+
+It is overly verbose.
+
 ### Commenting
 
 Use C99 line comments:
@@ -276,6 +332,9 @@ Do NOT use block comments:
  */
 int foo(void);
 ```
+
+The only place where "block" style comments should be used is to identify
+unused function parameters (see previous section).
 
 ### Editor modelines
 

--- a/cli/ec_node_devargs.c
+++ b/cli/ec_node_devargs.c
@@ -14,14 +14,8 @@
 
 EC_LOG_TYPE_REGISTER(node_devargs);
 
-static int ec_node_devargs_parse(
-	const struct ec_node *node,
-	struct ec_pnode *pstate,
-	const struct ec_strvec *strvec
-) {
-	(void)node;
-	(void)pstate;
-
+static int
+ec_node_devargs_parse(const struct ec_node *, struct ec_pnode *, const struct ec_strvec *strvec) {
 	if (ec_strvec_len(strvec) == 0)
 		return EC_PARSE_NOMATCH;
 

--- a/cli/ec_node_dyn.c
+++ b/cli/ec_node_dyn.c
@@ -17,14 +17,8 @@ struct ec_node_dyn {
 	void *cb_arg;
 };
 
-static int ec_node_dyn_parse(
-	const struct ec_node *node,
-	struct ec_pnode *pstate,
-	const struct ec_strvec *strvec
-) {
-	(void)node;
-	(void)pstate;
-
+static int
+ec_node_dyn_parse(const struct ec_node *, struct ec_pnode *, const struct ec_strvec *strvec) {
 	if (ec_strvec_len(strvec) == 0)
 		return EC_PARSE_NOMATCH;
 

--- a/cli/interact.c
+++ b/cli/interact.c
@@ -45,9 +45,7 @@ out:
 	ec_editline_free_helps(sug, n);
 }
 
-static void sighandler(int signum) {
-	(void)signum;
-}
+static void sighandler(int) { }
 
 #if defined(__has_feature) && !defined(__SANITIZE_ADDRESS__)
 #if __has_feature(address_sanitizer)

--- a/cli/log.c
+++ b/cli/log.c
@@ -10,9 +10,9 @@
 #include <errno.h>
 #include <unistd.h>
 
-bool stdin_isatty;
-bool stdout_isatty;
-bool stderr_isatty;
+static bool stdin_isatty;
+static bool stdout_isatty;
+static bool stderr_isatty;
 
 void tty_init(void) {
 	stdin_isatty = isatty(0);

--- a/cli/main.c
+++ b/cli/main.c
@@ -53,7 +53,7 @@ struct gr_cli_opts {
 	bool trace_commands;
 };
 
-struct gr_cli_opts opts;
+static struct gr_cli_opts opts;
 
 static int parse_args(int argc, char **argv) {
 	int c;

--- a/cli/quit.c
+++ b/cli/quit.c
@@ -4,9 +4,7 @@
 #include <gr_api.h>
 #include <gr_cli.h>
 
-static cmd_status_t quit(const struct gr_api_client *c, const struct ec_pnode *p) {
-	(void)c;
-	(void)p;
+static cmd_status_t quit(const struct gr_api_client *, const struct ec_pnode *) {
 	return CMD_EXIT;
 }
 

--- a/main/dpdk.c
+++ b/main/dpdk.c
@@ -24,7 +24,7 @@ int gr_rte_log_type;
 static FILE *log_stream;
 static bool log_syslog;
 
-static ssize_t log_write(void *, const char *buf, size_t size) {
+static ssize_t log_write(void * /*cookie*/, const char *buf, size_t size) {
 	ssize_t n;
 	if (log_syslog) {
 		// Syslog error levels are from 0 to 7, so subtract 1 to convert.

--- a/main/main.c
+++ b/main/main.c
@@ -127,8 +127,7 @@ end:
 	return 0;
 }
 
-static void finalize_close_fd(struct event *ev, void *priv) {
-	(void)priv;
+static void finalize_close_fd(struct event *ev, void * /*priv*/) {
 	close(event_get_fd(ev));
 }
 
@@ -149,11 +148,9 @@ static ssize_t send_response(evutil_socket_t sock, struct gr_api_response *resp)
 
 static struct event_base *ev_base;
 
-static void api_write_cb(evutil_socket_t sock, short what, void *priv) {
+static void api_write_cb(evutil_socket_t sock, short /*what*/, void *priv) {
 	struct event *ev = event_base_get_running_event(ev_base);
 	struct gr_api_response *resp = priv;
-
-	(void)what;
 
 	if (send_response(sock, resp) < 0) {
 		if (errno == EAGAIN || errno == EWOULDBLOCK)
@@ -175,7 +172,7 @@ free:
 		event_free(ev);
 }
 
-static void api_read_cb(evutil_socket_t sock, short what, void *ctx) {
+static void api_read_cb(evutil_socket_t sock, short what, void * /*ctx*/) {
 	struct event *ev = event_base_get_running_event(ev_base);
 	void *req_payload = NULL, *resp_payload = NULL;
 	struct gr_api_response *resp = NULL;
@@ -183,8 +180,6 @@ static void api_read_cb(evutil_socket_t sock, short what, void *ctx) {
 	struct event *write_ev;
 	struct api_out out;
 	ssize_t len;
-
-	(void)ctx;
 
 	if (what & EV_CLOSED)
 		goto close;
@@ -273,11 +268,9 @@ close:
 		event_free_finalize(0, ev, finalize_close_fd);
 }
 
-static void listen_cb(evutil_socket_t sock, short what, void *ctx) {
+static void listen_cb(evutil_socket_t sock, short what, void * /*ctx*/) {
 	struct event *ev;
 	int fd;
-
-	(void)ctx;
 
 	if (what & EV_CLOSED) {
 		ev = event_base_get_running_event(ev_base);
@@ -354,7 +347,7 @@ static int listen_api_socket(void) {
 	return 0;
 }
 
-static int ev_close(const struct event_base *, const struct event *ev, void *) {
+static int ev_close(const struct event_base *, const struct event *ev, void * /*priv*/) {
 	event_callback_fn cb = event_get_callback(ev);
 	if (cb == api_read_cb || cb == api_write_cb)
 		event_free_finalize(0, (struct event *)ev, finalize_close_fd);

--- a/main/signals.c
+++ b/main/signals.c
@@ -10,10 +10,8 @@
 #include <signal.h>
 #include <string.h>
 
-static void signal_cb(evutil_socket_t sig, short what, void *priv) {
+static void signal_cb(evutil_socket_t sig, short /*what*/, void *priv) {
 	struct event_base *base = priv;
-
-	(void)what;
 
 	LOG(NOTICE, "received signal SIG%s", sigabbrev_np(sig));
 

--- a/meson.build
+++ b/meson.build
@@ -19,9 +19,13 @@ project(
   ],
 )
 
+compiler = meson.get_compiler('c')
 add_project_arguments('-D_GNU_SOURCE', language: 'c')
 add_project_arguments('-DALLOW_EXPERIMENTAL_API', language: 'c')
 add_project_arguments('-Wmissing-prototypes', language: 'c')
+if compiler.has_argument('-Wmissing-variable-declarations')
+  add_project_arguments('-Wmissing-variable-declarations', language: 'c')
+endif
 add_project_arguments('-fstrict-aliasing', language: 'c')
 add_project_arguments('-Wstrict-aliasing=2', language: 'c')
 add_project_arguments('-Wno-format-truncation', language: 'c')

--- a/modules/infra/api/graph.c
+++ b/modules/infra/api/graph.c
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include <sys/queue.h>
 
-static struct api_out graph_dump(const void *request, void **response) {
+static struct api_out graph_dump(const void * /*request*/, void **response) {
 	struct gr_infra_graph_dump_resp *resp;
 	size_t buf_len = 0, resp_len = 0;
 	const char *graph_name;
@@ -21,8 +21,6 @@ static struct api_out graph_dump(const void *request, void **response) {
 	FILE *stream = NULL;
 	char *buf = NULL;
 	int ret = 0;
-
-	(void)request;
 
 	STAILQ_FOREACH (worker, &workers, next) {
 		for (int i = 0; i < 2; i++) {

--- a/modules/infra/api/iface.c
+++ b/modules/infra/api/iface.c
@@ -52,11 +52,9 @@ static struct api_out iface_add(const void *request, void **response) {
 	return api_out(0, sizeof(*resp));
 }
 
-static struct api_out iface_del(const void *request, void **response) {
+static struct api_out iface_del(const void *request, void ** /*response*/) {
 	const struct gr_infra_iface_del_req *req = request;
 	int ret;
-
-	(void)response;
 
 	ret = iface_destroy(req->iface_id);
 
@@ -101,11 +99,9 @@ static struct api_out iface_list(const void *request, void **response) {
 	return api_out(0, len);
 }
 
-static struct api_out iface_set(const void *request, void **response) {
+static struct api_out iface_set(const void *request, void ** /*response*/) {
 	const struct gr_infra_iface_set_req *req = request;
 	int ret;
-
-	(void)response;
 
 	ret = iface_reconfig(
 		req->iface.id,

--- a/modules/infra/api/rxq.c
+++ b/modules/infra/api/rxq.c
@@ -13,14 +13,12 @@
 #include <sys/queue.h>
 #include <unistd.h>
 
-static struct api_out rxq_list(const void *request, void **response) {
+static struct api_out rxq_list(const void * /*request*/, void **response) {
 	struct gr_infra_rxq_list_resp *resp = NULL;
 	struct queue_map *qmap;
 	struct worker *worker;
 	uint16_t n_rxqs = 0;
 	size_t len;
-
-	(void)request;
 
 	STAILQ_FOREACH (worker, &workers, next)
 		n_rxqs += arrlen(worker->rxqs);
@@ -48,12 +46,10 @@ static struct api_out rxq_list(const void *request, void **response) {
 	return api_out(0, len);
 }
 
-static struct api_out rxq_set(const void *request, void **response) {
+static struct api_out rxq_set(const void *request, void ** /*response*/) {
 	const struct gr_infra_rxq_set_req *req = request;
 	struct iface *iface = iface_from_id(req->iface_id);
 	struct iface_info_port *port;
-
-	(void)response;
 
 	if (iface == NULL)
 		return api_out(errno, 0);

--- a/modules/infra/api/stats.c
+++ b/modules/infra/api/stats.c
@@ -175,13 +175,10 @@ err:
 	return api_out(-ret, 0);
 }
 
-static struct api_out stats_reset(const void *request, void **response) {
+static struct api_out stats_reset(const void * /*request*/, void ** /*response*/) {
 	struct worker *worker;
 	struct iface *iface;
 	int ret;
-
-	(void)request;
-	(void)response;
 
 	STAILQ_FOREACH (worker, &workers, next)
 		atomic_store(&worker->stats_reset, true);

--- a/modules/infra/cli/graph.c
+++ b/modules/infra/cli/graph.c
@@ -11,11 +11,9 @@
 #include <stdio.h>
 #include <unistd.h>
 
-static cmd_status_t graph_dump(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t graph_dump(const struct gr_api_client *c, const struct ec_pnode *) {
 	const struct gr_infra_graph_dump_resp *resp;
 	void *resp_ptr = NULL;
-
-	(void)p;
 
 	if (gr_api_client_send_recv(c, GR_INFRA_GRAPH_DUMP, 0, NULL, &resp_ptr) < 0)
 		return CMD_ERROR;

--- a/modules/infra/cli/iface.c
+++ b/modules/infra/cli/iface.c
@@ -39,16 +39,13 @@ const struct cli_iface_type *type_from_name(const char *name) {
 }
 
 int complete_iface_types(
-	const struct gr_api_client *c,
+	const struct gr_api_client *,
 	const struct ec_node *node,
 	struct ec_comp *comp,
 	const char *arg,
-	void *cb_arg
+	void * /*cb_arg*/
 ) {
 	const struct cli_iface_type *type;
-
-	(void)c;
-	(void)cb_arg;
 
 	STAILQ_FOREACH (type, &types, next) {
 		if (!ec_str_startswith(type->name, arg))

--- a/modules/infra/cli/port.c
+++ b/modules/infra/cli/port.c
@@ -143,12 +143,10 @@ static int rxqs_order(const void *a, const void *b) {
 	return rxq_a->cpu_id - rxq_b->cpu_id;
 }
 
-static cmd_status_t rxq_list(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t rxq_list(const struct gr_api_client *c, const struct ec_pnode *) {
 	struct libscols_table *table = scols_new_table();
 	struct gr_infra_rxq_list_resp *resp;
 	void *resp_ptr = NULL;
-
-	(void)p;
 
 	if (table == NULL)
 		return CMD_ERROR;

--- a/modules/infra/cli/stats.c
+++ b/modules/infra/cli/stats.c
@@ -103,9 +103,7 @@ fail:
 	return CMD_ERROR;
 }
 
-static cmd_status_t stats_reset(const struct gr_api_client *c, const struct ec_pnode *p) {
-	(void)p;
-
+static cmd_status_t stats_reset(const struct gr_api_client *c, const struct ec_pnode *) {
 	if (gr_api_client_send_recv(c, GR_INFRA_STATS_RESET, 0, NULL, NULL) < 0)
 		return CMD_ERROR;
 

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -610,7 +610,7 @@ static void port_to_api(void *info, const struct iface *iface) {
 
 static struct event *link_event;
 
-static void link_event_cb(evutil_socket_t, short, void *) {
+static void link_event_cb(evutil_socket_t, short /*what*/, void * /*priv*/) {
 	unsigned max_sleep_us, rx_buffer_us;
 	struct rte_eth_rxq_info qinfo;
 	struct rte_eth_link link;
@@ -670,7 +670,12 @@ static void link_event_cb(evutil_socket_t, short, void *) {
 	}
 }
 
-static int lsc_port_cb(uint16_t, enum rte_eth_event_type, void *, void *) {
+static int lsc_port_cb(
+	uint16_t /*port_id*/,
+	enum rte_eth_event_type,
+	void * /*cb_arg*/,
+	void * /*ret_param*/
+) {
 	// This callback may be executed from any dataplane or DPDK thread.
 	// In order to serialize the update of port status, propagate the callback
 	// event to the event loop running in the main lcore.

--- a/modules/infra/control/worker_test.c
+++ b/modules/infra/control/worker_test.c
@@ -24,6 +24,7 @@ static struct worker w3 = {.cpu_id = 3, .started = true};
 static struct rte_eth_dev_info dev_info = {.nb_rx_queues = 2};
 
 // mocked types/functions
+extern int gr_rte_log_type;
 int gr_rte_log_type;
 void gr_register_api_handler(struct gr_api_handler *) { }
 void gr_register_module(struct gr_module *) { }
@@ -32,7 +33,7 @@ void iface_event_notify(iface_event_t, struct iface *) { }
 mock_func(struct rte_mempool *, gr_pktmbuf_pool_get(int8_t, uint32_t));
 void gr_pktmbuf_pool_release(struct rte_mempool *, uint32_t) { }
 
-struct gr_args args;
+static struct gr_args args;
 const struct gr_args *gr_args(void) {
 	return &args;
 }

--- a/modules/infra/control/worker_test.c
+++ b/modules/infra/control/worker_test.c
@@ -41,9 +41,8 @@ struct iface *iface_from_id(uint16_t ifid) {
 	return ifid < ARRAY_DIM(ifaces) ? ifaces[ifid] : NULL;
 }
 
-struct iface *iface_next(uint16_t type_id, const struct iface *prev) {
+struct iface *iface_next(uint16_t /*type_id*/, const struct iface *prev) {
 	uint16_t ifid;
-	(void)type_id;
 	if (prev == NULL)
 		ifid = 0;
 	else

--- a/modules/infra/datapath/control_input.c
+++ b/modules/infra/datapath/control_input.c
@@ -49,8 +49,12 @@ int post_to_stack(control_input_t type, void *data) {
 	return 0;
 }
 
-static uint16_t
-control_input_process(struct rte_graph *graph, struct rte_node *node, void **, uint16_t) {
+static uint16_t control_input_process(
+	struct rte_graph *graph,
+	struct rte_node *node,
+	void ** /*objs*/,
+	uint16_t /*nb_objs*/
+) {
 	struct gr_control_input_msg msg[RTE_GRAPH_BURST_SIZE];
 	struct rte_mempool *mp;
 	struct rte_mbuf *mbuf;
@@ -86,8 +90,7 @@ static int control_input_init(const struct rte_graph *graph, struct rte_node *no
 	return 0;
 }
 
-static void control_input_fini(const struct rte_graph *graph, struct rte_node *node) {
-	(void)graph;
+static void control_input_fini(const struct rte_graph *, struct rte_node *node) {
 	gr_pktmbuf_pool_release(node->ctx_ptr, RTE_GRAPH_BURST_SIZE);
 	node->ctx_ptr = NULL;
 }

--- a/modules/infra/datapath/drop.c
+++ b/modules/infra/datapath/drop.c
@@ -7,11 +7,7 @@
 #include <rte_graph_worker.h>
 #include <rte_mbuf.h>
 
-uint16_t
-drop_packets(struct rte_graph *graph, struct rte_node *node, void **objs, uint16_t nb_objs) {
-	(void)node;
-	(void)graph;
-
+uint16_t drop_packets(struct rte_graph *, struct rte_node *node, void **objs, uint16_t nb_objs) {
 	if (unlikely(packet_trace_enabled)) {
 		LOG(NOTICE, "[%s] %u packets", node->name, nb_objs);
 	}

--- a/modules/infra/datapath/main_loop.c
+++ b/modules/infra/datapath/main_loop.c
@@ -30,8 +30,8 @@ struct stats_context {
 };
 
 static int node_stats_callback(
-	bool is_first,
-	bool is_last,
+	bool /*is_first*/,
+	bool /*is_last*/,
 	void *cookie,
 	const struct rte_graph_cluster_node_stats *stats
 ) {
@@ -39,9 +39,6 @@ static int node_stats_callback(
 	struct node_stats *s;
 	uint64_t objs_incr;
 	uint8_t index;
-
-	(void)is_first;
-	(void)is_last;
 
 	objs_incr = stats->objs - stats->prev_objs;
 	ctx->last_count += objs_incr;

--- a/modules/infra/datapath/rx.c
+++ b/modules/infra/datapath/rx.c
@@ -33,15 +33,13 @@ struct rx_ctx {
 };
 
 static uint16_t
-rx_process(struct rte_graph *graph, struct rte_node *node, void **objs, uint16_t count) {
+rx_process(struct rte_graph *graph, struct rte_node *node, void ** /*objs*/, uint16_t count) {
 	const struct rx_ctx *ctx = node->ctx_ptr;
 	struct eth_input_mbuf_data *d;
 	const struct iface *iface;
 	struct rx_port_queue q;
 	uint16_t rx;
 	unsigned r;
-
-	(void)objs;
 
 	count = 0;
 	for (int i = 0; i < ctx->n_queues; i++) {
@@ -77,8 +75,6 @@ static int rx_init(const struct rte_graph *graph, struct rte_node *node) {
 	const struct rx_node_queues *data;
 	struct rx_ctx *ctx;
 
-	(void)graph;
-
 	if ((data = gr_node_data_get(graph->name, node->name)) == NULL)
 		return -1;
 
@@ -97,8 +93,7 @@ static int rx_init(const struct rte_graph *graph, struct rte_node *node) {
 	return 0;
 }
 
-static void rx_fini(const struct rte_graph *graph, struct rte_node *node) {
-	(void)graph;
+static void rx_fini(const struct rte_graph *, struct rte_node *node) {
 	rte_free(node->ctx_ptr);
 }
 

--- a/modules/infra/datapath/tx.c
+++ b/modules/infra/datapath/tx.c
@@ -78,8 +78,6 @@ static int tx_init(const struct rte_graph *graph, struct rte_node *node) {
 	const struct tx_node_queues *data;
 	struct tx_ctx *ctx;
 
-	(void)graph;
-
 	if ((data = gr_node_data_get(graph->name, node->name)) == NULL)
 		return -1;
 
@@ -94,8 +92,7 @@ static int tx_init(const struct rte_graph *graph, struct rte_node *node) {
 	return 0;
 }
 
-static void tx_fini(const struct rte_graph *graph, struct rte_node *node) {
-	(void)graph;
+static void tx_fini(const struct rte_graph *, struct rte_node *node) {
 	rte_free(node->ctx_ptr);
 }
 

--- a/modules/ip/cli/address.c
+++ b/modules/ip/cli/address.c
@@ -56,8 +56,6 @@ static cmd_status_t addr_list(const struct gr_api_client *c, const struct ec_pno
 	void *resp_ptr = NULL;
 	char buf[BUFSIZ];
 
-	(void)p;
-
 	if (table == NULL)
 		return CMD_ERROR;
 

--- a/modules/ip/cli/nexthop.c
+++ b/modules/ip/cli/nexthop.c
@@ -61,8 +61,6 @@ static cmd_status_t nh4_list(const struct gr_api_client *c, const struct ec_pnod
 	void *resp_ptr = NULL;
 	ssize_t n;
 
-	(void)p;
-
 	if (table == NULL)
 		return CMD_ERROR;
 	if (arg_u16(p, "VRF", &req.vrf_id) < 0 && errno != ENOENT) {

--- a/modules/ip/cli/route.c
+++ b/modules/ip/cli/route.c
@@ -54,8 +54,6 @@ static cmd_status_t route4_list(const struct gr_api_client *c, const struct ec_p
 	char dest[BUFSIZ], nh[BUFSIZ];
 	void *resp_ptr = NULL;
 
-	(void)p;
-
 	if (table == NULL)
 		return CMD_ERROR;
 

--- a/modules/ip/control/address.c
+++ b/modules/ip/control/address.c
@@ -56,15 +56,13 @@ struct nexthop *ip4_addr_get_preferred(uint16_t iface_id, ip4_addr_t dst) {
 	return addrs->nh[0];
 }
 
-static struct api_out addr_add(const void *request, void **response) {
+static struct api_out addr_add(const void *request, void ** /*response*/) {
 	const struct gr_ip4_addr_add_req *req = request;
 	struct hoplist *ifaddrs;
 	const struct iface *iface;
 	unsigned addr_index;
 	struct nexthop *nh;
 	int ret;
-
-	(void)response;
 
 	iface = iface_from_id(req->addr.iface_id);
 	if (iface == NULL)
@@ -107,13 +105,11 @@ static struct api_out addr_add(const void *request, void **response) {
 	return api_out(0, 0);
 }
 
-static struct api_out addr_del(const void *request, void **response) {
+static struct api_out addr_del(const void *request, void ** /*response*/) {
 	const struct gr_ip4_addr_del_req *req = request;
 	struct hoplist *addrs;
 	struct nexthop *nh = NULL;
 	unsigned i;
-
-	(void)response;
 
 	if ((addrs = ip4_addr_get_all(req->addr.iface_id)) == NULL)
 		return api_out(ENODEV, 0);

--- a/modules/ip/control/nexthop.c
+++ b/modules/ip/control/nexthop.c
@@ -46,7 +46,7 @@ struct lookup_filter {
 	struct nexthop *nh;
 };
 
-static void nh_lookup_cb(struct rte_mempool *, void *opaque, void *obj, unsigned) {
+static void nh_lookup_cb(struct rte_mempool *, void *opaque, void *obj, unsigned /*obj_idx*/) {
 	struct lookup_filter *filter = opaque;
 	struct nexthop *nh = obj;
 	if (filter->nh == NULL && nh->ref_count > 0 && nh->ip == filter->ip
@@ -82,12 +82,10 @@ void ip4_nexthop_incref(struct nexthop *nh) {
 	nh->ref_count++;
 }
 
-static struct api_out nh4_add(const void *request, void **response) {
+static struct api_out nh4_add(const void *request, void ** /*response*/) {
 	const struct gr_ip4_nh_add_req *req = request;
 	struct nexthop *nh;
 	int ret;
-
-	(void)response;
 
 	if (req->nh.host == 0)
 		return api_out(EINVAL, 0);
@@ -113,11 +111,9 @@ static struct api_out nh4_add(const void *request, void **response) {
 	return api_out(-ret, 0);
 }
 
-static struct api_out nh4_del(const void *request, void **response) {
+static struct api_out nh4_del(const void *request, void ** /*response*/) {
 	const struct gr_ip4_nh_del_req *req = request;
 	struct nexthop *nh;
-
-	(void)response;
 
 	if (req->vrf_id >= IP4_MAX_VRFS)
 		return api_out(EOVERFLOW, 0);
@@ -143,7 +139,7 @@ struct list_context {
 	struct gr_ip4_nh *nh;
 };
 
-static void nh_list_cb(struct rte_mempool *, void *opaque, void *obj, unsigned) {
+static void nh_list_cb(struct rte_mempool *, void *opaque, void *obj, unsigned /*obj_idx*/) {
 	struct list_context *ctx = opaque;
 	struct nexthop *nh = obj;
 	struct gr_ip4_nh api_nh;
@@ -187,7 +183,7 @@ static struct api_out nh4_list(const void *request, void **response) {
 	return api_out(0, len);
 }
 
-static void nh_gc_cb(struct rte_mempool *, void *, void *obj, unsigned) {
+static void nh_gc_cb(struct rte_mempool *, void * /*opaque*/, void *obj, unsigned /*obj_idx*/) {
 	uint64_t now = rte_get_tsc_cycles();
 	uint64_t reply_age, request_age;
 	unsigned probes, max_probes;
@@ -238,7 +234,7 @@ static void nh_gc_cb(struct rte_mempool *, void *, void *obj, unsigned) {
 	}
 }
 
-static void nexthop_gc(evutil_socket_t, short, void *) {
+static void nexthop_gc(evutil_socket_t, short /*what*/, void * /*priv*/) {
 	rte_mempool_obj_iter(nh_pool, nh_gc_cb, NULL);
 }
 

--- a/modules/ip/control/route.c
+++ b/modules/ip/control/route.c
@@ -174,14 +174,12 @@ int ip4_route_delete(uint16_t vrf_id, ip4_addr_t ip, uint8_t prefixlen) {
 	return 0;
 }
 
-static struct api_out route4_add(const void *request, void **response) {
+static struct api_out route4_add(const void *request, void ** /*response*/) {
 	const struct gr_ip4_route_add_req *req = request;
 	uint32_t host_order_ip;
 	struct rte_fib *fib;
 	struct nexthop *nh;
 	int ret;
-
-	(void)response;
 
 	nh = ip4_route_lookup_exact(req->vrf_id, req->dest.ip, req->dest.prefixlen);
 	if (nh != NULL) {
@@ -213,11 +211,9 @@ static struct api_out route4_add(const void *request, void **response) {
 	return api_out(0, 0);
 }
 
-static struct api_out route4_del(const void *request, void **response) {
+static struct api_out route4_del(const void *request, void ** /*response*/) {
 	const struct gr_ip4_route_del_req *req = request;
 	struct nexthop *nh;
-
-	(void)response;
 
 	if ((nh = ip4_route_lookup_exact(req->vrf_id, req->dest.ip, req->dest.prefixlen)) == NULL) {
 		if (req->missing_ok)
@@ -266,8 +262,6 @@ static struct api_out route4_list(const void *request, void **response) {
 	size_t num, len;
 	uintptr_t nh_id;
 	uint32_t ip;
-
-	(void)request;
 
 	if (fib == NULL)
 		return api_out(errno, 0);

--- a/modules/ip/datapath/ip_error.c
+++ b/modules/ip/datapath/ip_error.c
@@ -87,7 +87,7 @@ static int no_route_init(const struct rte_graph *, struct rte_node *node) {
 	return 0;
 }
 
-struct rte_node_register ip_forward_ttl_exceeded_node = {
+static struct rte_node_register ip_forward_ttl_exceeded_node = {
 	.name = "ip_error_ttl_exceeded",
 	.process = ip_error_process,
 	.nb_edges = EDGE_COUNT,

--- a/modules/ip6/cli/address.c
+++ b/modules/ip6/cli/address.c
@@ -56,8 +56,6 @@ static cmd_status_t addr_list(const struct gr_api_client *c, const struct ec_pno
 	void *resp_ptr = NULL;
 	char buf[BUFSIZ];
 
-	(void)p;
-
 	if (table == NULL)
 		return CMD_ERROR;
 

--- a/modules/ip6/cli/nexthop.c
+++ b/modules/ip6/cli/nexthop.c
@@ -61,8 +61,6 @@ static cmd_status_t nh6_list(const struct gr_api_client *c, const struct ec_pnod
 	void *resp_ptr = NULL;
 	ssize_t n;
 
-	(void)p;
-
 	if (table == NULL)
 		return CMD_ERROR;
 	if (arg_u16(p, "VRF", &req.vrf_id) < 0 && errno != ENOENT) {

--- a/modules/ip6/cli/route.c
+++ b/modules/ip6/cli/route.c
@@ -54,8 +54,6 @@ static cmd_status_t route6_list(const struct gr_api_client *c, const struct ec_p
 	char dest[BUFSIZ], nh[BUFSIZ];
 	void *resp_ptr = NULL;
 
-	(void)p;
-
 	if (table == NULL)
 		return CMD_ERROR;
 

--- a/modules/ip6/control/address.c
+++ b/modules/ip6/control/address.c
@@ -179,13 +179,11 @@ iface6_addr_add(const struct iface *iface, const struct rte_ipv6_addr *ip, uint8
 	return 0;
 }
 
-static struct api_out addr6_add(const void *request, void **response) {
+static struct api_out addr6_add(const void *request, void ** /*response*/) {
 	const struct gr_ip6_addr_add_req *req = request;
 	struct rte_ipv6_addr solicited_node;
 	struct iface *iface;
 	int ret;
-
-	(void)response;
 
 	iface = iface_from_id(req->addr.iface_id);
 	if (iface == NULL)
@@ -203,14 +201,12 @@ static struct api_out addr6_add(const void *request, void **response) {
 	return api_out(0, 0);
 }
 
-static struct api_out addr6_del(const void *request, void **response) {
+static struct api_out addr6_del(const void *request, void ** /*response*/) {
 	const struct gr_ip6_addr_del_req *req = request;
 	struct rte_ipv6_addr solicited_node;
 	struct nexthop6 *nh = NULL;
 	struct hoplist6 *addrs;
 	unsigned i;
-
-	(void)response;
 
 	if ((addrs = ip6_addr_get_all(req->addr.iface_id)) == NULL)
 		return api_out(errno, 0);

--- a/modules/ip6/control/nexthop.c
+++ b/modules/ip6/control/nexthop.c
@@ -48,7 +48,7 @@ struct lookup_filter {
 	struct nexthop6 *nh;
 };
 
-static void nh_lookup_cb(struct rte_mempool *, void *opaque, void *obj, unsigned) {
+static void nh_lookup_cb(struct rte_mempool *, void *opaque, void *obj, unsigned /*obj_idx*/) {
 	struct lookup_filter *filter = opaque;
 	struct nexthop6 *nh = obj;
 	if (filter->nh == NULL && nh->ref_count > 0 && rte_ipv6_addr_eq(&nh->ip, filter->ip)
@@ -84,12 +84,10 @@ void ip6_nexthop_incref(struct nexthop6 *nh) {
 	nh->ref_count++;
 }
 
-static struct api_out nh6_add(const void *request, void **response) {
+static struct api_out nh6_add(const void *request, void ** /*response*/) {
 	const struct gr_ip6_nh_add_req *req = request;
 	struct nexthop6 *nh;
 	int ret;
-
-	(void)response;
 
 	if (rte_ipv6_addr_is_unspec(&req->nh.host) || rte_ipv6_addr_is_mcast(&req->nh.host))
 		return api_out(EINVAL, 0);
@@ -115,11 +113,9 @@ static struct api_out nh6_add(const void *request, void **response) {
 	return api_out(-ret, 0);
 }
 
-static struct api_out nh6_del(const void *request, void **response) {
+static struct api_out nh6_del(const void *request, void ** /*response*/) {
 	const struct gr_ip6_nh_del_req *req = request;
 	struct nexthop6 *nh;
-
-	(void)response;
 
 	if (req->vrf_id >= IP6_MAX_VRFS)
 		return api_out(EOVERFLOW, 0);
@@ -145,7 +141,7 @@ struct list_context {
 	struct gr_ip6_nh *nh;
 };
 
-static void nh_list_cb(struct rte_mempool *, void *opaque, void *obj, unsigned) {
+static void nh_list_cb(struct rte_mempool *, void *opaque, void *obj, unsigned /*obj_idx*/) {
 	struct list_context *ctx = opaque;
 	struct nexthop6 *nh = obj;
 	struct gr_ip6_nh api_nh;
@@ -189,7 +185,7 @@ static struct api_out nh6_list(const void *request, void **response) {
 	return api_out(0, len);
 }
 
-static void nh_gc_cb(struct rte_mempool *, void *, void *obj, unsigned) {
+static void nh_gc_cb(struct rte_mempool *, void * /*opaque*/, void *obj, unsigned /*obj_idx*/) {
 	uint64_t now = rte_get_tsc_cycles();
 	uint64_t reply_age, request_age;
 	unsigned probes, max_probes;
@@ -237,7 +233,7 @@ static void nh_gc_cb(struct rte_mempool *, void *, void *obj, unsigned) {
 	}
 }
 
-static void nexthop_gc(evutil_socket_t, short, void *) {
+static void nexthop_gc(evutil_socket_t, short /*what*/, void * /*priv*/) {
 	rte_mempool_obj_iter(nh_pool, nh_gc_cb, NULL);
 }
 

--- a/modules/ip6/control/route.c
+++ b/modules/ip6/control/route.c
@@ -175,13 +175,11 @@ int ip6_route_delete(uint16_t vrf_id, const struct rte_ipv6_addr *ip, uint8_t pr
 	return 0;
 }
 
-static struct api_out route6_add(const void *request, void **response) {
+static struct api_out route6_add(const void *request, void ** /*response*/) {
 	const struct gr_ip6_route_add_req *req = request;
 	struct rte_fib6 *fib6;
 	struct nexthop6 *nh;
 	int ret;
-
-	(void)response;
 
 	nh = ip6_route_lookup_exact(req->vrf_id, &req->dest.ip, req->dest.prefixlen);
 	if (nh != NULL) {
@@ -211,11 +209,9 @@ static struct api_out route6_add(const void *request, void **response) {
 	return api_out(0, 0);
 }
 
-static struct api_out route6_del(const void *request, void **response) {
+static struct api_out route6_del(const void *request, void ** /*response*/) {
 	const struct gr_ip6_route_del_req *req = request;
 	struct nexthop6 *nh;
-
-	(void)response;
 
 	if ((nh = ip6_route_lookup_exact(req->vrf_id, &req->dest.ip, req->dest.prefixlen))
 	    == NULL) {
@@ -265,8 +261,6 @@ static struct api_out route6_list(const void *request, void **response) {
 	struct rte_rib6 *rib;
 	size_t num, len;
 	uintptr_t nh_id;
-
-	(void)request;
 
 	if (fib == NULL)
 		return api_out(errno, 0);

--- a/modules/ip6/datapath/ip6_error.c
+++ b/modules/ip6/datapath/ip6_error.c
@@ -124,7 +124,7 @@ static struct rte_node_register dest_unreach_node = {
 	.init = no_route_init,
 };
 
-struct rte_node_register ttl_exceeded_node = {
+static struct rte_node_register ttl_exceeded_node = {
 	.name = "ip6_error_ttl_exceeded",
 	.process = ip6_error_process,
 	.nb_edges = EDGE_COUNT,

--- a/modules/ipip/cli.c
+++ b/modules/ipip/cli.c
@@ -11,11 +11,9 @@
 
 #include <errno.h>
 
-static void ipip_show(const struct gr_api_client *c, const struct gr_iface *iface) {
+static void ipip_show(const struct gr_api_client *, const struct gr_iface *iface) {
 	const struct gr_iface_info_ipip *ipip = (const struct gr_iface_info_ipip *)iface->info;
 	char local[64], remote[64];
-
-	(void)c;
 
 	inet_ntop(AF_INET, &ipip->local, local, sizeof(local));
 	inet_ntop(AF_INET, &ipip->remote, remote, sizeof(remote));
@@ -24,11 +22,9 @@ static void ipip_show(const struct gr_api_client *c, const struct gr_iface *ifac
 }
 
 static void
-ipip_list_info(const struct gr_api_client *c, const struct gr_iface *iface, char *buf, size_t len) {
+ipip_list_info(const struct gr_api_client *, const struct gr_iface *iface, char *buf, size_t len) {
 	const struct gr_iface_info_ipip *ipip = (const struct gr_iface_info_ipip *)iface->info;
 	char local[64], remote[64];
-
-	(void)c;
 
 	inet_ntop(AF_INET, &ipip->local, local, sizeof(local));
 	inet_ntop(AF_INET, &ipip->remote, remote, sizeof(remote));


### PR DESCRIPTION
Remove all occurrences of:

	(void)unused_param;

Since these can be confusing and do not convey any meaning about the variable being unused. It is a legacy way to silence the unused-parameter compiler warning.

The whole grout code base is compiled with --std=gnu2x which allows unnamed parameters even in function definitions. Make use of that to indicate unused parameters. When the parameter type is explicit (e.g. struct rte_graph *), simply remove the parameter name which is usually redundant, e.g.:

	void foo(const struct rte_graph *, struct rte_node *node) { }

When the type is not explicit (e.g. int), keep the parameter wrapped in a comment, e.g.:

	int foo(void * /*cookie*/, const char *buf, size_t size) { }