### PR TITLE
iface: avoid use after free on duplicate name

### DIFF
--- a/modules/infra/control/iface.c
+++ b/modules/infra/control/iface.c
@@ -79,6 +79,7 @@ struct iface *iface_create(
 		goto fail;
 	while ((iface = iface_next(GR_IFACE_TYPE_UNDEF, iface)) != NULL) {
 		if (strcmp(name, iface->name) == 0) {
+			iface = NULL;
 			errno = EEXIST;
 			goto fail;
 		}


### PR DESCRIPTION
When an interface name is already taken, we return an error but the iface pointer is set the already existing interface. Before returning from iface_create, that pointer is freed without removing the interface from the system.

When listing interface or accessing anything after that causes an invalid memory access.

Avoid going through the free code path and return immediately when either the interface type or name are invalid or if the name is duplicate.

Fixes: a0f9d6699605 ("iface: forbid duplicate names on creation")
Reported-by: Christophe Fontaine <cfontain@redhat.com>