### PR TITLE
infra: add cli to enable/disable packet logging

### DIFF
--- a/main/gr_log.h
+++ b/main/gr_log.h
@@ -40,6 +40,4 @@ static inline void *__errno_log_null(int errnum, const char *func, const char *w
 
 #define errno_log_null(err, what) __errno_log_null(err, __func__, what)
 
-extern bool packet_trace_enabled;
-
 #endif

--- a/main/main.c
+++ b/main/main.c
@@ -10,6 +10,7 @@
 
 #include <gr_api.h>
 #include <gr_log.h>
+#include <gr_trace.h>
 #include <gr_vec.h>
 
 #include <event2/event.h>
@@ -52,7 +53,6 @@ static void usage(const char *prog) {
 }
 
 static struct gr_args args;
-bool packet_trace_enabled;
 
 const struct gr_args *gr_args(void) {
 	return &args;
@@ -117,7 +117,7 @@ static int parse_args(int argc, char **argv) {
 			gr_vec_add(args.eal_extra_args, optarg);
 			break;
 		case 'x':
-			packet_trace_enabled = true;
+			gr_packet_logging_set(true);
 			break;
 		case 'v':
 			args.log_level++;

--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -236,4 +236,12 @@ struct gr_infra_packet_trace_set_req {
 
 // struct gr_infra_packet_trace_set_resp { };
 
+#define GR_INFRA_PACKET_LOG_SET REQUEST_TYPE(GR_INFRA_MODULE, 0x0043)
+// struct gr_infra_packet_log_set_req { };
+// struct gr_infra_packet_log_set_resp { };
+
+#define GR_INFRA_PACKET_LOG_CLEAR REQUEST_TYPE(GR_INFRA_MODULE, 0x0044)
+// struct gr_infra_packet_log_clear_req { };
+// struct gr_infra_packet_log_clear_resp { };
+
 #endif

--- a/modules/infra/cli/trace.c
+++ b/modules/infra/cli/trace.c
@@ -91,6 +91,20 @@ static cmd_status_t trace_clear(const struct gr_api_client *c, const struct ec_p
 	return CMD_SUCCESS;
 }
 
+static cmd_status_t packet_logging_set(const struct gr_api_client *c, const struct ec_pnode *) {
+	if (gr_api_client_send_recv(c, GR_INFRA_PACKET_LOG_SET, 0, NULL, NULL) < 0)
+		return CMD_ERROR;
+
+	return CMD_SUCCESS;
+}
+
+static cmd_status_t packet_logging_clear(const struct gr_api_client *c, const struct ec_pnode *) {
+	if (gr_api_client_send_recv(c, GR_INFRA_PACKET_LOG_CLEAR, 0, NULL, NULL) < 0)
+		return CMD_ERROR;
+
+	return CMD_SUCCESS;
+}
+
 static int ctx_init(struct ec_node *root) {
 	int ret;
 
@@ -145,6 +159,24 @@ static int ctx_init(struct ec_node *root) {
 
 	ret = CLI_COMMAND(
 		CLI_CONTEXT(root, CTX_CLEAR), "trace", trace_clear, "Clear packet tracing buffer.",
+	);
+	if (ret < 0)
+		return ret;
+
+	ret = CLI_COMMAND(
+		CLI_CONTEXT(root, CTX_SET),
+		"packet logging",
+		packet_logging_set,
+		"Dump packets on grout stdout.",
+	);
+	if (ret < 0)
+		return ret;
+
+	ret = CLI_COMMAND(
+		CLI_CONTEXT(root, CTX_CLEAR),
+		"packet logging",
+		packet_logging_clear,
+		"Stop packet dump on grout stdout.",
 	);
 	if (ret < 0)
 		return ret;

--- a/modules/infra/datapath/drop.c
+++ b/modules/infra/datapath/drop.c
@@ -10,9 +10,9 @@
 #include <rte_mbuf.h>
 
 uint16_t drop_packets(struct rte_graph *, struct rte_node *node, void **objs, uint16_t nb_objs) {
-	if (unlikely(packet_trace_enabled)) {
+	if (unlikely(gr_packet_logging_enabled()))
 		LOG(NOTICE, "[%s] %u packets", node->name, nb_objs);
-	}
+
 	for (int i = 0; i < nb_objs; i++) {
 		struct rte_mbuf *mbuf = objs[i];
 		if (gr_mbuf_is_traced(mbuf)) {

--- a/modules/infra/datapath/eth_output.c
+++ b/modules/infra/datapath/eth_output.c
@@ -70,7 +70,8 @@ eth_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 		eth->src_addr = *src_mac;
 		eth->ether_type = priv->ether_type;
 		mbuf->port = port->port_id;
-		if (unlikely(packet_trace_enabled))
+
+		if (gr_packet_logging_enabled())
 			trace_log_packet(mbuf, "tx", priv->iface->name);
 
 		if (gr_mbuf_is_traced(mbuf)) {

--- a/modules/infra/datapath/gr_trace.h
+++ b/modules/infra/datapath/gr_trace.h
@@ -14,6 +14,8 @@
 #include <rte_ip6.h>
 #include <rte_mbuf.h>
 
+void gr_packet_logging_set(bool);
+bool gr_packet_logging_enabled(void);
 // Write a log message with detailed packet information.
 void trace_log_packet(const struct rte_mbuf *m, const char *node, const char *iface);
 

--- a/modules/infra/datapath/rx.c
+++ b/modules/infra/datapath/rx.c
@@ -69,7 +69,8 @@ rx_process(struct rte_graph *graph, struct rte_node *node, void ** /*objs*/, uin
 				t->queue_id = q.rxq_id;
 			}
 		}
-		if (unlikely(packet_trace_enabled)) {
+
+		if (gr_packet_logging_enabled()) {
 			for (r = count; r < count + rx; r++) {
 				trace_log_packet(node->objs[r], "rx", iface->name);
 			}


### PR DESCRIPTION
Add cli commands in addition to the command line option ( -x ) to enable/disable packet logging.

- set packet logging
- clear packet logging