### PR TITLE
devtools: fix check-patches with dash

### DIFF
--- a/devtools/check-patches
+++ b/devtools/check-patches
@@ -47,7 +47,7 @@ check_issue() {
 		-H "Accept: application/vnd.github+json" \
 		-H "X-GitHub-Api-Version: 2022-11-28" \
 		"$api_url/issues/${1##*/}") || return 1
-	test "$(echo "$json" | jq -r .state)" = open
+	test "$(printf '%s\n' "$json" | jq -r .state)" = open
 }
 
 for rev in $revisions; do


### PR DESCRIPTION
If dash is used as the default shell interpreter at /bin/sh, which is more POSIX-compliant than bash, the hook related to the issue check might fail if one field of the JSON output (like "body") contains multiples lines.

Example with the issue 78::

  jq: parse error: Invalid string: control characters from U+0000
      through U+001F must be escaped at line 130, column 4
  error [PATCH 1/1]  [...] 'https://github.com/DPDK/grout/issues/78'
        does not reference a valid open issue

From POSIX spec for echo::

  It is not possible to use echo portably across all POSIX systems
  unless both -n (as the first argument) and escape sequences are
  omitted.
  [...]
  New applications are encouraged to use printf instead of echo.

Use ``printf`` instead of ``echo`` to be more portable.