### PR TITLE
arp: fix source ip in arp reply

### DIFF
--- a/modules/ip/datapath/arp_output_reply.c
+++ b/modules/ip/datapath/arp_output_reply.c
@@ -32,6 +32,7 @@ static uint16_t arp_output_reply_process(
 	const struct iface *iface;
 	struct rte_arp_hdr *arp;
 	struct rte_mbuf *mbuf;
+	ip4_addr_t tmp_ip;
 	rte_edge_t edge;
 	uint16_t num;
 
@@ -61,8 +62,9 @@ static uint16_t arp_output_reply_process(
 			edge = ERROR;
 			goto next;
 		}
-		arp->arp_data.arp_tip = arp_data->remote->ip;
-		arp->arp_data.arp_sip = arp_data->local->ip;
+		tmp_ip = arp->arp_data.arp_tip;
+		arp->arp_data.arp_tip = arp->arp_data.arp_sip;
+		arp->arp_data.arp_sip = tmp_ip;
 
 		// Prepare ethernet layer info.
 		eth_data = eth_output_mbuf_data(mbuf);


### PR DESCRIPTION
Given the following configuration:
iface0: 192.168.0.1/32
iface1: 192.168.0.2/24

When an arp_request arrives on iface1 (who has 192.168.0.1?), grout answers with the ip belonging to the interface iface1, so the tip field in the arp message is filled with "192.168.0.2" instead of the requested IP.

Swap the fields SIP and TIP to avoid this: this is safe as the only possible upstream node is "arp_input".