### PR TITLE
infra: packet tracing

### DIFF
--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -25,6 +25,7 @@
 #define GR_IFACE_F_UP GR_BIT16(0)
 #define GR_IFACE_F_PROMISC GR_BIT16(1)
 #define GR_IFACE_F_ALLMULTI GR_BIT16(2)
+#define GR_IFACE_F_PACKET_TRACE GR_BIT16(3)
 // Interface state flags
 #define GR_IFACE_S_RUNNING GR_BIT16(0)
 

--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -204,4 +204,29 @@ struct gr_infra_graph_dump_resp {
 	char dot[/* len */];
 };
 
+// packet tracing //////////////////////////////////////////////////////////////
+#define GR_INFRA_PACKET_TRACE_CLEAR REQUEST_TYPE(GR_INFRA_MODULE, 0x0040)
+
+// struct gr_infra_trace_clear_req { };
+// struct gr_infra_trace_clear_resp { };
+
+#define GR_INFRA_PACKET_TRACE_DUMP REQUEST_TYPE(GR_INFRA_MODULE, 0x0041)
+
+// struct gr_infra_trace_dump_req { };
+
+struct gr_infra_packet_trace_dump_resp {
+	uint32_t len;
+	char trace[/* len */];
+};
+
+#define GR_INFRA_PACKET_TRACE_SET REQUEST_TYPE(GR_INFRA_MODULE, 0x0042)
+
+struct gr_infra_packet_trace_set_req {
+	bool enabled;
+	bool all;
+	uint16_t iface_id;
+};
+
+// struct gr_infra_packet_trace_set_resp { };
+
 #endif

--- a/modules/infra/api/meson.build
+++ b/modules/infra/api/meson.build
@@ -6,6 +6,7 @@ src += files(
   'iface.c',
   'rxq.c',
   'stats.c',
+  'trace.c',
 )
 
 api_headers += files('gr_infra.h')

--- a/modules/infra/api/trace.c
+++ b/modules/infra/api/trace.c
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024 Christophe Fontaine
+
+#include <gr_api.h>
+#include <gr_iface.h>
+#include <gr_infra.h>
+#include <gr_module.h>
+#include <gr_trace.h>
+
+#include <stdatomic.h>
+
+static atomic_bool trace_enabled = false;
+
+bool gr_trace_all_enabled() {
+	return atomic_load(&trace_enabled);
+}
+
+static void iface_callback(iface_event_t event, struct iface *iface) {
+	if (event == IFACE_EVENT_POST_ADD && trace_enabled)
+		iface->flags |= GR_IFACE_F_PACKET_TRACE;
+}
+
+static struct api_out set_trace(const void *request, void ** /*response*/) {
+	const struct gr_infra_packet_trace_set_req *req = request;
+	struct iface *iface = NULL;
+
+	if (req->all) {
+		trace_enabled = req->enabled;
+
+		while ((iface = iface_next(GR_IFACE_TYPE_UNDEF, iface)) != NULL) {
+			if (req->enabled)
+				iface->flags |= GR_IFACE_F_PACKET_TRACE;
+			else
+				iface->flags &= ~GR_IFACE_F_PACKET_TRACE;
+		}
+	} else {
+		if ((iface = iface_from_id(req->iface_id)) == NULL)
+			return api_out(ENODEV, 0);
+
+		if (req->enabled)
+			iface->flags |= GR_IFACE_F_PACKET_TRACE;
+		else
+			iface->flags &= ~GR_IFACE_F_PACKET_TRACE;
+	}
+
+	return api_out(0, 0);
+}
+
+#define TRACE_MAX_LEN (6 * 1024) // 64 nodes, 80 cols per node: ~5120 bytes.
+
+static struct api_out dump_trace(const void * /*request*/, void **response) {
+	struct gr_infra_packet_trace_dump_resp *resp;
+	int len = 0;
+
+	if ((resp = calloc(1, sizeof(*resp) + TRACE_MAX_LEN)) == NULL)
+		return api_out(ENOMEM, 0);
+
+	if ((len = gr_trace_dump(resp->trace, TRACE_MAX_LEN)) < 0) {
+		free(resp);
+		return api_out(-len, 0);
+	}
+
+	resp->len = len;
+	*response = resp;
+
+	return api_out(0, sizeof(*resp) + len);
+}
+
+static struct api_out clear_trace(const void * /*request*/, void ** /*response*/) {
+	gr_trace_clear();
+	return api_out(0, 0);
+}
+
+static struct gr_api_handler set_trace_handler = {
+	.name = "trace set",
+	.request_type = GR_INFRA_PACKET_TRACE_SET,
+	.callback = set_trace,
+};
+
+static struct gr_api_handler dump_trace_handler = {
+	.name = "trace dump",
+	.request_type = GR_INFRA_PACKET_TRACE_DUMP,
+	.callback = dump_trace,
+};
+
+static struct gr_api_handler clear_trace_handler = {
+	.name = "trace clear",
+	.request_type = GR_INFRA_PACKET_TRACE_CLEAR,
+	.callback = clear_trace,
+};
+
+static struct iface_event_handler iface_event_trace_handler = {
+	.callback = iface_callback,
+};
+
+RTE_INIT(trace_init) {
+	gr_register_api_handler(&set_trace_handler);
+	gr_register_api_handler(&dump_trace_handler);
+	gr_register_api_handler(&clear_trace_handler);
+	iface_event_register_handler(&iface_event_trace_handler);
+}

--- a/modules/infra/cli/iface.c
+++ b/modules/infra/cli/iface.c
@@ -279,6 +279,8 @@ static cmd_status_t iface_list(const struct gr_api_client *c, const struct ec_pn
 			n += snprintf(buf + n, sizeof(buf) - n, " promisc");
 		if (iface->flags & GR_IFACE_F_ALLMULTI)
 			n += snprintf(buf + n, sizeof(buf) - n, " allmulti");
+		if (iface->flags & GR_IFACE_F_PACKET_TRACE)
+			n += snprintf(buf + n, sizeof(buf) - n, " tracing");
 		scols_line_set_data(line, 2, buf);
 
 		// vrf
@@ -331,6 +333,8 @@ static cmd_status_t iface_show(const struct gr_api_client *c, const struct ec_pn
 		printf(" promisc");
 	if (iface.flags & GR_IFACE_F_ALLMULTI)
 		printf(" allmulti");
+	if (iface.flags & GR_IFACE_F_PACKET_TRACE)
+		printf(" tracing");
 	printf("\n");
 	printf("vrf: %u\n", iface.vrf_id);
 	printf("mtu: %u\n", iface.mtu);

--- a/modules/infra/cli/meson.build
+++ b/modules/infra/cli/meson.build
@@ -5,8 +5,9 @@ cli_src += files(
   'graph.c',
   'iface.c',
   'port.c',
-  'vlan.c',
   'stats.c',
+  'trace.c',
+  'vlan.c',
 )
 
 cli_inc += include_directories('.')

--- a/modules/infra/cli/trace.c
+++ b/modules/infra/cli/trace.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024 Christophe Fontaine
+
+#include <gr_api.h>
+#include <gr_cli.h>
+#include <gr_cli_iface.h>
+#include <gr_infra.h>
+#include <gr_net_types.h>
+
+#include <ecoli.h>
+
+#include <stdio.h>
+#include <unistd.h>
+
+static cmd_status_t trace_set(const struct gr_api_client *c, const struct ec_pnode *p) {
+	struct gr_infra_packet_trace_set_req req;
+	struct gr_iface iface;
+
+	req.enabled = true;
+
+	if (arg_str(p, "all") != NULL)
+		req.all = true;
+	else if (iface_from_name(c, arg_str(p, "NAME"), &iface) < 0)
+		return CMD_ERROR;
+	else
+		req.iface_id = iface.id;
+
+	if (gr_api_client_send_recv(c, GR_INFRA_PACKET_TRACE_SET, sizeof(req), &req, NULL) < 0)
+		return CMD_ERROR;
+
+	return CMD_SUCCESS;
+}
+
+static cmd_status_t trace_del(const struct gr_api_client *c, const struct ec_pnode *p) {
+	struct gr_infra_packet_trace_set_req req;
+	struct gr_iface iface;
+
+	req.enabled = false;
+	if (arg_str(p, "all") != NULL)
+		req.all = true;
+	else if (iface_from_name(c, arg_str(p, "NAME"), &iface) < 0)
+		return CMD_ERROR;
+	else
+		req.iface_id = iface.id;
+
+	if (gr_api_client_send_recv(c, GR_INFRA_PACKET_TRACE_SET, sizeof(req), &req, NULL) < 0)
+		return CMD_ERROR;
+
+	return CMD_SUCCESS;
+}
+
+static cmd_status_t trace_show(const struct gr_api_client *c, const struct ec_pnode *) {
+	const struct gr_infra_packet_trace_dump_resp *resp = NULL;
+	void *resp_ptr = NULL;
+	size_t len = 0;
+
+	do {
+		if (gr_api_client_send_recv(c, GR_INFRA_PACKET_TRACE_DUMP, 0, NULL, &resp_ptr) < 0)
+			return CMD_ERROR;
+
+		resp = resp_ptr;
+		len = resp->len;
+		if (len > 1) {
+			fwrite(resp->trace, 1, resp->len, stdout);
+		}
+		free(resp_ptr);
+	} while (len > 0);
+
+	return CMD_SUCCESS;
+}
+
+static cmd_status_t trace_clear(const struct gr_api_client *c, const struct ec_pnode *) {
+	if (gr_api_client_send_recv(c, GR_INFRA_PACKET_TRACE_CLEAR, 0, NULL, NULL) < 0)
+		return CMD_ERROR;
+
+	return CMD_SUCCESS;
+}
+
+static int ctx_init(struct ec_node *root) {
+	int ret;
+
+	ret = CLI_COMMAND(
+		CLI_CONTEXT(
+			root,
+			CTX_SET,
+			CTX_ARG("trace", "Enable packet tracing for specified interface")
+		),
+		"all|(iface NAME)",
+		trace_set,
+		"Enable packet tracing for all or specified interface.",
+		with_help("all interfaces.", ec_node_str("all", "all")),
+		with_help(
+			"Interface name.",
+			ec_node_dyn("NAME", complete_iface_names, INT2PTR(GR_IFACE_TYPE_UNDEF))
+		)
+	);
+	if (ret < 0)
+		return ret;
+
+	ret = CLI_COMMAND(
+		CLI_CONTEXT(
+			root,
+			CTX_DEL,
+			CTX_ARG("trace", "Disable packet tracing for specified interface")
+		),
+		"all|(iface NAME)",
+		trace_del,
+		"Enable packet tracing for all or specified interface.",
+		with_help("all interfaces.", ec_node_str("all", "all")),
+		with_help(
+			"Interface name.",
+			ec_node_dyn("NAME", complete_iface_names, INT2PTR(GR_IFACE_TYPE_UNDEF))
+		)
+	);
+	if (ret < 0)
+		return ret;
+
+	ret = CLI_COMMAND(CLI_CONTEXT(root, CTX_SHOW), "trace", trace_show, "Show traced packets.");
+	if (ret < 0)
+		return ret;
+
+	ret = CLI_COMMAND(
+		CLI_CONTEXT(root, CTX_CLEAR), "trace", trace_clear, "Clear packet tracing buffer.",
+	);
+	if (ret < 0)
+		return ret;
+
+	return 0;
+}
+
+static struct gr_cli_context ctx = {
+	.name = "trace",
+	.init = ctx_init,
+};
+
+static void __attribute__((constructor, used)) init(void) {
+	register_context(&ctx);
+}

--- a/modules/infra/control/gr_graph.h
+++ b/modules/infra/control/gr_graph.h
@@ -18,6 +18,7 @@ int gr_node_data_set(const char *graph, const char *node, void *data);
 rte_edge_t gr_node_attach_parent(const char *parent, const char *node);
 
 uint16_t drop_packets(struct rte_graph *, struct rte_node *, void **, uint16_t);
+int drop_format(char *buf, size_t buf_len, const void *data, size_t data_len);
 
 typedef void (*gr_node_register_cb_t)(void);
 
@@ -46,6 +47,7 @@ extern struct node_infos node_infos;
 	};                                                                                         \
 	static struct gr_node_info drop_info_##node_name = {                                       \
 		.node = &drop_node_##node_name,                                                    \
+		.trace_format = drop_format,                                                       \
 	};                                                                                         \
 	RTE_INIT(gr_drop_register_##node_name) {                                                   \
 		STAILQ_INSERT_TAIL(&node_infos, &drop_info_##node_name, next);                     \

--- a/modules/infra/control/gr_graph.h
+++ b/modules/infra/control/gr_graph.h
@@ -17,10 +17,12 @@ rte_edge_t gr_node_attach_parent(const char *parent, const char *node);
 
 uint16_t drop_packets(struct rte_graph *, struct rte_node *, void **, uint16_t);
 
+typedef void (*gr_node_register_cb_t)(void);
+
 struct gr_node_info {
 	struct rte_node_register *node;
-	void (*register_callback)(void);
-	void (*unregister_callback)(void);
+	gr_node_register_cb_t register_callback;
+	gr_node_register_cb_t unregister_callback;
 	STAILQ_ENTRY(gr_node_info) next;
 };
 

--- a/modules/infra/control/gr_graph.h
+++ b/modules/infra/control/gr_graph.h
@@ -4,6 +4,8 @@
 #ifndef _GR_INFRA_GRAPH
 #define _GR_INFRA_GRAPH
 
+#include <gr_trace.h>
+
 #include <rte_common.h>
 #include <rte_graph.h>
 
@@ -23,6 +25,7 @@ struct gr_node_info {
 	struct rte_node_register *node;
 	gr_node_register_cb_t register_callback;
 	gr_node_register_cb_t unregister_callback;
+	gr_trace_format_cb_t trace_format;
 	STAILQ_ENTRY(gr_node_info) next;
 };
 

--- a/modules/infra/control/gr_graph.h
+++ b/modules/infra/control/gr_graph.h
@@ -24,6 +24,8 @@ struct gr_node_info {
 	STAILQ_ENTRY(gr_node_info) next;
 };
 
+const struct gr_node_info *gr_node_info_get(rte_node_t node_id);
+
 STAILQ_HEAD(node_infos, gr_node_info);
 extern struct node_infos node_infos;
 

--- a/modules/infra/control/graph.c
+++ b/modules/infra/control/graph.c
@@ -259,6 +259,16 @@ int worker_graph_reload_all(void) {
 	return 0;
 }
 
+const struct gr_node_info *gr_node_info_get(rte_node_t node_id) {
+	const struct gr_node_info *info;
+
+	STAILQ_FOREACH (info, &node_infos, next)
+		if (info->node->id == node_id)
+			return info;
+
+	return errno_set_null(ENOENT);
+}
+
 static void graph_init(struct event_base *) {
 	struct rte_node_register *reg;
 	struct gr_node_info *info;

--- a/modules/infra/datapath/control_input.c
+++ b/modules/infra/datapath/control_input.c
@@ -7,6 +7,7 @@
 #include <gr_log.h>
 #include <gr_mbuf.h>
 #include <gr_mempool.h>
+#include <gr_trace.h>
 
 #include <rte_ether.h>
 #include <rte_graph_worker.h>
@@ -71,6 +72,8 @@ static uint16_t control_input_process(
 	for (unsigned i = 0; i < n; i++) {
 		mbuf = rte_pktmbuf_alloc(mp);
 		if (mbuf) {
+			if (gr_trace_all_enabled())
+				gr_mbuf_trace_add(mbuf, node, 0); // no data
 			control_input_mbuf_data(mbuf)->data = msg[i].data;
 			rte_node_enqueue_x1(graph, node, control_input_edges[msg[i].type], mbuf);
 		}

--- a/modules/infra/datapath/drop.c
+++ b/modules/infra/datapath/drop.c
@@ -3,6 +3,8 @@
 
 #include <gr_graph.h>
 #include <gr_log.h>
+#include <gr_mbuf.h>
+#include <gr_trace.h>
 
 #include <rte_graph_worker.h>
 #include <rte_mbuf.h>
@@ -11,9 +13,20 @@ uint16_t drop_packets(struct rte_graph *, struct rte_node *node, void **objs, ui
 	if (unlikely(packet_trace_enabled)) {
 		LOG(NOTICE, "[%s] %u packets", node->name, nb_objs);
 	}
+	for (int i = 0; i < nb_objs; i++) {
+		struct rte_mbuf *mbuf = objs[i];
+		if (gr_mbuf_is_traced(mbuf)) {
+			gr_mbuf_trace_add(mbuf, node, 0);
+			gr_mbuf_trace_finish(mbuf);
+		}
+	}
 	rte_pktmbuf_free_bulk((struct rte_mbuf **)objs, nb_objs);
 
 	return nb_objs;
+}
+
+int drop_format(char *buf, size_t len, const void * /*data*/, size_t /*data_len*/) {
+	return snprintf(buf, len, "drop");
 }
 
 // Global drop counters, used by multiple nodes

--- a/modules/infra/datapath/eth_input.c
+++ b/modules/infra/datapath/eth_input.c
@@ -4,6 +4,7 @@
 #include <gr_eth.h>
 #include <gr_graph.h>
 #include <gr_log.h>
+#include <gr_trace.h>
 #include <gr_vlan.h>
 
 #include <rte_byteorder.h>
@@ -95,9 +96,43 @@ eth_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 			eth_in->eth_dst = ETH_DST_OTHER;
 		}
 next:
+		if (gr_mbuf_is_traced(m)
+		    || (vlan_iface && vlan_iface->flags & GR_IFACE_F_PACKET_TRACE)) {
+			struct eth_trace_data *t = gr_mbuf_trace_add(m, node, sizeof(*t));
+			t->eth.dst_addr = eth->dst_addr;
+			t->eth.src_addr = eth->src_addr;
+			t->eth.ether_type = eth_type;
+			t->vlan_id = vlan_id;
+			t->iface_id = eth_in->iface->id;
+		}
 		rte_node_enqueue_x1(graph, node, edge, m);
 	}
 	return nb_objs;
+}
+
+int eth_trace_format(char *buf, size_t len, const void *data, size_t /*data_len*/) {
+	const struct eth_trace_data *t = data;
+	const struct iface *iface = iface_from_id(t->iface_id);
+	const char *ifname = iface ? iface->name : "[deleted]";
+	size_t n = 0;
+
+	SAFE_BUF(
+		snprintf,
+		len,
+		ETH_ADDR_FMT " > " ETH_ADDR_FMT " type=",
+		ETH_ADDR_SPLIT(&t->eth.src_addr),
+		ETH_ADDR_SPLIT(&t->eth.dst_addr)
+	);
+	SAFE_BUF(eth_type_format, len, t->eth.ether_type);
+
+	if (t->vlan_id != 0)
+		SAFE_BUF(snprintf, len, " vlan=%u", t->vlan_id);
+
+	SAFE_BUF(snprintf, len, " iface=%s", ifname);
+
+	return n;
+err:
+	return -1;
 }
 
 static struct rte_node_register node = {
@@ -114,6 +149,7 @@ static struct rte_node_register node = {
 
 static struct gr_node_info info = {
 	.node = &node,
+	.trace_format = eth_trace_format,
 };
 
 GR_NODE_REGISTER(info);

--- a/modules/infra/datapath/gr_eth.h
+++ b/modules/infra/datapath/gr_eth.h
@@ -32,4 +32,12 @@ GR_MBUF_PRIV_DATA_TYPE(eth_output_mbuf_data, {
 
 void gr_eth_input_add_type(rte_be16_t eth_type, const char *node_name);
 
+struct eth_trace_data {
+	struct rte_ether_hdr eth;
+	uint16_t vlan_id;
+	uint16_t iface_id;
+};
+
+int eth_trace_format(char *buf, size_t len, const void *data, size_t /*data_len*/);
+
 #endif

--- a/modules/infra/datapath/gr_mbuf.h
+++ b/modules/infra/datapath/gr_mbuf.h
@@ -5,17 +5,62 @@
 #define _GR_MBUF
 
 #include <rte_build_config.h>
+#include <rte_graph.h>
 #include <rte_mbuf.h>
+
+#include <sys/queue.h>
+
+#define GR_TRACE_ITEM_MAX_LEN 256
+
+struct gr_trace_item {
+	STAILQ_ENTRY(gr_trace_item) next;
+	struct timespec ts;
+	unsigned cpu_id;
+	rte_node_t node_id;
+	uint8_t len;
+	uint8_t data[GR_TRACE_ITEM_MAX_LEN];
+};
+
+STAILQ_HEAD(gr_trace_head, gr_trace_item);
 
 #define GR_MBUF_PRIV_MAX_SIZE RTE_CACHE_LINE_MIN_SIZE
 
 #define GR_MBUF_PRIV_DATA_TYPE(type_name, fields)                                                  \
 	struct type_name fields;                                                                   \
+	struct __##type_name {                                                                     \
+		struct gr_trace_head traces;                                                       \
+		struct type_name data;                                                             \
+	};                                                                                         \
 	static inline struct type_name *type_name(struct rte_mbuf *m) {                            \
-		static_assert(sizeof(struct type_name) <= GR_MBUF_PRIV_MAX_SIZE);                  \
-		return rte_mbuf_to_priv(m);                                                        \
+		static_assert(sizeof(struct __##type_name) <= GR_MBUF_PRIV_MAX_SIZE);              \
+		struct __##type_name *priv = rte_mbuf_to_priv(m);                                  \
+		return &priv->data;                                                                \
 	}
 
 GR_MBUF_PRIV_DATA_TYPE(queue_mbuf_data, { struct rte_mbuf *next; });
+
+// Get the head of trace items from an mbuf.
+static inline struct gr_trace_head *gr_mbuf_traces(struct rte_mbuf *m) {
+	return rte_mbuf_to_priv(m);
+}
+
+// Return true the mbuf already contains trace items.
+static inline bool gr_mbuf_is_traced(struct rte_mbuf *m) {
+	return !STAILQ_EMPTY(gr_mbuf_traces(m));
+}
+
+// Append a trace item to an mbuf.
+//
+// If the mbuf didn't contain any traces, store it as the first one and record
+// the current time into it.
+//
+// This cannot fail. If there are no free trace items available, the trace
+// buffer will be emptied starting from the oldest until one can be returned.
+//
+// Returns a pointer to a gr_trace_item.data buffer.
+void *gr_mbuf_trace_add(struct rte_mbuf *m, struct rte_node *node, size_t data_len);
+
+// Detach the trace items from an mbuf and store them in the trace buffer.
+void gr_mbuf_trace_finish(struct rte_mbuf *m);
 
 #endif

--- a/modules/infra/datapath/gr_rxtx.h
+++ b/modules/infra/datapath/gr_rxtx.h
@@ -6,6 +6,7 @@
 
 #include <rte_build_config.h>
 
+#include <stddef.h>
 #include <stdint.h>
 
 struct rx_port_queue {
@@ -21,5 +22,12 @@ struct rx_node_queues {
 struct tx_node_queues {
 	uint16_t txq_ids[RTE_MAX_ETHPORTS];
 };
+
+struct rxtx_trace_data {
+	uint16_t port_id;
+	uint16_t queue_id;
+};
+
+int rxtx_trace_format(char *buf, size_t len, const void *data, size_t /*data_len*/);
 
 #endif

--- a/modules/infra/datapath/gr_trace.h
+++ b/modules/infra/datapath/gr_trace.h
@@ -39,4 +39,7 @@ int gr_trace_dump(char *buf, size_t buf_len);
 // Empty the trace buffer.
 void gr_trace_clear(void);
 
+// Return true if trace is enabled for all interfaces.
+bool gr_trace_all_enabled(void);
+
 #endif

--- a/modules/infra/datapath/gr_trace.h
+++ b/modules/infra/datapath/gr_trace.h
@@ -7,6 +7,7 @@
 
 #include <rte_arp.h>
 #include <rte_graph.h>
+#include <rte_icmp.h>
 #include <rte_ip4.h>
 #include <rte_ip6.h>
 #include <rte_mbuf.h>
@@ -52,5 +53,7 @@ int trace_arp_format(char *buf, size_t len, const struct rte_arp_hdr *, size_t d
 int trace_ip_format(char *buf, size_t len, const struct rte_ipv4_hdr *, size_t data_len);
 
 int trace_ip6_format(char *buf, size_t len, const struct rte_ipv6_hdr *, size_t data_len);
+
+int trace_icmp_format(char *buf, size_t len, const struct rte_icmp_hdr *, size_t data_len);
 
 #endif

--- a/modules/infra/datapath/gr_trace.h
+++ b/modules/infra/datapath/gr_trace.h
@@ -5,6 +5,7 @@
 #ifndef _GR_INFRA_PACKET_TRACE
 #define _GR_INFRA_PACKET_TRACE
 
+#include <rte_arp.h>
 #include <rte_graph.h>
 #include <rte_mbuf.h>
 
@@ -43,5 +44,7 @@ void gr_trace_clear(void);
 bool gr_trace_all_enabled(void);
 
 int eth_type_format(char *buf, size_t len, rte_be16_t type);
+
+int trace_arp_format(char *buf, size_t len, const struct rte_arp_hdr *, size_t data_len);
 
 #endif

--- a/modules/infra/datapath/gr_trace.h
+++ b/modules/infra/datapath/gr_trace.h
@@ -7,6 +7,23 @@
 
 #include <rte_mbuf.h>
 
+// Call a function writing on a buffer called 'buf'.
+//
+// The offset at which to write is expected to be named 'n'.
+//
+// The function is expected to return a positive integer holding the number of
+// bytes written or a negative value on error. If a negative value is returned,
+// the macro will goto an 'err' label.
+//
+// On success, 'n' is incremented with the number of bytes written.
+#define SAFE_BUF(func, buf_size, ...)                                                              \
+	do {                                                                                       \
+		int __s = func(buf + n, buf_size - n, __VA_ARGS__);                                \
+		if (__s < 0)                                                                       \
+			goto err;                                                                  \
+		n += __s;                                                                          \
+	} while (0)
+
 // Write a log message with detailed packet information.
 void trace_log_packet(const struct rte_mbuf *m, const char *node, const char *iface);
 

--- a/modules/infra/datapath/gr_trace.h
+++ b/modules/infra/datapath/gr_trace.h
@@ -7,6 +7,7 @@
 
 #include <rte_arp.h>
 #include <rte_graph.h>
+#include <rte_ip4.h>
 #include <rte_mbuf.h>
 
 // Call a function writing on a buffer called 'buf'.
@@ -46,5 +47,7 @@ bool gr_trace_all_enabled(void);
 int eth_type_format(char *buf, size_t len, rte_be16_t type);
 
 int trace_arp_format(char *buf, size_t len, const struct rte_arp_hdr *, size_t data_len);
+
+int trace_ip_format(char *buf, size_t len, const struct rte_ipv4_hdr *, size_t data_len);
 
 #endif

--- a/modules/infra/datapath/gr_trace.h
+++ b/modules/infra/datapath/gr_trace.h
@@ -5,6 +5,8 @@
 #ifndef _GR_INFRA_PACKET_TRACE
 #define _GR_INFRA_PACKET_TRACE
 
+#include <gr_icmp6.h>
+
 #include <rte_arp.h>
 #include <rte_graph.h>
 #include <rte_icmp.h>
@@ -55,5 +57,7 @@ int trace_ip_format(char *buf, size_t len, const struct rte_ipv4_hdr *, size_t d
 int trace_ip6_format(char *buf, size_t len, const struct rte_ipv6_hdr *, size_t data_len);
 
 int trace_icmp_format(char *buf, size_t len, const struct rte_icmp_hdr *, size_t data_len);
+
+int trace_icmp6_format(char *buf, size_t len, const struct icmp6 *, size_t data_len);
 
 #endif

--- a/modules/infra/datapath/gr_trace.h
+++ b/modules/infra/datapath/gr_trace.h
@@ -8,6 +8,7 @@
 #include <rte_arp.h>
 #include <rte_graph.h>
 #include <rte_ip4.h>
+#include <rte_ip6.h>
 #include <rte_mbuf.h>
 
 // Call a function writing on a buffer called 'buf'.
@@ -49,5 +50,7 @@ int eth_type_format(char *buf, size_t len, rte_be16_t type);
 int trace_arp_format(char *buf, size_t len, const struct rte_arp_hdr *, size_t data_len);
 
 int trace_ip_format(char *buf, size_t len, const struct rte_ipv4_hdr *, size_t data_len);
+
+int trace_ip6_format(char *buf, size_t len, const struct rte_ipv6_hdr *, size_t data_len);
 
 #endif

--- a/modules/infra/datapath/gr_trace.h
+++ b/modules/infra/datapath/gr_trace.h
@@ -42,4 +42,6 @@ void gr_trace_clear(void);
 // Return true if trace is enabled for all interfaces.
 bool gr_trace_all_enabled(void);
 
+int eth_type_format(char *buf, size_t len, rte_be16_t type);
+
 #endif

--- a/modules/infra/datapath/gr_trace.h
+++ b/modules/infra/datapath/gr_trace.h
@@ -5,6 +5,7 @@
 #ifndef _GR_INFRA_PACKET_TRACE
 #define _GR_INFRA_PACKET_TRACE
 
+#include <rte_graph.h>
 #include <rte_mbuf.h>
 
 // Call a function writing on a buffer called 'buf'.
@@ -26,5 +27,16 @@
 
 // Write a log message with detailed packet information.
 void trace_log_packet(const struct rte_mbuf *m, const char *node, const char *iface);
+
+// Callback associated with each node that will be invoked by gr_trace_dump
+// to format each individual trace items.
+typedef int (*gr_trace_format_cb_t)(char *buf, size_t buf_len, const void *data, size_t data_len);
+
+// Format the buffered trace items and empty the buffer.
+// Return the number of bytes written to buffer or a negative value on error.
+int gr_trace_dump(char *buf, size_t buf_len);
+
+// Empty the trace buffer.
+void gr_trace_clear(void);
 
 #endif

--- a/modules/ip/datapath/arp_input.c
+++ b/modules/ip/datapath/arp_input.c
@@ -7,6 +7,7 @@
 #include <gr_ip4_datapath.h>
 #include <gr_log.h>
 #include <gr_mbuf.h>
+#include <gr_trace.h>
 
 #include <rte_arp.h>
 #include <rte_byteorder.h>
@@ -133,6 +134,10 @@ arp_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 		arp_data->local = local;
 		arp_data->remote = remote;
 next:
+		if (gr_mbuf_is_traced(mbuf)) {
+			struct rte_arp_hdr *t = gr_mbuf_trace_add(mbuf, node, sizeof(*t));
+			*t = *arp;
+		}
 		rte_node_enqueue_x1(graph, node, edge, mbuf);
 	}
 
@@ -163,6 +168,7 @@ static struct rte_node_register node = {
 static struct gr_node_info info = {
 	.node = &node,
 	.register_callback = arp_input_register,
+	.trace_format = (gr_trace_format_cb_t)trace_arp_format,
 };
 
 GR_NODE_REGISTER(info);

--- a/modules/ip/datapath/icmp_input.c
+++ b/modules/ip/datapath/icmp_input.c
@@ -7,6 +7,7 @@
 #include <gr_ip4_datapath.h>
 #include <gr_log.h>
 #include <gr_mbuf.h>
+#include <gr_trace.h>
 
 #include <rte_byteorder.h>
 #include <rte_ether.h>
@@ -63,6 +64,10 @@ icmp_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 			edge = UNSUPPORTED;
 		}
 next:
+		if (gr_mbuf_is_traced(mbuf)) {
+			struct rte_icmp_hdr *d = gr_mbuf_trace_add(mbuf, node, sizeof(*d));
+			*d = *icmp;
+		}
 		rte_node_enqueue_x1(graph, node, edge, mbuf);
 	}
 
@@ -99,6 +104,7 @@ static struct rte_node_register icmp_input_node = {
 static struct gr_node_info icmp_input_info = {
 	.node = &icmp_input_node,
 	.register_callback = icmp_input_register,
+	.trace_format = (gr_trace_format_cb_t)trace_icmp_format,
 };
 
 GR_NODE_REGISTER(icmp_input_info);

--- a/modules/ip/datapath/icmp_local_send.c
+++ b/modules/ip/datapath/icmp_local_send.c
@@ -106,6 +106,8 @@ static uint16_t icmp_local_send_process(
 
 		next = OUTPUT;
 
+		if (gr_mbuf_is_traced(mbuf))
+			gr_mbuf_trace_add(mbuf, node, 0);
 		rte_node_enqueue_x1(graph, node, next, mbuf);
 		free(msg);
 	}

--- a/modules/ip/datapath/ip_error.c
+++ b/modules/ip/datapath/ip_error.c
@@ -7,6 +7,7 @@
 #include <gr_ip4_datapath.h>
 #include <gr_log.h>
 #include <gr_mbuf.h>
+#include <gr_trace.h>
 
 #include <rte_common.h>
 #include <rte_graph_worker.h>
@@ -39,6 +40,7 @@ ip_error_process(struct rte_graph *graph, struct rte_node *node, void **objs, ui
 
 		ip = rte_pktmbuf_mtod(mbuf, struct rte_ipv4_hdr *);
 		icmp = (struct rte_icmp_hdr *)rte_pktmbuf_prepend(mbuf, sizeof(*icmp));
+
 		if (unlikely(icmp == NULL)) {
 			edge = NO_HEADROOM;
 			goto next;
@@ -73,6 +75,9 @@ ip_error_process(struct rte_graph *graph, struct rte_node *node, void **objs, ui
 
 		edge = ICMP_OUTPUT;
 next:
+		if (gr_mbuf_is_traced(mbuf)) {
+			gr_mbuf_trace_add(mbuf, node, 0);
+		}
 		rte_node_enqueue_x1(graph, node, edge, mbuf);
 	}
 

--- a/modules/ip/datapath/ip_forward.c
+++ b/modules/ip/datapath/ip_forward.c
@@ -2,6 +2,8 @@
 // Copyright (c) 2024 Robin Jarry
 
 #include <gr_graph.h>
+#include <gr_mbuf.h>
+#include <gr_trace.h>
 
 #include <rte_fib.h>
 #include <rte_graph_worker.h>
@@ -33,6 +35,10 @@ ip_forward_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 		csum = ip->hdr_checksum + RTE_BE16(0x0100);
 		csum += csum >= 0xffff;
 		ip->hdr_checksum = csum;
+
+		if (gr_mbuf_is_traced(mbuf))
+			gr_mbuf_trace_add(mbuf, node, 0);
+
 		rte_node_enqueue_x1(graph, node, OUTPUT, mbuf);
 	}
 

--- a/modules/ip/datapath/ip_input.c
+++ b/modules/ip/datapath/ip_input.c
@@ -6,6 +6,7 @@
 #include <gr_ip4_control.h>
 #include <gr_ip4_datapath.h>
 #include <gr_log.h>
+#include <gr_trace.h>
 
 #include <rte_byteorder.h>
 #include <rte_errno.h>
@@ -111,6 +112,10 @@ ip_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, ui
 		else
 			edge = FORWARD;
 next:
+		if (gr_mbuf_is_traced(mbuf)) {
+			struct rte_ipv4_hdr *t = gr_mbuf_trace_add(mbuf, node, sizeof(*t));
+			*t = *ip;
+		}
 		// Store the resolved next hop for ip_output to avoid a second route lookup.
 		d->nh = nh;
 		d->input_iface = iface;
@@ -143,6 +148,7 @@ static struct rte_node_register input_node = {
 static struct gr_node_info info = {
 	.node = &input_node,
 	.register_callback = ip_input_register,
+	.trace_format = (gr_trace_format_cb_t)trace_ip_format,
 };
 
 GR_NODE_REGISTER(info);

--- a/modules/ip/datapath/ip_local.c
+++ b/modules/ip/datapath/ip_local.c
@@ -5,6 +5,7 @@
 #include <gr_graph.h>
 #include <gr_ip4_datapath.h>
 #include <gr_log.h>
+#include <gr_trace.h>
 
 #include <rte_graph_worker.h>
 #include <rte_ip.h>
@@ -34,6 +35,10 @@ static uint16_t ip_input_local_process(
 	for (i = 0; i < nb_objs; i++) {
 		mbuf = objs[i];
 		ip = rte_pktmbuf_mtod(mbuf, struct rte_ipv4_hdr *);
+
+		if (gr_mbuf_is_traced(mbuf))
+			gr_mbuf_trace_add(mbuf, node, 0);
+
 		edge = edges[ip->next_proto_id];
 		if (edge != UNKNOWN_PROTO) {
 			const struct iface *iface = ip_output_mbuf_data(mbuf)->input_iface;

--- a/modules/ip/datapath/ip_output.c
+++ b/modules/ip/datapath/ip_output.c
@@ -10,6 +10,7 @@
 #include <gr_ip4_datapath.h>
 #include <gr_log.h>
 #include <gr_mbuf.h>
+#include <gr_trace.h>
 
 #include <rte_byteorder.h>
 #include <rte_ether.h>
@@ -144,6 +145,10 @@ ip_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 		eth_data->iface = iface;
 		sent++;
 next:
+		if (gr_mbuf_is_traced(mbuf)) {
+			struct rte_ipv4_hdr *t = gr_mbuf_trace_add(mbuf, node, sizeof(*t));
+			*t = *ip;
+		}
 		rte_node_enqueue_x1(graph, node, edge, mbuf);
 	}
 
@@ -164,6 +169,7 @@ static struct rte_node_register output_node = {
 
 static struct gr_node_info info = {
 	.node = &output_node,
+	.trace_format = (gr_trace_format_cb_t)trace_ip_format,
 };
 
 GR_NODE_REGISTER(info);

--- a/modules/ip6/datapath/ip6_error.c
+++ b/modules/ip6/datapath/ip6_error.c
@@ -8,6 +8,7 @@
 #include <gr_ip6_datapath.h>
 #include <gr_log.h>
 #include <gr_mbuf.h>
+#include <gr_trace.h>
 
 #include <rte_common.h>
 #include <rte_graph_worker.h>
@@ -37,6 +38,9 @@ ip6_error_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 
 	for (uint16_t i = 0; i < nb_objs; i++) {
 		mbuf = objs[i];
+
+		if (gr_mbuf_is_traced(mbuf))
+			gr_mbuf_trace_add(mbuf, node, 0);
 
 		// Get the pointer to the start of the ipv6 header before
 		// prepending any data

--- a/modules/ip6/datapath/ip6_forward.c
+++ b/modules/ip6/datapath/ip6_forward.c
@@ -2,6 +2,8 @@
 // Copyright (c) 2024 Robin Jarry
 
 #include <gr_graph.h>
+#include <gr_mbuf.h>
+#include <gr_trace.h>
 
 #include <rte_fib6.h>
 #include <rte_graph_worker.h>
@@ -23,6 +25,8 @@ ip6_forward_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 	for (i = 0; i < nb_objs; i++) {
 		mbuf = objs[i];
 		ip = rte_pktmbuf_mtod(mbuf, struct rte_ipv6_hdr *);
+		if (gr_mbuf_is_traced(mbuf))
+			gr_mbuf_trace_add(mbuf, node, 0);
 
 		if (ip->hop_limits <= 1) {
 			rte_node_enqueue_x1(graph, node, TTL_EXCEEDED, mbuf);

--- a/modules/ip6/datapath/ip6_local.c
+++ b/modules/ip6/datapath/ip6_local.c
@@ -6,6 +6,7 @@
 #include <gr_ip6_control.h>
 #include <gr_ip6_datapath.h>
 #include <gr_log.h>
+#include <gr_trace.h>
 
 #include <rte_graph_worker.h>
 #include <rte_ip6.h>
@@ -82,6 +83,9 @@ static uint16_t ip6_input_local_process(
 			break;
 		}
 next:
+		if (gr_mbuf_is_traced(m))
+			gr_mbuf_trace_add(m, node, 0);
+
 		rte_node_enqueue_x1(graph, node, edge, m);
 	}
 

--- a/modules/ip6/datapath/ip6_output.c
+++ b/modules/ip6/datapath/ip6_output.c
@@ -10,6 +10,7 @@
 #include <gr_ip6_datapath.h>
 #include <gr_log.h>
 #include <gr_mbuf.h>
+#include <gr_trace.h>
 
 #include <rte_byteorder.h>
 #include <rte_ether.h>
@@ -149,6 +150,10 @@ ip6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 		eth_data->iface = iface;
 		sent++;
 next:
+		if (gr_mbuf_is_traced(mbuf)) {
+			struct rte_ipv6_hdr *t = gr_mbuf_trace_add(mbuf, node, sizeof(*t));
+			*t = *ip;
+		}
 		rte_node_enqueue_x1(graph, node, edge, mbuf);
 	}
 
@@ -169,6 +174,7 @@ static struct rte_node_register output_node = {
 
 static struct gr_node_info info = {
 	.node = &output_node,
+	.trace_format = (gr_trace_format_cb_t)trace_ip6_format,
 };
 
 GR_NODE_REGISTER(info);

--- a/modules/ip6/datapath/ndp_na_input.c
+++ b/modules/ip6/datapath/ndp_na_input.c
@@ -7,6 +7,7 @@
 #include <gr_ip6_datapath.h>
 #include <gr_log.h>
 #include <gr_mbuf.h>
+#include <gr_trace.h>
 
 #include <rte_byteorder.h>
 #include <rte_ether.h>
@@ -135,9 +136,16 @@ static uint16_t ndp_na_input_process(
 		ASSERT_NDP(lladdr_found);
 
 		ndp_update_nexthop(graph, node, remote, iface, &lladdr);
+
+		if (gr_mbuf_is_traced(mbuf)) {
+			gr_mbuf_trace_add(mbuf, node, 0);
+			gr_mbuf_trace_finish(mbuf);
+		}
 		rte_pktmbuf_free(mbuf);
 		continue;
 next:
+		if (gr_mbuf_is_traced(mbuf))
+			gr_mbuf_trace_add(mbuf, node, 0);
 		rte_node_enqueue_x1(graph, node, next, mbuf);
 	}
 

--- a/modules/ip6/datapath/ndp_ns_output.c
+++ b/modules/ip6/datapath/ndp_ns_output.c
@@ -11,6 +11,7 @@
 #include <gr_ip6_datapath.h>
 #include <gr_log.h>
 #include <gr_macro.h>
+#include <gr_trace.h>
 
 #include <rte_byteorder.h>
 #include <rte_errno.h>
@@ -94,6 +95,11 @@ static uint16_t ndp_ns_output_process(
 		icmp6->cksum = 0;
 		icmp6->cksum = rte_ipv6_udptcp_cksum(ip, icmp6);
 
+		if (gr_mbuf_is_traced(mbuf)) {
+			uint8_t trace_len = RTE_MIN(payload_len, GR_TRACE_ITEM_MAX_LEN);
+			struct icmp6 *t = gr_mbuf_trace_add(mbuf, node, trace_len);
+			memcpy(t, icmp6, trace_len);
+		}
 		nh->last_request = rte_get_tsc_cycles();
 		ip6_output_mbuf_data(mbuf)->nh = nh;
 		next = OUTPUT;
@@ -121,6 +127,7 @@ static struct rte_node_register node = {
 static struct gr_node_info info = {
 	.node = &node,
 	.register_callback = ndp_output_solicit_register,
+	.trace_format = (gr_trace_format_cb_t)trace_icmp6_format,
 };
 
 GR_NODE_REGISTER(info);

--- a/modules/ipip/ipip_priv.h
+++ b/modules/ipip/ipip_priv.h
@@ -16,4 +16,10 @@ struct __rte_aligned(alignof(void *)) iface_info_ipip {
 
 struct iface *ipip_get_iface(ip4_addr_t local, ip4_addr_t remote, uint16_t vrf_id);
 
+struct trace_ipip_data {
+	uint16_t iface_id;
+};
+
+int trace_ipip_format(char *buf, size_t len, const void *data, size_t data_len);
+
 #endif

--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -41,6 +41,7 @@ grcli show ip nexthop
 grcli show ip route
 grcli show ip6 nexthop
 grcli show ip6 route
+grcli show trace
 EOF
 
 set -x
@@ -53,3 +54,5 @@ if [ "$run_grout" = true ]; then
 	grout $grout_flags &
 fi
 socat FILE:/dev/null UNIX-CONNECT:$GROUT_SOCK_PATH,retry=10
+
+grcli set trace all


### PR DESCRIPTION
- Prepend a common structure for all mbuf priv data Prepend to all mbuf_priv data a common structure, which will include data available for the whole life of the packet.

- Add packet tracing infra, to log the packet traversal on each node. Add CLI to enable/disable packet tracing per interface. Add relevant trace function on nodes.

'show trace' command is destructive and empties the ring.

Sample output:
```
# show trace
--------- 19:08:04.169479762Z cpu 1 ---------
port_rx: p1q0 iface gi2dmo1
eth_input: IP4 ba:d0:ca:ca:00:01 -> f0:0d:ac:dc:00:01 iface gi2dmo1 vlan 0
ip_input: 172.16.1.2 -> 192.168.2.10 next proto: UDP ttl 64
ip_error_dest_unreach:
ip_output: 172.16.1.1 -> 172.16.1.2 next proto: ICMP ttl 64
eth_output: IP4 f0:0d:ac:dc:00:01 -> ba:d0:ca:ca:00:01 iface gi2dmo1 vlan 0
port_tx: p1q0
```