### PR TITLE
dpdk: update to 24.11

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,7 +48,7 @@ $(BUILDDIR)/build.ninja:
 empty :=
 space := $(empty) $(empty)
 version := $(shell { git describe --long --abbrev=8 --dirty 2>/dev/null || \
-	sed -En 's/.* \|\| echo (v[0-9\.]+)\>.*/\1-'`date +%Y%m%d%H%M%S`.`hostname`'/p' meson.build; } | \
+	sed -En 's/.* \|\| echo (v[0-9\.]+)\>.*/\1-'`date +%Y%m%d%H%M%S.local`'/p' meson.build; } | \
 	sed 's/^v//;s/-/ /')
 debversion = $(subst $(space),+,$(version))
 

--- a/README.md
+++ b/README.md
@@ -110,34 +110,34 @@ systemctl restart grout.service
 [root@grout]$ systemctl status -n40 grout.service
 ● grout.service - Graph router daemon
      Loaded: loaded (/usr/lib/systemd/system/grout.service; enabled; preset: disabled)
-     Active: active (running) since Mon 2024-09-09 10:31:40 CEST; 4s ago
+     Active: active (running) since Sat 2024-11-30 10:31:40 CEST; 4s ago
     Process: 31298 ExecStartPre=/usr/bin/udevadm settle (code=exited, status=0/SUCCESS)
     Process: 31302 ExecStartPost=/usr/bin/grcli -xef /etc/grout.init (code=exited, status=0/SUCCESS)
    Main PID: 31299 (grout)
-     Status: "grout version v0.1-108-gb46a80db started"
+     Status: "grout version v0.2-93-gf53240e3750a started"
       Tasks: 5 (limit: 195427)
      Memory: 6.6M
         CPU: 19.185s
      CGroup: /system.slice/grout.service
              └─31299 /usr/sbin/grout
 
-Sep 09 10:31:31 grout systemd[1]: Starting Graph router daemon...
-Sep 09 10:31:31 grout grout[31299]: GROUT: main: starting grout version v0.1-108-gb46a80db
-Sep 09 10:31:31 grout grout[31299]: GROUT: dpdk_init: DPDK 24.07.0
-Sep 09 10:31:31 grout grcli[31302]: + add interface port p0 devargs 0000:8a:00.0 rxqs 1 qsize 2048
-Sep 09 10:31:32 grout grout[31299]: GROUT: gr_datapath_loop: [CPU 1] starting tid=31303
-Sep 09 10:31:40 grout grcli[31302]: Created interface 1
-Sep 09 10:31:32 grout grcli[31302]: + add interface port p1 devargs 0000:8a:00.1 rxqs 1 qsize 2048
-Sep 09 10:31:40 grout grcli[31302]: Created interface 2
-Sep 09 10:31:33 grout grcli[31302]: + set port qmap p0 rxq 0 cpu 2
-Sep 09 10:31:33 grout grout[31299]: GROUT: gr_datapath_loop: [CPU 2] starting tid=31304
-Sep 09 10:31:38 grout grcli[31302]: + set port qmap p1 rxq 0 cpu 22
-Sep 09 10:31:38 grout grout[31299]: GROUT: gr_datapath_loop: [CPU 22] starting tid=31305
-Sep 09 10:31:38 grout grout[31299]: GROUT: gr_datapath_loop: [CPU 1] shutting down tid=31303
-Sep 09 10:31:40 grout grcli[31302]: + add ip address 172.16.0.2/24 iface p0
-Sep 09 10:31:40 grout grcli[31302]: + add ip address 172.16.1.2/24 iface p1
-Sep 09 10:31:40 grout grcli[31302]: + add ip route 0.0.0.0/0 via 172.16.1.183
-Sep 09 10:31:40 grout systemd[1]: Started Graph router daemon.
+Nov 30 10:31:31 grout systemd[1]: Starting Graph router daemon...
+Nov 30 10:31:31 grout grout[31299]: GROUT: main: starting grout version v0.2-93-gf53240e3750a
+Nov 30 10:31:31 grout grout[31299]: GROUT: dpdk_init: DPDK 24.11.0
+Nov 30 10:31:31 grout grcli[31302]: + add interface port p0 devargs 0000:8a:00.0 rxqs 1 qsize 2048
+Nov 30 10:31:32 grout grout[31299]: GROUT: gr_datapath_loop: [CPU 1] starting tid=31303
+Nov 30 10:31:40 grout grcli[31302]: Created interface 1
+Nov 30 10:31:32 grout grcli[31302]: + add interface port p1 devargs 0000:8a:00.1 rxqs 1 qsize 2048
+Nov 30 10:31:40 grout grcli[31302]: Created interface 2
+Nov 30 10:31:33 grout grcli[31302]: + set port qmap p0 rxq 0 cpu 2
+Nov 30 10:31:33 grout grout[31299]: GROUT: gr_datapath_loop: [CPU 2] starting tid=31304
+Nov 30 10:31:38 grout grcli[31302]: + set port qmap p1 rxq 0 cpu 22
+Nov 30 10:31:38 grout grout[31299]: GROUT: gr_datapath_loop: [CPU 22] starting tid=31305
+Nov 30 10:31:38 grout grout[31299]: GROUT: gr_datapath_loop: [CPU 1] shutting down tid=31303
+Nov 30 10:31:40 grout grcli[31302]: + add ip address 172.16.0.2/24 iface p0
+Nov 30 10:31:40 grout grcli[31302]: + add ip address 172.16.1.2/24 iface p1
+Nov 30 10:31:40 grout grcli[31302]: + add ip route 0.0.0.0/0 via 172.16.1.183
+Nov 30 10:31:40 grout systemd[1]: Started Graph router daemon.
 ```
 
 ### Interact with the CLI
@@ -264,8 +264,8 @@ The binaries are located in the build directory:
 
 ```console
 [root@dev grout]$ taskset --cpu-list 0,2,22 ./build/grout -v -s grout.sock
-INFO: GROUT: dpdk_init: starting grout version v0.1-103.g39e42d1e
-INFO: GROUT: dpdk_init: DPDK 24.07.0
+INFO: GROUT: dpdk_init: starting grout version v0.2-93-gf53240e3750a
+INFO: GROUT: dpdk_init: DPDK 24.11.0
 INFO: GROUT: dpdk_init: EAL arguments: -l 0 -a 0000:00:00.0 --log-level=*:notice --log-level=grout:info
 ...
 INFO: GROUT: listen_api_socket: listening on API socket grout.sock

--- a/subprojects/dpdk.wrap
+++ b/subprojects/dpdk.wrap
@@ -1,6 +1,7 @@
 [wrap-git]
 url = https://github.com/DPDK/dpdk
-revision = v24.11-rc1
+revision = v24.11
+diff_files = log-fix-double-free-on-cleanup.patch
 depth = 1
 
 [provide]

--- a/subprojects/packagefiles/log-fix-double-free-on-cleanup.patch
+++ b/subprojects/packagefiles/log-fix-double-free-on-cleanup.patch
@@ -1,0 +1,85 @@
+From fe6b72e20c62920f7e61ee32e4d4ccc38dc8354e Mon Sep 17 00:00:00 2001
+From: Robin Jarry <rjarry@redhat.com>
+Date: Fri, 29 Nov 2024 16:49:42 +0100
+Subject: [PATCH dpdk] log: fix double free on cleanup
+
+Fix the following crash when closing a log file after rte_eal_cleanup():
+
+    double free or corruption (!prev)
+
+    Thread 1 "grout" received signal SIGABRT, Aborted.
+    __pthread_kill_implementation (threadid=<optimized out>,
+    signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
+    ...
+    #10 _IO_new_fclose (fp=0xb63090) at iofclose.c:74
+    #11 0x000000000049c04e in dpdk_fini () at ../main/dpdk.c:204
+    #12 0x0000000000402ab8 in main (...) at ../main/main.c:217
+    (gdb) up 11
+    #11 0x000000000049c04e in dpdk_fini () at ../main/dpdk.c:204
+    202             rte_eal_cleanup();
+    203             if (log_stream != NULL)
+    204                     fclose(log_stream);
+
+When the application has passed a custom file via rte_openlog_stream()
+DPDK should not call fclose() on it.
+
+Add an internal is_internal_file field to track whether the file has
+been allocated by DPDK (syslog or journald) to determine if it should be
+closed or not.
+
+Fixes: 985130369be3 ("log: rework syslog handling")
+Signed-off-by: Robin Jarry <rjarry@redhat.com>
+---
+ lib/log/log.c | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/lib/log/log.c b/lib/log/log.c
+index eb087d601e8b..e1c18a8e5351 100644
+--- a/lib/log/log.c
++++ b/lib/log/log.c
+@@ -38,6 +38,7 @@ static struct rte_logs {
+ 	uint32_t type;  /**< Bitfield with enabled logs. */
+ 	uint32_t level; /**< Log level. */
+ 	FILE *file;     /**< Output file set by rte_openlog_stream, or NULL. */
++	bool is_internal_file;
+ 	log_print_t print_func;
+ 	size_t dynamic_types_len;
+ 	struct rte_log_dynamic_type *dynamic_types;
+@@ -80,8 +81,11 @@ static RTE_DEFINE_PER_LCORE(struct log_cur_msg, log_cur_msg);
+ int
+ rte_openlog_stream(FILE *f)
+ {
++	if (rte_logs.is_internal_file && rte_logs.file != NULL)
++		fclose(rte_logs.file);
+ 	rte_logs.file = f;
+ 	rte_logs.print_func = vfprintf;
++	rte_logs.is_internal_file = false;
+ 	return 0;
+ }
+ 
+@@ -520,6 +524,7 @@ eal_log_init(const char *id)
+ 		/* if either syslog or journal is used, then no special handling */
+ 		if (logf) {
+ 			rte_openlog_stream(logf);
++			rte_logs.is_internal_file = true;
+ 		} else {
+ 			bool is_terminal = isatty(fileno(stderr));
+ 			bool use_color = log_color_enabled(is_terminal);
+@@ -550,11 +555,8 @@ eal_log_init(const char *id)
+ void
+ rte_eal_log_cleanup(void)
+ {
+-	FILE *log_stream = rte_logs.file;
+-
+-	/* don't close stderr on the application */
+-	if (log_stream != NULL)
+-		fclose(log_stream);
+-
++	if (rte_logs.is_internal_file && rte_logs.file != NULL)
++		fclose(rte_logs.file);
+ 	rte_logs.file = NULL;
++	rte_logs.is_internal_file = false;
+ }
+-- 
+2.47.1
+


### PR DESCRIPTION
Unfortunately, there is a regression introduced in 24.11. I submitted a fix upstream which is applied locally until it will be merged.

The fix will most likely be backported in the first 24.11 stable Z release.

Link: https://patches.dpdk.org/project/dpdk/patch/20241129161013.704859-2-rjarry@redhat.com/