### PR TITLE
ip6: fix crash upon interface creation

### DIFF
--- a/modules/ip6/datapath/ndp_ns_input.c
+++ b/modules/ip6/datapath/ndp_ns_input.c
@@ -78,7 +78,7 @@ static uint16_t ndp_ns_input_process(
 		ASSERT_NDP(!rte_ipv6_addr_is_mcast(&ns->target));
 
 		local = ip6_addr_get_preferred(iface->id, &ns->target);
-		if (!rte_ipv6_addr_eq(&local->ip, &ns->target)) {
+		if (local == NULL || !rte_ipv6_addr_eq(&local->ip, &ns->target)) {
 			next = IGNORE;
 			goto next;
 		}


### PR DESCRIPTION
With an interface up, we have a race between the local ipv6 assignation and the packet reception.
Check that we have a valid ip6 address before accessing it.