### PR TITLE
main: add support for debugging eal arguments

### DIFF
--- a/docs/grout.8.scd
+++ b/docs/grout.8.scd
@@ -14,26 +14,80 @@ Grout is a software router based on DPDK rte_graph.
 
 ; Please keep flags/options in alphabetical order.
 
-*grout* [*-h*] [*-p*] [*-s* _PATH_] [*-t*] [*-V*] [*-v*] [*-x*]
+*grout* [*-h*] [*-L* _<type>:<level>_] [*-p*] [*-s* _<path>_] [*-t*] [*-T*
+_<regexp>_] [*-B* _<size>_] [*-D* _<path>_] [*-M* _<mode>_] [*-x*] [*-v*] [*-V*]
+
 
 # OPTIONS
 
 *-h*, *--help*
 	Display usage help.
+
 *-p*, *--poll-mode*
 	Disable automatic micro-sleep.
-*-s* _PATH_, *--socket* _PATH_
+
+*-s*, *--socket* _<path>_
 	Path the control plane API socket.
 
 	Default: *GROUT_SOCK_PATH* from environment or _/run/grout.sock_).
+
 *-t*, *--test-mode*
 	Run in test mode (no huge pages).
+
 *-V*, *--version*
 	Print version and exit.
+
 *-v*, *--verbose*
 	Increase verbosity. Can be specified multiple times.
+
 *-x*, *--trace-packets*
 	Print all ingress/egress packets (for debugging purposes).
+
+*-L*, *--log-level* _<type>:<level>_
+	Specify log level for a specific component. For example:
+
+		*--log-level* _lib.eal:debug_
+
+	Can be specified multiple times.
+
+*-T*, *--trace* _<regexp>_
+	Enable trace based on regular expression trace name. By default, the
+	trace is disabled. User must specify this option to enable trace. For
+	example:
+
+	Global trace configuration for EAL only:
+		*--trace* _eal_
+	Global trace configuration for ALL the components:
+		*--trace* _.\*_
+
+	Can be specified multiple times up to 32 times.
+
+*-D*, *--trace-dir* _<path>_
+	Specify trace directory for trace output. For example:
+
+		*--trace-dir* _/tmp_
+
+	By default, trace output will created at home directory and parameter
+	must be specified once only.
+
+*-B*, *--trace-bufsz* _<size>_
+	Specify maximum size of allocated memory for trace output for each
+	thread. Valid unit can be either B or K or M for Bytes, KBytes and
+	MBytes respectively. For example:
+
+		*--trace-bufsz* _2M_
+
+	By default, size of trace output file is 1MB and parameter must be
+	specified once only.
+
+*-M*, *--trace-mode* _o|overwrite|d|discard_
+	Specify the mode of update of trace output file. Either update on a file
+	can be wrapped or discarded when file size reaches its maximum limit.
+	For example:
+
+		*--trace-mode* _discard_
+
+	Default mode is _overwrite_ and parameter must be specified once only.
 
 # AUTHORS
 

--- a/main/dpdk.c
+++ b/main/dpdk.c
@@ -133,7 +133,7 @@ static int cpuset_format(char *buf, size_t len, cpu_set_t *set) {
 int dpdk_init(const struct gr_args *args) {
 	char affinity[BUFSIZ] = "";
 	char main_lcore[32] = "";
-	char **eal_args = NULL;
+	char **eal_args = NULL, *arg;
 	cpu_set_t cpus;
 	int ret;
 
@@ -168,6 +168,9 @@ int dpdk_init(const struct gr_args *args) {
 	} else {
 		gr_vec_add(eal_args, "--in-memory");
 	}
+
+	gr_vec_foreach (arg, args->eal_extra_args)
+		gr_vec_add(eal_args, arg);
 
 	LOG(INFO, "%s", rte_version());
 

--- a/main/gr.h
+++ b/main/gr.h
@@ -11,6 +11,7 @@ struct gr_args {
 	unsigned log_level;
 	bool test_mode;
 	bool poll_mode;
+	char **eal_extra_args;
 };
 
 const struct gr_args *gr_args(void);

--- a/main/main.c
+++ b/main/main.c
@@ -10,6 +10,7 @@
 
 #include <gr_api.h>
 #include <gr_log.h>
+#include <gr_vec.h>
 
 #include <event2/event.h>
 #include <event2/thread.h>
@@ -26,20 +27,28 @@
 // Please keep options/flags in alphabetical order.
 
 static void usage(const char *prog) {
-	printf("Usage: %s [-h] [-p] [-s PATH] [-t] [-v] [-v] [-x]\n", prog);
+	printf("Usage: %s [-h] [-L <type>:<lvl>] [-p] [-s <path>] [-t] [-T <regexp>]\n", prog);
+	printf("       %*s [-B <size>] [-D <path>] [-M <mode>] [-x] [-v] [-V]\n",
+	       (int)strlen(prog),
+	       "");
 	puts("");
-	printf("  Graph router version %s.\n", GROUT_VERSION);
+	printf("  Graph router version %s (%s).\n", GROUT_VERSION, rte_version());
 	puts("");
 	puts("options:");
-	puts("  -h, --help                 Display this help message and exit.");
-	puts("  -p, --poll-mode            Disable automatic micro-sleep.");
-	puts("  -s PATH, --socket PATH     Path the control plane API socket.");
-	puts("                             Default: GROUT_SOCK_PATH from env or");
-	printf("                             %s).\n", GR_DEFAULT_SOCK_PATH);
-	puts("  -t, --test-mode            Run in test mode (no hugepages).");
-	puts("  -V, --version              Print version and exit.");
-	puts("  -v, --verbose              Increase verbosity.");
-	puts("  -x, --trace-packets        Print all ingress/egress packets.");
+	puts("  -h, --help                     Display this help message and exit.");
+	puts("  -L, --log-level <type>:<lvl>   Specify log level for a specific component.");
+	puts("  -p, --poll-mode                Disable automatic micro-sleep.");
+	puts("  -s, --socket <path>            Path the control plane API socket.");
+	puts("                                 Default: GROUT_SOCK_PATH from env or");
+	printf("                                 %s).\n", GR_DEFAULT_SOCK_PATH);
+	puts("  -t, --test-mode                Run in test mode (no hugepages).");
+	puts("  -T, --trace <regexp>           Enable trace matching the regular expression.");
+	puts("  -B, --trace-bufsz <size>       Maximum size of allocated memory for trace output.");
+	puts("  -D, --trace-dir <path>         Change path for trace output.");
+	puts("  -M, --trace-mode <mode>        Specify the mode of update of trace output file.");
+	puts("  -x, --trace-packets            Print all ingress/egress packets.");
+	puts("  -v, --verbose                  Increase verbosity.");
+	puts("  -V, --version                  Print version and exit.");
 }
 
 static struct gr_args args;
@@ -52,28 +61,40 @@ const struct gr_args *gr_args(void) {
 static int parse_args(int argc, char **argv) {
 	int c;
 
-#define FLAGS ":hps:tVvx"
+#define FLAGS ":B:D:L:M:T:Vhps:t:vx"
 	static struct option long_options[] = {
 		{"help", no_argument, NULL, 'h'},
+		{"log-level", required_argument, NULL, 'L'},
 		{"poll-mode", no_argument, NULL, 'p'},
 		{"socket", required_argument, NULL, 's'},
 		{"test-mode", no_argument, NULL, 't'},
-		{"version", no_argument, NULL, 'V'},
-		{"verbose", no_argument, NULL, 'v'},
+		{"trace", required_argument, NULL, 'T'},
+		{"trace-bufsz", required_argument, NULL, 'B'},
+		{"trace-dir", required_argument, NULL, 'D'},
+		{"trace-mode", required_argument, NULL, 'M'},
 		{"trace-packets", no_argument, NULL, 'x'},
+		{"verbose", no_argument, NULL, 'v'},
+		{"version", no_argument, NULL, 'V'},
 		{0},
 	};
 
 	opterr = 0; // disable getopt default error reporting
 
 	args.api_sock_path = getenv("GROUT_SOCK_PATH");
+	if (args.api_sock_path == NULL)
+		args.api_sock_path = GR_DEFAULT_SOCK_PATH;
 	args.log_level = RTE_LOG_NOTICE;
+	args.eal_extra_args = NULL;
 
 	while ((c = getopt_long(argc, argv, FLAGS, long_options, NULL)) != -1) {
 		switch (c) {
 		case 'h':
 			usage(argv[0]);
 			return -1;
+		case 'L':
+			gr_vec_add(args.eal_extra_args, "--log-level");
+			gr_vec_add(args.eal_extra_args, optarg);
+			break;
 		case 'p':
 			args.poll_mode = true;
 			break;
@@ -83,15 +104,27 @@ static int parse_args(int argc, char **argv) {
 		case 't':
 			args.test_mode = true;
 			break;
-		case 'V':
-			printf("grout %s (%s)\n", GROUT_VERSION, rte_version());
-			exit(EXIT_SUCCESS);
+		case 'T':
+			gr_vec_add(args.eal_extra_args, "--trace");
+			gr_vec_add(args.eal_extra_args, optarg);
+			break;
+		case 'D':
+			gr_vec_add(args.eal_extra_args, "--trace-dir");
+			gr_vec_add(args.eal_extra_args, optarg);
+			break;
+		case 'M':
+			gr_vec_add(args.eal_extra_args, "--trace-mode");
+			gr_vec_add(args.eal_extra_args, optarg);
+			break;
+		case 'x':
+			packet_trace_enabled = true;
 			break;
 		case 'v':
 			args.log_level++;
 			break;
-		case 'x':
-			packet_trace_enabled = true;
+		case 'V':
+			printf("grout %s (%s)\n", GROUT_VERSION, rte_version());
+			exit(EXIT_SUCCESS);
 			break;
 		case ':':
 			usage(argv[0]);
@@ -110,9 +143,6 @@ end:
 		fputs("error: invalid arguments", stderr);
 		return errno_set(EINVAL);
 	}
-
-	if (args.api_sock_path == NULL)
-		args.api_sock_path = GR_DEFAULT_SOCK_PATH;
 
 	return 0;
 }
@@ -188,5 +218,6 @@ dpdk_stop:
 	if (err != 0)
 		sd_notifyf(0, "ERRNO=%i", err);
 end:
+	gr_vec_free(args.eal_extra_args);
 	return ret;
 }


### PR DESCRIPTION
Some EAL parameters can be useful to profile and/or debug specific issues in DPDK. Add support for the following parameters:

	--log-level
	--trace
	--trace-dir
	--trace-bufsz
	--trace-mode

The EAL arguments are mapped to grout flags to prevent the users from passing any supported EAL parameter by DPDK. Indeed, grout initialization has specific needs which may get disturbed by some flags. Only expose the ones that are harmless.