### PR TITLE
meson: use latest libecoli release

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,7 +61,17 @@ dpdk_dep = dependency(
 ev_core_dep = dependency('libevent_core')
 ev_thread_dep = dependency('libevent_pthreads')
 numa_dep = dependency('numa')
-ecoli_dep = dependency('libecoli', fallback: ['ecoli', 'libecoli_dep'])
+ecoli_dep = dependency(
+  'libecoli',
+  fallback: ['ecoli', 'libecoli_dep'],
+  default_options: [
+    'doc=disabled',
+    'editline=enabled',
+    'examples=disabled',
+    'tests=disabled',
+    'yaml=disabled',
+  ]
+)
 smartcols_dep = dependency('smartcols')
 
 src = []

--- a/subprojects/ecoli.wrap
+++ b/subprojects/ecoli.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/rjarry/libecoli
-revision = v0.2.0
+revision = v0.3.0
 depth = 1
 
 [provide]


### PR DESCRIPTION
The build options have been changed to meson auto features and now default to all enabled if the dependencies are found. Explicitly set editline=enabled to fail if libedit is not installed.

Disable all other features since grout does not need them.