### PR TITLE
treewide: add custom printf specifiers for addresses

### DIFF
--- a/api/meson.build
+++ b/api/meson.build
@@ -11,4 +11,14 @@ api_headers += files(
   'gr_net_types.h',
 )
 
+src += files('printf.c')
+cli_src += files('printf.c')
+
 api_inc += include_directories('.')
+
+tests += [
+  {
+    'sources': files('printf_test.c', 'printf.c'),
+    'link_args': [],
+  },
+]

--- a/api/printf.c
+++ b/api/printf.c
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024 Robin Jarry
+
+#include <gr_net_types.h>
+
+#include <arpa/inet.h>
+#include <printf.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+
+static int format_pointer(FILE *f, const struct printf_info *info, const void *const *args) {
+	char buf[INET6_ADDRSTRLEN];
+	const void *arg = *(const void **)*args;
+
+	if (arg == NULL)
+		return fprintf(f, "(nil)");
+
+	switch (info->width) {
+	case 2: // struct rte_ether_addr *
+		const struct rte_ether_addr *mac = arg;
+		return fprintf(
+			f,
+			"%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx",
+			mac->addr_bytes[0],
+			mac->addr_bytes[1],
+			mac->addr_bytes[2],
+			mac->addr_bytes[3],
+			mac->addr_bytes[4],
+			mac->addr_bytes[5]
+		);
+	case 4: // ip4_addr_t *
+		inet_ntop(AF_INET, arg, buf, sizeof(buf));
+		return fprintf(f, "%s", buf);
+	case 6: // struct rte_ipv6_addr *
+		inet_ntop(AF_INET6, arg, buf, sizeof(buf));
+		return fprintf(f, "%s", buf);
+	}
+
+	return fprintf(f, "0x%lx", (uintptr_t)arg);
+}
+
+static int check_pointer_arg(const struct printf_info *, size_t n, int *argtypes, int *sizes) {
+	if (n == 1) {
+		sizes[0] = sizeof(void *);
+		argtypes[0] = PA_POINTER;
+		return 1;
+	}
+	return -1;
+}
+
+static void __attribute__((constructor, used)) init(void) {
+	if (register_printf_specifier('p', format_pointer, check_pointer_arg) < 0)
+		abort();
+}

--- a/api/printf_test.c
+++ b/api/printf_test.c
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024 Robin Jarry
+
+#include <gr_cmocka.h>
+#include <gr_net_types.h>
+
+#include <stddef.h>
+#include <stdio.h>
+
+static void ether(void **) {
+	struct rte_ether_addr mac = {{0x90, 0x2e, 0x16, 0x55, 0x8e, 0x6a}};
+	char buf[64];
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), ETH_F, &mac);
+	assert_string_equal(buf, "90:2e:16:55:8e:6a");
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), ETH_F, NULL);
+	assert_string_equal(buf, "(nil)");
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), ADDR_F, 2, &mac);
+	assert_string_equal(buf, "90:2e:16:55:8e:6a");
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), ADDR_F, 2, NULL);
+	assert_string_equal(buf, "(nil)");
+}
+
+static void ipv4(void **) {
+	ip4_addr_t ip4 = htonl(0x01020304);
+	char buf[64];
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), IP4_F, &ip4);
+	assert_string_equal(buf, "1.2.3.4");
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), IP4_F, NULL);
+	assert_string_equal(buf, "(nil)");
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), ADDR_F, 4, &ip4);
+	assert_string_equal(buf, "1.2.3.4");
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), ADDR_F, 4, NULL);
+	assert_string_equal(buf, "(nil)");
+}
+
+static void ipv6(void **) {
+	struct rte_ipv6_addr ip6 = {
+		{0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0x2e, 0x8b, 0x35, 0x2e, 0x66, 0xbf, 0x3a, 0xd8}
+	};
+	char buf[64];
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), IP6_F, &ip6);
+	assert_string_equal(buf, "fe80::2e8b:352e:66bf:3ad8");
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), IP6_F, NULL);
+	assert_string_equal(buf, "(nil)");
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), ADDR_F, 6, &ip6);
+	assert_string_equal(buf, "fe80::2e8b:352e:66bf:3ad8");
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), ADDR_F, 6, NULL);
+	assert_string_equal(buf, "(nil)");
+}
+
+static void pointers(void **) {
+	void *p = (void *)(uintptr_t)0x7ffd3aae340c;
+	char buf[64];
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), "%p", p);
+	assert_string_equal(buf, "0x7ffd3aae340c");
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), "%1337p", p);
+	assert_string_equal(buf, "0x7ffd3aae340c");
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), "%42p", p);
+	assert_string_equal(buf, "0x7ffd3aae340c");
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), "%p", NULL);
+	assert_string_equal(buf, "(nil)");
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), "%1337p", NULL);
+	assert_string_equal(buf, "(nil)");
+	buf[0] = 0;
+	snprintf(buf, sizeof(buf), "%42p", NULL);
+	assert_string_equal(buf, "(nil)");
+}
+
+int main(void) {
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(ether),
+		cmocka_unit_test(ipv4),
+		cmocka_unit_test(ipv6),
+		cmocka_unit_test(pointers),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/modules/infra/cli/port.c
+++ b/modules/infra/cli/port.c
@@ -19,7 +19,7 @@ static void port_show(const struct gr_api_client *, const struct gr_iface *iface
 
 	printf("devargs: %s\n", port->devargs);
 	printf("driver:  %s\n", port->driver_name);
-	printf("mac: " ETH_ADDR_FMT "\n", ETH_ADDR_SPLIT(&port->mac));
+	printf("mac: " ETH_F "\n", &port->mac);
 	printf("n_rxq: %u\n", port->n_rxq);
 	printf("n_txq: %u\n", port->n_txq);
 	printf("rxq_size: %u\n", port->rxq_size);
@@ -29,9 +29,7 @@ static void port_show(const struct gr_api_client *, const struct gr_iface *iface
 static void
 port_list_info(const struct gr_api_client *, const struct gr_iface *iface, char *buf, size_t len) {
 	const struct gr_iface_info_port *port = (const struct gr_iface_info_port *)iface->info;
-	snprintf(
-		buf, len, "devargs=%s mac=" ETH_ADDR_FMT, port->devargs, ETH_ADDR_SPLIT(&port->mac)
-	);
+	snprintf(buf, len, "devargs=%s mac=" ETH_F, port->devargs, &port->mac);
 }
 
 static struct cli_iface_type port_type = {

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -448,10 +448,10 @@ static int port_mac_add(struct iface *iface, const struct rte_ether_addr *mac) {
 	for (i = 0; i < filter->count; i++) {
 		if (rte_is_same_ether_addr(&filter->mac[i], mac)) {
 			LOG(DEBUG,
-			    "%s: %s mac " ETH_ADDR_FMT " already filtered (refs=%u)",
+			    "%s: %s mac " ETH_F " already filtered (refs=%u)",
 			    iface->name,
 			    mac_type,
-			    ETH_ADDR_SPLIT(mac),
+			    mac,
 			    filter->refcnt[i]++);
 			return 0;
 		}
@@ -463,11 +463,7 @@ static int port_mac_add(struct iface *iface, const struct rte_ether_addr *mac) {
 	filter->refcnt[i] = 1;
 	filter->count++;
 
-	LOG(INFO,
-	    "%s: enabling %s " ETH_ADDR_FMT " mac filter",
-	    iface->name,
-	    mac_type,
-	    ETH_ADDR_SPLIT(mac));
+	LOG(INFO, "%s: enabling %s " ETH_F " mac filter", iface->name, mac_type, mac);
 
 	if (filter->flags & MAC_FILTER_F_ALL)
 		return 0;
@@ -540,19 +536,15 @@ static int port_mac_del(struct iface *iface, const struct rte_ether_addr *mac) {
 found:
 	if (--filter->refcnt[i] > 0) {
 		LOG(DEBUG,
-		    "%s: %s mac " ETH_ADDR_FMT " still filtered (refs=%u)",
+		    "%s: %s mac " ETH_F " still filtered (refs=%u)",
 		    iface->name,
 		    mac_type,
-		    ETH_ADDR_SPLIT(mac),
+		    mac,
 		    filter->refcnt[i]);
 		return 0;
 	}
 
-	LOG(INFO,
-	    "%s: removing %s " ETH_ADDR_FMT " mac filter",
-	    iface->name,
-	    mac_type,
-	    ETH_ADDR_SPLIT(mac));
+	LOG(INFO, "%s: removing %s " ETH_F " mac filter", iface->name, mac_type, mac);
 
 	if (i + 1 < filter->count) {
 		// shift other addresses and ref counts left

--- a/modules/infra/datapath/eth_input.c
+++ b/modules/infra/datapath/eth_input.c
@@ -116,13 +116,7 @@ int eth_trace_format(char *buf, size_t len, const void *data, size_t /*data_len*
 	const char *ifname = iface ? iface->name : "[deleted]";
 	size_t n = 0;
 
-	SAFE_BUF(
-		snprintf,
-		len,
-		ETH_ADDR_FMT " > " ETH_ADDR_FMT " type=",
-		ETH_ADDR_SPLIT(&t->eth.src_addr),
-		ETH_ADDR_SPLIT(&t->eth.dst_addr)
-	);
+	SAFE_BUF(snprintf, len, ETH_F " > " ETH_F " type=", &t->eth.src_addr, &t->eth.dst_addr);
 	SAFE_BUF(eth_type_format, len, t->eth.ether_type);
 
 	if (t->vlan_id != 0)

--- a/modules/ip/cli/address.c
+++ b/modules/ip/cli/address.c
@@ -52,9 +52,7 @@ static cmd_status_t addr_list(const struct gr_api_client *c, const struct ec_pno
 	const struct gr_ip4_addr_list_resp *resp;
 	struct gr_ip4_addr_list_req req = {0};
 	struct gr_iface iface;
-
 	void *resp_ptr = NULL;
-	char buf[BUFSIZ];
 
 	if (table == NULL)
 		return CMD_ERROR;
@@ -78,12 +76,11 @@ static cmd_status_t addr_list(const struct gr_api_client *c, const struct ec_pno
 	for (size_t i = 0; i < resp->n_addrs; i++) {
 		struct libscols_line *line = scols_table_new_line(table, NULL);
 		const struct gr_ip4_ifaddr *addr = &resp->addrs[i];
-		ip4_net_format(&addr->addr, buf, sizeof(buf));
 		if (iface_from_id(c, addr->iface_id, &iface) == 0)
 			scols_line_sprintf(line, 0, "%s", iface.name);
 		else
 			scols_line_sprintf(line, 0, "%u", addr->iface_id);
-		scols_line_sprintf(line, 1, "%s", buf);
+		scols_line_sprintf(line, 1, IP4_F "/%hhu", &addr->addr.ip, addr->addr.prefixlen);
 	}
 
 	scols_print_table(table);

--- a/modules/ip/cli/icmp.c
+++ b/modules/ip/cli/icmp.c
@@ -83,17 +83,17 @@ static cmd_status_t icmp_send(
 			switch (reply_resp->type) {
 			case RTE_ICMP_TYPE_ECHO_REPLY:
 				if (mode_traceroute) {
-					printf("%2d  " IP4_ADDR_FMT " time=%.3f ms\n",
+					printf("%2d  " IP4_F " time=%.3f ms\n",
 					       i,
-					       IP4_ADDR_SPLIT(&reply_resp->src_addr),
+					       &reply_resp->src_addr,
 					       reply_resp->response_time / 1000.);
 					stop = true;
 					errors = 0;
 					errno = 0;
 				} else {
-					printf("reply from " IP4_ADDR_FMT ": icmp_seq=%d ttl=%d "
+					printf("reply from " IP4_F ": icmp_seq=%d ttl=%d "
 					       "time=%.3f ms\n",
-					       IP4_ADDR_SPLIT(&reply_resp->src_addr),
+					       &reply_resp->src_addr,
 					       reply_resp->seq_num,
 					       reply_resp->ttl,
 					       reply_resp->response_time / 1000.);
@@ -102,8 +102,8 @@ static cmd_status_t icmp_send(
 			case RTE_ICMP_TYPE_DEST_UNREACHABLE:
 				errors++;
 				errno = EHOSTUNREACH;
-				printf("reply from " IP4_ADDR_FMT ": icmp_seq=%d ttl=%d: %s\n",
-				       IP4_ADDR_SPLIT(&reply_resp->src_addr),
+				printf("reply from " IP4_F ": icmp_seq=%d ttl=%d: %s\n",
+				       &reply_resp->src_addr,
 				       reply_resp->seq_num,
 				       reply_resp->ttl,
 				       icmp_dest_unreachable[reply_resp->code]);
@@ -111,9 +111,9 @@ static cmd_status_t icmp_send(
 			case RTE_ICMP_TYPE_TTL_EXCEEDED:
 				errors++;
 				errno = ETIMEDOUT;
-				printf("%2d  " IP4_ADDR_FMT " time=%.3f ms\n",
+				printf("%2d  " IP4_F " time=%.3f ms\n",
 				       i,
-				       IP4_ADDR_SPLIT(&reply_resp->src_addr),
+				       &reply_resp->src_addr,
 				       reply_resp->response_time / 1000.);
 				break;
 			}

--- a/modules/ip/cli/nexthop.c
+++ b/modules/ip/cli/nexthop.c
@@ -57,9 +57,9 @@ static cmd_status_t nh4_list(const struct gr_api_client *c, const struct ec_pnod
 	struct gr_ip4_nh_list_req req = {.vrf_id = UINT16_MAX};
 	struct libscols_table *table = scols_new_table();
 	const struct gr_ip4_nh_list_resp *resp;
-	char ip[BUFSIZ], buf[BUFSIZ];
 	struct gr_iface iface;
 	void *resp_ptr = NULL;
+	char buf[BUFSIZ];
 	ssize_t n;
 
 	if (table == NULL)
@@ -98,12 +98,10 @@ static cmd_status_t nh4_list(const struct gr_api_client *c, const struct ec_pnod
 		if (n > 0)
 			buf[n - 1] = '\0';
 
-		inet_ntop(AF_INET, &nh->host, ip, sizeof(ip));
-
 		scols_line_sprintf(line, 0, "%u", nh->vrf_id);
-		scols_line_sprintf(line, 1, "%s", ip);
+		scols_line_sprintf(line, 1, IP4_F, &nh->host);
 		if (nh->flags & GR_IP4_NH_F_REACHABLE) {
-			scols_line_sprintf(line, 2, ETH_ADDR_FMT, ETH_ADDR_SPLIT(&nh->mac));
+			scols_line_sprintf(line, 2, ETH_F, &nh->mac);
 			if (iface_from_id(c, nh->iface_id, &iface) == 0)
 				scols_line_sprintf(line, 3, "%s", iface.name);
 			else

--- a/modules/ip/cli/route.c
+++ b/modules/ip/cli/route.c
@@ -51,7 +51,6 @@ static cmd_status_t route4_list(const struct gr_api_client *c, const struct ec_p
 	struct gr_ip4_route_list_req req = {.vrf_id = UINT16_MAX};
 	struct libscols_table *table = scols_new_table();
 	const struct gr_ip4_route_list_resp *resp;
-	char dest[BUFSIZ], nh[BUFSIZ];
 	void *resp_ptr = NULL;
 
 	if (table == NULL)
@@ -74,11 +73,9 @@ static cmd_status_t route4_list(const struct gr_api_client *c, const struct ec_p
 	for (size_t i = 0; i < resp->n_routes; i++) {
 		struct libscols_line *line = scols_table_new_line(table, NULL);
 		const struct gr_ip4_route *route = &resp->routes[i];
-		ip4_net_format(&route->dest, dest, sizeof(dest));
-		inet_ntop(AF_INET, &route->nh, nh, sizeof(nh));
 		scols_line_sprintf(line, 0, "%u", route->vrf_id);
-		scols_line_set_data(line, 1, dest);
-		scols_line_set_data(line, 2, nh);
+		scols_line_sprintf(line, 1, IP4_F "/%hhu", &route->dest.ip, route->dest.prefixlen);
+		scols_line_sprintf(line, 2, IP4_F, &route->nh);
 	}
 
 	scols_print_table(table);
@@ -93,7 +90,6 @@ static cmd_status_t route4_get(const struct gr_api_client *c, const struct ec_pn
 	struct gr_ip4_route_get_req req = {0};
 	struct gr_iface iface;
 	void *resp_ptr = NULL;
-	char buf[BUFSIZ];
 	const char *dest = arg_str(p, "DEST");
 
 	if (dest == NULL) {
@@ -112,12 +108,11 @@ static cmd_status_t route4_get(const struct gr_api_client *c, const struct ec_pn
 		return CMD_ERROR;
 
 	resp = resp_ptr;
-	inet_ntop(AF_INET, &resp->nh.host, buf, sizeof(buf));
-	printf("%s via %s lladdr " ETH_ADDR_FMT, dest, buf, ETH_ADDR_SPLIT(&resp->nh.mac));
+	printf("%s via " IP4_F " lladdr " ETH_F, dest, &resp->nh.host, &resp->nh.mac);
 	if (iface_from_id(c, resp->nh.iface_id, &iface) == 0)
-		printf("iface %s", iface.name);
+		printf(" iface %s", iface.name);
 	else
-		printf("iface %u", resp->nh.iface_id);
+		printf(" iface %u", resp->nh.iface_id);
 	printf("\n");
 	free(resp_ptr);
 

--- a/modules/ip/control/nexthop.c
+++ b/modules/ip/control/nexthop.c
@@ -187,7 +187,6 @@ static void nh_gc_cb(struct rte_mempool *, void * /*opaque*/, void *obj, unsigne
 	uint64_t now = rte_get_tsc_cycles();
 	uint64_t reply_age, request_age;
 	unsigned probes, max_probes;
-	char buf[INET_ADDRSTRLEN];
 	struct nexthop *nh = obj;
 
 	max_probes = IP4_NH_UCAST_PROBES + IP4_NH_BCAST_PROBES;
@@ -201,10 +200,9 @@ static void nh_gc_cb(struct rte_mempool *, void * /*opaque*/, void *obj, unsigne
 
 	if (nh->flags & (GR_IP4_NH_F_PENDING | GR_IP4_NH_F_STALE) && request_age > probes) {
 		if (probes >= max_probes && !(nh->flags & GR_IP4_NH_F_GATEWAY)) {
-			inet_ntop(AF_INET, &nh->ip, buf, sizeof(buf));
 			LOG(DEBUG,
-			    "%s vrf=%u failed_probes=%u held_pkts=%u: %s -> failed",
-			    buf,
+			    IP4_F " vrf=%u failed_probes=%u held_pkts=%u: %s -> failed",
+			    &nh->ip,
 			    nh->vrf_id,
 			    probes,
 			    nh->held_pkts_num,
@@ -220,10 +218,9 @@ static void nh_gc_cb(struct rte_mempool *, void * /*opaque*/, void *obj, unsigne
 		nh->flags &= ~GR_IP4_NH_F_REACHABLE;
 		nh->flags |= GR_IP4_NH_F_STALE;
 	} else if (nh->flags & GR_IP4_NH_F_FAILED && request_age > IP4_NH_LIFETIME_UNREACHABLE) {
-		inet_ntop(AF_INET, &nh->ip, buf, sizeof(buf));
 		LOG(DEBUG,
-		    "%s vrf=%u failed_probes=%u held_pkts=%u: failed -> <destroy>",
-		    buf,
+		    IP4_F " vrf=%u failed_probes=%u held_pkts=%u: failed -> <destroy>",
+		    &nh->ip,
 		    nh->vrf_id,
 		    probes,
 		    nh->held_pkts_num);

--- a/modules/ip/control/route.c
+++ b/modules/ip/control/route.c
@@ -385,11 +385,7 @@ void ip4_route_cleanup(struct nexthop *nh) {
 			rte_rib_get_depth(rn, &prefixlen);
 			ip = rte_cpu_to_be_32(ip);
 
-			LOG(DEBUG,
-			    "delete " IP4_ADDR_FMT "/%d via " IP4_ADDR_FMT,
-			    IP4_ADDR_SPLIT(&ip),
-			    prefixlen,
-			    IP4_ADDR_SPLIT(&nh->ip));
+			LOG(DEBUG, "delete " IP4_F "/%hhu via " IP4_F, &ip, prefixlen, &nh->ip);
 
 			ip4_route_delete(nh->vrf_id, ip, prefixlen);
 			ip4_route_delete(nh->vrf_id, ip, 32);
@@ -405,11 +401,7 @@ void ip4_route_cleanup(struct nexthop *nh) {
 			rte_rib_get_depth(rn, &prefixlen);
 			ip = rte_cpu_to_be_32(ip);
 
-			LOG(DEBUG,
-			    "delete " IP4_ADDR_FMT "/%d via " IP4_ADDR_FMT,
-			    IP4_ADDR_SPLIT(&ip),
-			    prefixlen,
-			    IP4_ADDR_SPLIT(&nh->ip));
+			LOG(DEBUG, "delete " IP4_F "/%hhu via " IP4_F, &ip, prefixlen, &nh->ip);
 
 			ip4_route_delete(nh->vrf_id, nh->ip, nh->prefixlen);
 			ip4_route_delete(nh->vrf_id, nh->ip, 32);

--- a/modules/ip6/cli/address.c
+++ b/modules/ip6/cli/address.c
@@ -52,9 +52,7 @@ static cmd_status_t addr_list(const struct gr_api_client *c, const struct ec_pno
 	const struct gr_ip6_addr_list_resp *resp;
 	struct gr_ip6_addr_list_req req = {0};
 	struct gr_iface iface;
-
 	void *resp_ptr = NULL;
-	char buf[BUFSIZ];
 
 	if (table == NULL)
 		return CMD_ERROR;
@@ -78,12 +76,11 @@ static cmd_status_t addr_list(const struct gr_api_client *c, const struct ec_pno
 	for (size_t i = 0; i < resp->n_addrs; i++) {
 		struct libscols_line *line = scols_table_new_line(table, NULL);
 		const struct gr_ip6_ifaddr *addr = &resp->addrs[i];
-		ip6_net_format(&addr->addr, buf, sizeof(buf));
 		if (iface_from_id(c, addr->iface_id, &iface) == 0)
 			scols_line_sprintf(line, 0, "%s", iface.name);
 		else
 			scols_line_sprintf(line, 0, "%u", addr->iface_id);
-		scols_line_sprintf(line, 1, "%s", buf);
+		scols_line_sprintf(line, 1, IP6_F "/%hhu", &addr->addr, addr->addr.prefixlen);
 	}
 
 	scols_print_table(table);

--- a/modules/ip6/cli/nexthop.c
+++ b/modules/ip6/cli/nexthop.c
@@ -56,7 +56,7 @@ static cmd_status_t nh6_list(const struct gr_api_client *c, const struct ec_pnod
 	struct gr_ip6_nh_list_req req = {.vrf_id = UINT16_MAX};
 	struct libscols_table *table = scols_new_table();
 	const struct gr_ip6_nh_list_resp *resp;
-	char ip[INET6_ADDRSTRLEN], state[128];
+	char state[128];
 	struct gr_iface iface;
 	void *resp_ptr = NULL;
 	ssize_t n;
@@ -100,12 +100,10 @@ static cmd_status_t nh6_list(const struct gr_api_client *c, const struct ec_pnod
 		if (n > 0)
 			state[n - 1] = '\0';
 
-		inet_ntop(AF_INET6, &nh->host, ip, sizeof(ip));
-
 		scols_line_sprintf(line, 0, "%u", nh->vrf_id);
-		scols_line_sprintf(line, 1, "%s", ip);
+		scols_line_sprintf(line, 1, IP6_F, &nh->host);
 		if (nh->flags & GR_IP6_NH_F_REACHABLE) {
-			scols_line_sprintf(line, 2, ETH_ADDR_FMT, ETH_ADDR_SPLIT(&nh->mac));
+			scols_line_sprintf(line, 2, ETH_F, &nh->mac);
 			if (iface_from_id(c, nh->iface_id, &iface) == 0)
 				scols_line_sprintf(line, 3, "%s", iface.name);
 			else

--- a/modules/ip6/control/address.c
+++ b/modules/ip6/control/address.c
@@ -81,7 +81,7 @@ static int ip6_mcast_addr_add(struct iface *iface, const struct rte_ipv6_addr *i
 	struct nexthop6 *nh = NULL;
 	unsigned i;
 
-	LOG(INFO, "%s: joining multicast group " IPV6_ADDR_FMT, iface->name, IPV6_ADDR_SPLIT(ip));
+	LOG(INFO, "%s: joining multicast group " IP6_F, iface->name, ip);
 
 	for (i = 0; i < maddrs->count; i++)
 		if (rte_ipv6_addr_eq(&maddrs->nh[i]->ip, ip))
@@ -111,7 +111,7 @@ static int ip6_mcast_addr_del(struct iface *iface, const struct rte_ipv6_addr *i
 	unsigned i;
 	int ret;
 
-	LOG(INFO, "%s: leaving multicast group " IPV6_ADDR_FMT, iface->name, IPV6_ADDR_SPLIT(ip));
+	LOG(INFO, "%s: leaving multicast group " IP6_F, iface->name, ip);
 
 	for (i = 0; i < maddrs->count; i++) {
 		if (rte_ipv6_addr_eq(&maddrs->nh[i]->ip, ip)) {

--- a/modules/ip6/control/nexthop.c
+++ b/modules/ip6/control/nexthop.c
@@ -204,8 +204,8 @@ static void nh_gc_cb(struct rte_mempool *, void * /*opaque*/, void *obj, unsigne
 	if (nh->flags & (GR_IP6_NH_F_PENDING | GR_IP6_NH_F_STALE) && request_age > probes) {
 		if (probes >= max_probes && !(nh->flags & GR_IP6_NH_F_GATEWAY)) {
 			LOG(DEBUG,
-			    IPV6_ADDR_FMT " vrf=%u failed_probes=%u held_pkts=%u: %s -> failed",
-			    IPV6_ADDR_SPLIT(&nh->ip),
+			    IP6_F " vrf=%u failed_probes=%u held_pkts=%u: %s -> failed",
+			    &nh->ip,
 			    nh->vrf_id,
 			    probes,
 			    nh->held_pkts_num,
@@ -222,8 +222,8 @@ static void nh_gc_cb(struct rte_mempool *, void * /*opaque*/, void *obj, unsigne
 		nh->flags |= GR_IP6_NH_F_STALE;
 	} else if (nh->flags & GR_IP6_NH_F_FAILED && request_age > IP6_NH_LIFETIME_UNREACHABLE) {
 		LOG(DEBUG,
-		    IPV6_ADDR_FMT " vrf=%u failed_probes=%u held_pkts=%u: failed -> <destroy>",
-		    IPV6_ADDR_SPLIT(&nh->ip),
+		    IP6_F " vrf=%u failed_probes=%u held_pkts=%u: failed -> <destroy>",
+		    &nh->ip,
 		    nh->vrf_id,
 		    probes,
 		    nh->held_pkts_num);

--- a/modules/ip6/control/route.c
+++ b/modules/ip6/control/route.c
@@ -381,11 +381,7 @@ void ip6_route_cleanup(struct nexthop6 *nh) {
 			rte_rib6_get_ip(rn, &ip);
 			rte_rib6_get_depth(rn, &depth);
 
-			LOG(DEBUG,
-			    "delete " IPV6_ADDR_FMT "/%d via " IPV6_ADDR_FMT,
-			    IPV6_ADDR_SPLIT(&ip),
-			    depth,
-			    IPV6_ADDR_SPLIT(&nh->ip));
+			LOG(DEBUG, "delete " IP6_F "/%hhu via " IP6_F, &ip, depth, &nh->ip);
 
 			ip6_route_delete(nh->vrf_id, &ip, depth);
 			ip6_route_delete(nh->vrf_id, &ip, RTE_IPV6_MAX_DEPTH);
@@ -400,11 +396,7 @@ void ip6_route_cleanup(struct nexthop6 *nh) {
 			rte_rib6_get_ip(rn, &ip);
 			rte_rib6_get_depth(rn, &depth);
 
-			LOG(DEBUG,
-			    "delete " IPV6_ADDR_FMT "/%d via " IPV6_ADDR_FMT,
-			    IPV6_ADDR_SPLIT(&ip),
-			    depth,
-			    IPV6_ADDR_SPLIT(&nh->ip));
+			LOG(DEBUG, "delete " IP6_F "/%hhu via " IP6_F, &ip, depth, &nh->ip);
 
 			ip6_route_delete(nh->vrf_id, &nh->ip, nh->prefixlen);
 			ip6_route_delete(nh->vrf_id, &nh->ip, RTE_IPV6_MAX_DEPTH);

--- a/modules/ipip/cli.c
+++ b/modules/ipip/cli.c
@@ -13,22 +13,16 @@
 
 static void ipip_show(const struct gr_api_client *, const struct gr_iface *iface) {
 	const struct gr_iface_info_ipip *ipip = (const struct gr_iface_info_ipip *)iface->info;
-	char local[64], remote[64];
 
-	inet_ntop(AF_INET, &ipip->local, local, sizeof(local));
-	inet_ntop(AF_INET, &ipip->remote, remote, sizeof(remote));
-	printf("local: %s\n", local);
-	printf("remote: %s\n", remote);
+	printf("local: " IP4_F "\n", &ipip->local);
+	printf("remote: " IP4_F "\n", &ipip->remote);
 }
 
 static void
 ipip_list_info(const struct gr_api_client *, const struct gr_iface *iface, char *buf, size_t len) {
 	const struct gr_iface_info_ipip *ipip = (const struct gr_iface_info_ipip *)iface->info;
-	char local[64], remote[64];
 
-	inet_ntop(AF_INET, &ipip->local, local, sizeof(local));
-	inet_ntop(AF_INET, &ipip->remote, remote, sizeof(remote));
-	snprintf(buf, len, "local=%s remote=%s", local, remote);
+	snprintf(buf, len, "local=" IP4_F " remote=" IP4_F, &ipip->local, &ipip->remote);
 }
 
 static struct cli_iface_type ipip_type = {


### PR DESCRIPTION
Formatting networking addresses can be tedious and lead to ugly code, especially when dealing with IPv6.

Unfortunately, we cannot use custom printf specifiers since these lead to `-Wformat` warnings. Neither GCC nor clang know of any libc custom printf handlers.

Redefine the builtin `"%p"` pointer printf specifier with a custom function. Leverage the fact that printf supports width specifiers. Use well known widths to associate pointers with specific types. Add short defines to hold these specifiers for clarity:

|  define    |   specifier     |   expected argument type   |
|------------| ----------------| -------------------------   |
|  `ETH_F`     |   `"%2p"`         |   `struct rte_ether_addr *` | 
|  `IP4_F`     |   `"%4p"`         |   `ip4_addr_t *`   |
|  `IP6_F`     |   `"%6p"`         |   `struct rte_ipv6_addr *` |

Replace all printf/log statements to use these specifiers. Remove all manual address splitting and `inet_ntop()` calls.

Also add a generic address format specifier that is meant to be used with a variable width argument:


| define      | specifier       | expected arguments types   |
| ------------ |---------------- |-------------------------  |
| `ADDR_F` |      `"%*p"`    |        `int, void *`    |

Which can be used as follows:

```c
void print_addr(int family, void *addr) {
        printf(ADDR_F "\n", family == AF_INET ? 4 : 6, addr);
}
```

If any of the pointer arguments are NULL, they will be formatted as `"(nil)"` like with the default `"%p"` specifier, regardless of the width value.

The ability to define custom handlers for printf specifiers is only supported in GLIBC. We do not target any other platform at the moment.

Add unit tests to ensure it works as advertised.