### PR TITLE
Iface internal notifications

### DIFF
--- a/modules/infra/cli/iface.c
+++ b/modules/infra/cli/iface.c
@@ -295,6 +295,7 @@ static cmd_status_t iface_list(const struct gr_api_client *c, const struct ec_pn
 			// type
 			scols_line_set_data(line, 4, type->name);
 			// info
+			buf[0] = 0;
 			type->list_info(c, iface, buf, sizeof(buf));
 			scols_line_set_data(line, 5, buf);
 		}

--- a/modules/infra/control/gr_iface.h
+++ b/modules/infra/control/gr_iface.h
@@ -86,7 +86,7 @@ struct iface *iface_next(uint16_t type_id, const struct iface *prev);
 
 #define IFACE_EVENTS                                                                               \
 	IFACE_EVENT(UNKNOWN), IFACE_EVENT(POST_ADD), IFACE_EVENT(PRE_REMOVE),                      \
-		IFACE_EVENT(PORT_POST_RECONFIG)
+		IFACE_EVENT(PORT_POST_RECONFIG), IFACE_EVENT(STATUS_UP), IFACE_EVENT(STATUS_DOWN)
 
 #define IFACE_EVENT(name) IFACE_EVENT_##name
 typedef enum {

--- a/modules/infra/control/gr_iface.h
+++ b/modules/infra/control/gr_iface.h
@@ -86,7 +86,7 @@ struct iface *iface_next(uint16_t type_id, const struct iface *prev);
 
 #define IFACE_EVENTS                                                                               \
 	IFACE_EVENT(UNKNOWN), IFACE_EVENT(POST_ADD), IFACE_EVENT(PRE_REMOVE),                      \
-		IFACE_EVENT(PORT_POST_RECONFIG), IFACE_EVENT(STATUS_UP), IFACE_EVENT(STATUS_DOWN)
+		IFACE_EVENT(POST_RECONFIG), IFACE_EVENT(STATUS_UP), IFACE_EVENT(STATUS_DOWN)
 
 #define IFACE_EVENT(name) IFACE_EVENT_##name
 typedef enum {

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -302,7 +302,7 @@ int iface_port_reconfig(
 	if (stopped && (ret = rte_eth_dev_start(p->port_id)) < 0)
 		return errno_log(-ret, "rte_eth_dev_start");
 
-	iface_event_notify(IFACE_EVENT_PORT_POST_RECONFIG, iface);
+	iface_event_notify(IFACE_EVENT_POST_RECONFIG, iface);
 
 	return port_plug(p->port_id);
 }

--- a/modules/infra/control/vlan.c
+++ b/modules/infra/control/vlan.c
@@ -129,6 +129,8 @@ static int iface_vlan_reconfig(
 	if (set_attrs & GR_IFACE_SET_VRF)
 		iface->vrf_id = vrf_id;
 
+	iface_event_notify(IFACE_EVENT_POST_RECONFIG, iface);
+
 	return 0;
 }
 

--- a/modules/ipip/control.c
+++ b/modules/ipip/control.c
@@ -85,6 +85,8 @@ static int iface_ipip_reconfig(
 	if (set_attrs & GR_IFACE_SET_MTU)
 		iface->mtu = mtu;
 
+	iface_event_notify(IFACE_EVENT_POST_RECONFIG, iface);
+
 	return 0;
 }
 


### PR DESCRIPTION
Add notifications for up/down status, and trigger post-reconfig event for virtual interfaces as well.
This post-reconfig event is required when a 3rd party system will want to get a notification when the VRF associated to an interface is modified.