### PR TITLE
main: move libevent api callbacks to separate file

### DIFF
--- a/main/api.c
+++ b/main/api.c
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024 Robin Jarry
+
+#include "api.h"
+#include "control.h"
+#include "gr.h"
+
+#include <gr_api.h>
+#include <gr_log.h>
+#include <gr_macro.h>
+
+#include <event2/event.h>
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+static void finalize_fd(struct event *ev, void * /*priv*/) {
+	int fd = event_get_fd(ev);
+	if (fd >= 0)
+		close(fd);
+}
+
+static ssize_t send_response(evutil_socket_t sock, struct gr_api_response *resp) {
+	if (resp == NULL)
+		return errno_set(ENOMEM);
+
+	LOG(DEBUG,
+	    "for_id=%u len=%u status=%u %s",
+	    resp->for_id,
+	    resp->payload_len,
+	    resp->status,
+	    strerror(resp->status));
+
+	size_t len = sizeof(*resp) + resp->payload_len;
+	return send(sock, resp, len, MSG_DONTWAIT | MSG_NOSIGNAL);
+}
+
+// This is allocated in main() but we need a reference here.
+// write_cb() needs both struct event_base AND struct gr_api_response and we
+// cannot pass two private pointers.
+static struct event_base *ev_base;
+
+static void write_cb(evutil_socket_t sock, short /*what*/, void *priv) {
+	struct event *ev = event_base_get_running_event(ev_base);
+	struct gr_api_response *resp = priv;
+
+	if (send_response(sock, resp) < 0) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK)
+			goto retry;
+		LOG(ERR, "send_response: %s", strerror(errno));
+	}
+	goto free;
+
+retry:
+	if (ev == NULL || event_add(ev, NULL) < 0) {
+		LOG(ERR, "failed to add event to loop");
+		goto free;
+	}
+	return;
+
+free:
+	free(resp);
+	if (ev != NULL)
+		event_free(ev);
+}
+
+static void read_cb(evutil_socket_t sock, short what, void * /*priv*/) {
+	struct event *ev = event_base_get_running_event(ev_base);
+	void *req_payload = NULL, *resp_payload = NULL;
+	struct gr_api_response *resp = NULL;
+	struct gr_api_request req;
+	struct event *write_ev;
+	struct api_out out;
+	ssize_t len;
+
+	if (what & EV_CLOSED)
+		goto close;
+
+	if ((len = recv(sock, &req, sizeof(req), MSG_DONTWAIT)) < 0) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			return;
+		}
+		LOG(ERR, "recv: %s", strerror(errno));
+		goto close;
+	} else if (len == 0) {
+		LOG(DEBUG, "client disconnected");
+		goto close;
+	}
+
+	if (req.payload_len > 0) {
+		req_payload = malloc(req.payload_len);
+		if (req_payload == NULL) {
+			LOG(ERR, "cannot allocate %u bytes for request payload", req.payload_len);
+			goto close;
+		}
+		if ((len = recv(sock, req_payload, req.payload_len, MSG_DONTWAIT)) < 0) {
+			LOG(ERR, "recv: %s", strerror(errno));
+			goto close;
+		} else if (len == 0) {
+			LOG(DEBUG, "client disconnected");
+			goto close;
+		}
+	}
+
+	const struct gr_api_handler *handler = lookup_api_handler(&req);
+	if (handler == NULL) {
+		out.status = ENOTSUP;
+		out.len = 0;
+		goto send;
+	}
+
+	LOG(DEBUG,
+	    "request: id=%u type=0x%08x '%s' len=%u",
+	    req.id,
+	    req.type,
+	    handler->name,
+	    req.payload_len);
+
+	out = handler->callback(req_payload, &resp_payload);
+
+send:
+	resp = malloc(sizeof(*resp) + out.len);
+	if (resp == NULL) {
+		LOG(ERR, "cannot allocate %zu bytes for response payload", sizeof(*resp) + out.len);
+		goto close;
+	}
+	resp->for_id = req.id;
+	resp->status = out.status;
+	resp->payload_len = out.len;
+	if (resp_payload != NULL && out.len > 0) {
+		memcpy(PAYLOAD(resp), resp_payload, out.len);
+		free(resp_payload);
+		resp_payload = NULL;
+	}
+	if (send_response(sock, resp) < 0) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK)
+			goto retry_send;
+		LOG(ERR, "send: %s", strerror(errno));
+		goto close;
+	}
+	free(req_payload);
+	free(resp);
+	return;
+
+retry_send:
+	write_ev = event_new(ev_base, sock, EV_WRITE | EV_FINALIZE, write_cb, resp);
+	if (write_ev == NULL || event_add(write_ev, NULL) < 0) {
+		LOG(ERR, "failed to add event to loop");
+		if (write_ev != NULL)
+			event_free(write_ev);
+		goto close;
+	}
+	free(req_payload);
+	return;
+
+close:
+	free(req_payload);
+	free(resp);
+	if (ev != NULL)
+		event_free_finalize(0, ev, finalize_fd);
+}
+
+static int close_connections(const struct event_base *, const struct event *ev, void * /*priv*/) {
+	event_callback_fn cb = event_get_callback(ev);
+	if (cb == read_cb || cb == write_cb)
+		event_free_finalize(0, (struct event *)ev, finalize_fd);
+	return 0;
+}
+
+static void listen_cb(evutil_socket_t sock, short what, void * /*priv*/) {
+	struct event *ev;
+	int fd;
+
+	if (what & EV_CLOSED) {
+		ev = event_base_get_running_event(ev_base);
+		event_free_finalize(0, ev, finalize_fd);
+		return;
+	}
+
+	if ((fd = accept4(sock, NULL, NULL, SOCK_NONBLOCK | SOCK_CLOEXEC)) < 0) {
+		if (errno != EAGAIN && errno != EWOULDBLOCK) {
+			LOG(ERR, "accept: %s", strerror(errno));
+		}
+		return;
+	}
+
+	LOG(DEBUG, "new connection");
+
+	ev = event_new(ev_base, fd, EV_READ | EV_CLOSED | EV_PERSIST | EV_FINALIZE, read_cb, NULL);
+	if (ev == NULL || event_add(ev, NULL) < 0) {
+		LOG(ERR, "failed to add event to loop");
+		if (ev != NULL)
+			event_free(ev);
+		close(fd);
+	}
+}
+
+#define SOCKET_LISTEN_BACKLOG 16
+static struct event *ev_listen;
+
+int api_socket_start(struct event_base *base) {
+	const char *path = gr_args()->api_sock_path;
+	union {
+		struct sockaddr_un un;
+		struct sockaddr a;
+	} addr;
+	int fd;
+
+	fd = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+	if (fd == -1)
+		return errno_log(errno, "socket");
+
+	addr.un.sun_family = AF_UNIX;
+	memccpy(addr.un.sun_path, path, 0, sizeof(addr.un.sun_path) - 1);
+
+	if (bind(fd, &addr.a, sizeof(addr.un)) < 0) {
+		close(fd);
+		return errno_log(errno, "bind");
+	}
+
+	if (listen(fd, SOCKET_LISTEN_BACKLOG) < 0) {
+		close(fd);
+		return errno_log(errno, "listen");
+	}
+
+	ev_listen = event_new(
+		base, fd, EV_READ | EV_WRITE | EV_CLOSED | EV_PERSIST | EV_FINALIZE, listen_cb, NULL
+	);
+	if (ev_listen == NULL || event_add(ev_listen, NULL) < 0) {
+		close(fd);
+		return errno_log(errno, "event_new");
+	}
+	// keep a reference for callbacks
+	ev_base = base;
+
+	LOG(INFO, "listening on API socket %s", path);
+
+	return 0;
+}
+
+void api_socket_stop(struct event_base *) {
+	if (ev_listen != NULL)
+		event_free_finalize(0, ev_listen, finalize_fd);
+
+	event_base_foreach_event(ev_base, close_connections, NULL);
+}

--- a/main/api.h
+++ b/main/api.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024 Robin Jarry
+
+#ifndef _GR_MAIN_API
+#define _GR_MAIN_API
+
+#include <event2/event.h>
+
+int api_socket_start(struct event_base *);
+void api_socket_stop(struct event_base *);
+
+#endif

--- a/main/main.c
+++ b/main/main.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2023 Robin Jarry
 
+#include "api.h"
 #include "control.h"
 #include "dpdk.h"
 #include "gr.h"
@@ -8,29 +9,18 @@
 #include "signals.h"
 
 #include <gr_api.h>
-#include <gr_control.h>
 #include <gr_log.h>
-#include <gr_macro.h>
 
 #include <event2/event.h>
 #include <event2/thread.h>
-#include <rte_eal.h>
-#include <rte_log.h>
-#include <rte_mempool.h>
 #include <rte_version.h>
 
-#include <fcntl.h>
 #include <getopt.h>
 #include <locale.h>
-#include <sched.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/epoll.h>
-#include <sys/signalfd.h>
-#include <sys/socket.h>
-#include <sys/un.h>
 #include <unistd.h>
 
 // Please keep options/flags in alphabetical order.
@@ -127,234 +117,8 @@ end:
 	return 0;
 }
 
-static void finalize_close_fd(struct event *ev, void * /*priv*/) {
-	close(event_get_fd(ev));
-}
-
-static ssize_t send_response(evutil_socket_t sock, struct gr_api_response *resp) {
-	if (resp == NULL)
-		return errno_set(ENOMEM);
-
-	LOG(DEBUG,
-	    "for_id=%u len=%u status=%u %s",
-	    resp->for_id,
-	    resp->payload_len,
-	    resp->status,
-	    strerror(resp->status));
-
-	size_t len = sizeof(*resp) + resp->payload_len;
-	return send(sock, resp, len, MSG_DONTWAIT | MSG_NOSIGNAL);
-}
-
-static struct event_base *ev_base;
-
-static void api_write_cb(evutil_socket_t sock, short /*what*/, void *priv) {
-	struct event *ev = event_base_get_running_event(ev_base);
-	struct gr_api_response *resp = priv;
-
-	if (send_response(sock, resp) < 0) {
-		if (errno == EAGAIN || errno == EWOULDBLOCK)
-			goto retry;
-		LOG(ERR, "send_response: %s", strerror(errno));
-	}
-	goto free;
-
-retry:
-	if (ev == NULL || event_add(ev, NULL) < 0) {
-		LOG(ERR, "failed to add event to loop");
-		goto free;
-	}
-	return;
-
-free:
-	free(resp);
-	if (ev != NULL)
-		event_free(ev);
-}
-
-static void api_read_cb(evutil_socket_t sock, short what, void * /*ctx*/) {
-	struct event *ev = event_base_get_running_event(ev_base);
-	void *req_payload = NULL, *resp_payload = NULL;
-	struct gr_api_response *resp = NULL;
-	struct gr_api_request req;
-	struct event *write_ev;
-	struct api_out out;
-	ssize_t len;
-
-	if (what & EV_CLOSED)
-		goto close;
-
-	if ((len = recv(sock, &req, sizeof(req), MSG_DONTWAIT)) < 0) {
-		if (errno == EAGAIN || errno == EWOULDBLOCK) {
-			return;
-		}
-		LOG(ERR, "recv: %s", strerror(errno));
-		goto close;
-	} else if (len == 0) {
-		LOG(DEBUG, "client disconnected");
-		goto close;
-	}
-
-	if (req.payload_len > 0) {
-		req_payload = malloc(req.payload_len);
-		if (req_payload == NULL) {
-			LOG(ERR, "cannot allocate %u bytes for request payload", req.payload_len);
-			goto close;
-		}
-		if ((len = recv(sock, req_payload, req.payload_len, MSG_DONTWAIT)) < 0) {
-			LOG(ERR, "recv: %s", strerror(errno));
-			goto close;
-		} else if (len == 0) {
-			LOG(DEBUG, "client disconnected");
-			goto close;
-		}
-	}
-
-	const struct gr_api_handler *handler = lookup_api_handler(&req);
-	if (handler == NULL) {
-		out.status = ENOTSUP;
-		out.len = 0;
-		goto send;
-	}
-
-	LOG(DEBUG,
-	    "request: id=%u type=0x%08x '%s' len=%u",
-	    req.id,
-	    req.type,
-	    handler->name,
-	    req.payload_len);
-
-	out = handler->callback(req_payload, &resp_payload);
-
-send:
-	resp = malloc(sizeof(*resp) + out.len);
-	if (resp == NULL) {
-		LOG(ERR, "cannot allocate %zu bytes for response payload", sizeof(*resp) + out.len);
-		goto close;
-	}
-	resp->for_id = req.id;
-	resp->status = out.status;
-	resp->payload_len = out.len;
-	if (resp_payload != NULL && out.len > 0) {
-		memcpy(PAYLOAD(resp), resp_payload, out.len);
-		free(resp_payload);
-		resp_payload = NULL;
-	}
-	if (send_response(sock, resp) < 0) {
-		if (errno == EAGAIN || errno == EWOULDBLOCK)
-			goto retry_send;
-		LOG(ERR, "send: %s", strerror(errno));
-		goto close;
-	}
-	free(req_payload);
-	free(resp);
-	return;
-
-retry_send:
-	write_ev = event_new(ev_base, sock, EV_WRITE | EV_FINALIZE, api_write_cb, resp);
-	if (write_ev == NULL || event_add(write_ev, NULL) < 0) {
-		LOG(ERR, "failed to add event to loop");
-		if (write_ev != NULL)
-			event_free(write_ev);
-		goto close;
-	}
-	free(req_payload);
-	return;
-
-close:
-	free(req_payload);
-	free(resp);
-	if (ev != NULL)
-		event_free_finalize(0, ev, finalize_close_fd);
-}
-
-static void listen_cb(evutil_socket_t sock, short what, void * /*ctx*/) {
-	struct event *ev;
-	int fd;
-
-	if (what & EV_CLOSED) {
-		ev = event_base_get_running_event(ev_base);
-		event_free_finalize(0, ev, finalize_close_fd);
-		return;
-	}
-
-	if ((fd = accept4(sock, NULL, NULL, SOCK_NONBLOCK | SOCK_CLOEXEC)) < 0) {
-		if (errno != EAGAIN && errno != EWOULDBLOCK) {
-			LOG(ERR, "accept: %s", strerror(errno));
-		}
-		return;
-	}
-
-	LOG(DEBUG, "new connection");
-
-	ev = event_new(
-		ev_base, fd, EV_READ | EV_CLOSED | EV_PERSIST | EV_FINALIZE, api_read_cb, NULL
-	);
-	if (ev == NULL || event_add(ev, NULL) < 0) {
-		LOG(ERR, "failed to add event to loop");
-		if (ev != NULL)
-			event_free(ev);
-		close(fd);
-	}
-}
-
-#define BACKLOG 16
-static struct event *ev_listen;
-
-static int listen_api_socket(void) {
-	union {
-		struct sockaddr_un un;
-		struct sockaddr a;
-	} addr;
-	int fd;
-
-	fd = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
-	if (fd == -1) {
-		LOG(ERR, "socket: %s", strerror(errno));
-		return -errno;
-	}
-
-	addr.un.sun_family = AF_UNIX;
-	strncpy(addr.un.sun_path, args.api_sock_path, sizeof addr.un.sun_path - 1);
-
-	if (bind(fd, &addr.a, sizeof(addr.un)) < 0) {
-		LOG(ERR, "bind: %s: %s", args.api_sock_path, strerror(errno));
-		close(fd);
-		return -errno;
-	}
-
-	if (listen(fd, BACKLOG) < 0) {
-		LOG(ERR, "listen: %s: %s", args.api_sock_path, strerror(errno));
-		close(fd);
-		return -errno;
-	}
-
-	ev_listen = event_new(
-		ev_base,
-		fd,
-		EV_READ | EV_WRITE | EV_CLOSED | EV_PERSIST | EV_FINALIZE,
-		listen_cb,
-		NULL
-	);
-	if (ev_listen == NULL || event_add(ev_listen, NULL) < 0) {
-		close(fd);
-		LOG(ERR, "event_new: %s: %s", args.api_sock_path, strerror(errno));
-		return -errno;
-	}
-
-	LOG(INFO, "listening on API socket %s", args.api_sock_path);
-
-	return 0;
-}
-
-static int ev_close(const struct event_base *, const struct event *ev, void * /*priv*/) {
-	event_callback_fn cb = event_get_callback(ev);
-	if (cb == api_read_cb || cb == api_write_cb)
-		event_free_finalize(0, (struct event *)ev, finalize_close_fd);
-	return 0;
-}
-
 int main(int argc, char **argv) {
+	struct event_base *ev_base = NULL;
 	int ret = EXIT_FAILURE;
 	int err = 0;
 
@@ -390,7 +154,7 @@ int main(int argc, char **argv) {
 
 	modules_init(ev_base);
 
-	if (listen_api_socket() < 0) {
+	if (api_socket_start(ev_base) < 0) {
 		err = errno;
 		goto shutdown;
 	}
@@ -414,12 +178,9 @@ int main(int argc, char **argv) {
 
 shutdown:
 	unregister_signals();
-	if (ev_listen)
-		event_free_finalize(0, ev_listen, finalize_close_fd);
-
 	if (ev_base) {
+		api_socket_stop(ev_base);
 		modules_fini(ev_base);
-		event_base_foreach_event(ev_base, ev_close, NULL);
 		event_base_free(ev_base);
 	}
 	unlink(args.api_sock_path);

--- a/main/meson.build
+++ b/main/meson.build
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Robin Jarry
 
 src += files(
+  'api.c',
   'control.c',
   'dpdk.c',
   'main.c',


### PR DESCRIPTION
The main.c file contains both command line parsing, the main() function *and* libevent stuff for managing the API socket. This is too many purposes for a single file.

Move the API socket handling in a separate file. Adjust stuff accordingly.