### PR TITLE
infra: fix failure when numa is unsupported

### DIFF
--- a/modules/infra/control/worker.c
+++ b/modules/infra/control/worker.c
@@ -159,7 +159,7 @@ int worker_ensure_default(int socket_id) {
 			return 0;
 	}
 
-	if (socket_id == SOCKET_ID_ANY)
+	if (socket_id == SOCKET_ID_ANY && numa_available() != -1)
 		socket_id = numa_preferred();
 
 	// try to spawn the default worker on the correct socket excluding the main lcore


### PR DESCRIPTION
During the EAL init, even if NUMA is unsupported on a given platform, DPDK will always return a socket id set to 0 instead of SOCKET_ID_ANY (-1). It breaks the current algorithm in grout, as no valid default worker for this given socket id can be found with libnuma.

On top of that, a pre-check should be done before calling any libnuma functions. According to man numa::

  Before any other calls in this library can be used numa_available()
  must be called. If it returns -1, all other functions in this
  library are undefined.

Let's fix that by checking if the current platform really supports NUMA.