### PR TITLE
calloc: fix order parameter

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,17 +19,25 @@ project(
   ],
 )
 
-compiler = meson.get_compiler('c')
-add_project_arguments('-D_GNU_SOURCE', language: 'c')
+# additional project C flags (keep alpha sorted)
 add_project_arguments('-DALLOW_EXPERIMENTAL_API', language: 'c')
-add_project_arguments('-Wmissing-prototypes', language: 'c')
-if compiler.has_argument('-Wmissing-variable-declarations')
-  add_project_arguments('-Wmissing-variable-declarations', language: 'c')
-endif
-add_project_arguments('-fstrict-aliasing', language: 'c')
-add_project_arguments('-Wstrict-aliasing=2', language: 'c')
-add_project_arguments('-Wno-format-truncation', language: 'c')
 add_project_arguments('-DGROUT_VERSION="' + meson.project_version() + '"', language: 'c')
+add_project_arguments('-D_GNU_SOURCE', language: 'c')
+add_project_arguments('-Wmissing-prototypes', language: 'c')
+add_project_arguments('-Wno-format-truncation', language: 'c')
+add_project_arguments('-Wstrict-aliasing=2', language: 'c')
+add_project_arguments('-fstrict-aliasing', language: 'c')
+
+# optional project C flags (keep alpha sorted)
+optional_c_args = [
+  '-Wmissing-variable-declarations',
+]
+compiler = meson.get_compiler('c')
+foreach arg : optional_c_args
+  if compiler.has_argument(arg)
+    add_project_arguments(arg, language: 'c')
+  endif
+endforeach
 
 dpdk_dep = dependency(
   'libdpdk',

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,7 @@ add_project_arguments('-fstrict-aliasing', language: 'c')
 
 # optional project C flags (keep alpha sorted)
 optional_c_args = [
+  '-Wcalloc-transposed-args',
   '-Wmissing-variable-declarations',
 ]
 compiler = meson.get_compiler('c')

--- a/modules/ip/control/address.c
+++ b/modules/ip/control/address.c
@@ -157,7 +157,7 @@ static struct api_out addr_list(const void *request, void **response) {
 	}
 
 	len = sizeof(*resp) + num * sizeof(struct gr_ip4_ifaddr);
-	if ((resp = calloc(len, 1)) == NULL)
+	if ((resp = calloc(1, len)) == NULL)
 		return api_out(ENOMEM, 0);
 
 	for (iface_id = 0; iface_id < MAX_IFACES; iface_id++) {

--- a/modules/ip/control/nexthop.c
+++ b/modules/ip/control/nexthop.c
@@ -169,7 +169,7 @@ static struct api_out nh4_list(const void *request, void **response) {
 	rte_mempool_obj_iter(nh_pool, nh_list_cb, &ctx);
 
 	len = sizeof(*resp) + arrlen(ctx.nh) * sizeof(*ctx.nh);
-	if ((resp = calloc(len, 1)) == NULL) {
+	if ((resp = calloc(1, len)) == NULL) {
 		arrfree(ctx.nh);
 		return api_out(ENOMEM, 0);
 	}

--- a/modules/ip6/control/address.c
+++ b/modules/ip6/control/address.c
@@ -259,7 +259,7 @@ static struct api_out addr6_list(const void *request, void **response) {
 	}
 
 	len = sizeof(*resp) + num * sizeof(struct gr_ip6_ifaddr);
-	if ((resp = calloc(len, 1)) == NULL)
+	if ((resp = calloc(1, len)) == NULL)
 		return api_out(ENOMEM, 0);
 
 	for (iface_id = 0; iface_id < MAX_IFACES; iface_id++) {

--- a/modules/ip6/control/nexthop.c
+++ b/modules/ip6/control/nexthop.c
@@ -172,7 +172,7 @@ static struct api_out nh6_list(const void *request, void **response) {
 	rte_mempool_obj_iter(nh_pool, nh_list_cb, &ctx);
 
 	len = sizeof(*resp) + arrlen(ctx.nh) * sizeof(*ctx.nh);
-	if ((resp = calloc(len, 1)) == NULL) {
+	if ((resp = calloc(1, len)) == NULL) {
 		arrfree(ctx.nh);
 		return api_out(ENOMEM, 0);
 	}


### PR DESCRIPTION
nit picking: First arg of calloc argument should specify number of elements, later size of each element.