### PR TITLE
Ip6 scoped linklocal

### DIFF
--- a/modules/infra/control/gr_nh_control.h
+++ b/modules/infra/control/gr_nh_control.h
@@ -95,7 +95,8 @@ struct hoplist {
 	struct nexthop *nh[HOPLIST_MAX_SIZE];
 };
 
-struct nexthop *nexthop_lookup(struct nh_pool *, uint16_t vrf_id, const void *addr);
+struct nexthop *
+nexthop_lookup(struct nh_pool *, uint16_t vrf_id, uint16_t iface_id, const void *addr);
 struct nexthop *nexthop_new(struct nh_pool *, uint16_t vrf_id, uint16_t iface_id, const void *addr);
 
 void nexthop_incref(struct nexthop *);

--- a/modules/infra/datapath/loop_input.c
+++ b/modules/infra/datapath/loop_input.c
@@ -75,7 +75,7 @@ static uint16_t loopback_input_process(
 
 			d = ip6_output_mbuf_data(mbuf);
 			ip = rte_pktmbuf_mtod_offset(mbuf, struct rte_ipv6_hdr *, sizeof(*pi));
-			nh = ip6_route_lookup(d->iface->vrf_id, &ip->dst_addr);
+			nh = ip6_route_lookup(d->iface->vrf_id, d->iface->id, &ip->dst_addr);
 
 			if (nh == NULL) {
 				edge = IP6_NO_ROUTE;

--- a/modules/ip/control/nexthop.c
+++ b/modules/ip/control/nexthop.c
@@ -31,7 +31,8 @@ struct nexthop *ip4_nexthop_new(uint16_t vrf_id, uint16_t iface_id, ip4_addr_t i
 }
 
 struct nexthop *ip4_nexthop_lookup(uint16_t vrf_id, ip4_addr_t ip) {
-	return nexthop_lookup(nh_pool, vrf_id, &ip);
+	// XXX: should we scope ip4 nh lookup based on rfc3927 ?
+	return nexthop_lookup(nh_pool, vrf_id, GR_IFACE_ID_UNDEF, &ip);
 }
 
 static control_input_t ip_output_node;

--- a/modules/ip/datapath/icmp_input.c
+++ b/modules/ip/datapath/icmp_input.c
@@ -33,14 +33,16 @@ icmp_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 	struct rte_icmp_hdr *icmp;
 	struct rte_mbuf *mbuf;
 	rte_edge_t edge;
+	uint16_t cksum;
 	ip4_addr_t ip;
 
 	for (uint16_t i = 0; i < nb_objs; i++) {
 		mbuf = objs[i];
 		icmp = rte_pktmbuf_mtod(mbuf, struct rte_icmp_hdr *);
 		ip_data = ip_local_mbuf_data(mbuf);
+		cksum = ~rte_raw_cksum(icmp, ip_data->len);
 
-		if (ip_data->len < ICMP_MIN_SIZE || (uint16_t)~rte_raw_cksum(icmp, ip_data->len)) {
+		if (ip_data->len < ICMP_MIN_SIZE || cksum) {
 			edge = INVALID;
 			goto next;
 		}

--- a/modules/ip6/control/address.c
+++ b/modules/ip6/control/address.c
@@ -90,8 +90,8 @@ static int ip6_mcast_addr_add(struct iface *iface, const struct rte_ipv6_addr *i
 	if (i == ARRAY_DIM(maddrs->nh))
 		return errno_set(ENOSPC);
 
-	if ((nh = ip6_nexthop_lookup(iface->vrf_id, ip)) == NULL) {
-		if ((nh = ip6_nexthop_new(iface->vrf_id, GR_IFACE_ID_UNDEF, ip)) == NULL)
+	if ((nh = ip6_nexthop_lookup(iface->vrf_id, iface->id, ip)) == NULL) {
+		if ((nh = ip6_nexthop_new(iface->vrf_id, iface->id, ip)) == NULL)
 			return errno_set(-errno);
 		rte_ether_mcast_from_ipv6(&nh->lladdr, ip);
 	}
@@ -155,7 +155,7 @@ iface6_addr_add(const struct iface *iface, const struct rte_ipv6_addr *ip, uint8
 	if (addrs->count == ARRAY_DIM(addrs->nh))
 		return errno_set(ENOSPC);
 
-	if (ip6_nexthop_lookup(iface->vrf_id, ip) != NULL)
+	if (ip6_nexthop_lookup(iface->vrf_id, iface->id, ip) != NULL)
 		return errno_set(EADDRINUSE);
 
 	if ((nh = ip6_nexthop_new(iface->vrf_id, iface->id, ip)) == NULL)
@@ -170,7 +170,7 @@ iface6_addr_add(const struct iface *iface, const struct rte_ipv6_addr *ip, uint8
 			return errno_set(-ret);
 		}
 
-	if ((ret = ip6_route_insert(iface->vrf_id, &nh->ipv6, nh->prefixlen, nh)) < 0)
+	if ((ret = ip6_route_insert(iface->vrf_id, iface->id, ip, nh->prefixlen, nh)) < 0)
 		return errno_set(-ret);
 
 	addrs->nh[addr_index] = nh;

--- a/modules/ip6/control/address.c
+++ b/modules/ip6/control/address.c
@@ -298,12 +298,7 @@ static void ip6_iface_event_handler(iface_event_t event, struct iface *iface) {
 	case IFACE_EVENT_POST_ADD:
 		if (iface_get_eth_addr(iface->id, &mac) == 0) {
 			rte_ipv6_llocal_from_ethernet(&link_local, &mac);
-			// Avoid address conflicts with VLAN interfaces (same mac address)
-			// Maybe we should do better than this and fallback on a pseudo random
-			// algorithm (such as SLAAC, RFC 7217).
-			link_local.a[11] = (iface->id >> 8) & 0xff;
-			link_local.a[12] = iface->id & 0xff;
-			if (iface6_addr_add(iface, &link_local, RTE_IPV6_MAX_DEPTH) < 0)
+			if (iface6_addr_add(iface, &link_local, 64) < 0)
 				errno_log(errno, "iface_addr_add");
 
 			rte_ipv6_solnode_from_addr(&solicited_node, &link_local);

--- a/modules/ip6/control/gr_ip6_control.h
+++ b/modules/ip6/control/gr_ip6_control.h
@@ -20,18 +20,28 @@
 #define IP6_MAX_NEXT_HOPS (1 << 16)
 #define IP6_MAX_ROUTES (1 << 16)
 
-struct nexthop *ip6_nexthop_lookup(uint16_t vrf_id, const struct rte_ipv6_addr *);
+struct nexthop *
+ip6_nexthop_lookup(uint16_t vrf_id, uint16_t iface_id, const struct rte_ipv6_addr *);
 struct nexthop *ip6_nexthop_new(uint16_t vrf_id, uint16_t iface_id, const struct rte_ipv6_addr *);
 
 void ip6_nexthop_unreachable_cb(struct rte_mbuf *m);
 void ndp_probe_input_cb(struct rte_mbuf *m);
 
-int ip6_route_insert(uint16_t vrf_id, const struct rte_ipv6_addr *, uint8_t prefixlen, struct nexthop *);
-int ip6_route_delete(uint16_t vrf_id, const struct rte_ipv6_addr *, uint8_t prefixlen);
+int ip6_route_insert(uint16_t vrf_id, uint16_t iface_id, const struct rte_ipv6_addr *, uint8_t prefixlen, struct nexthop *);
+int ip6_route_delete(
+	uint16_t vrf_id,
+	uint16_t iface_id,
+	const struct rte_ipv6_addr *,
+	uint8_t prefixlen
+);
 void ip6_route_cleanup(struct nexthop *);
-struct nexthop *ip6_route_lookup(uint16_t vrf_id, const struct rte_ipv6_addr *);
-struct nexthop *
-ip6_route_lookup_exact(uint16_t vrf_id, const struct rte_ipv6_addr *, uint8_t prefixlen);
+struct nexthop *ip6_route_lookup(uint16_t vrf_id, uint16_t iface_id, const struct rte_ipv6_addr *);
+struct nexthop *ip6_route_lookup_exact(
+	uint16_t vrf_id,
+	uint16_t iface_id,
+	const struct rte_ipv6_addr *,
+	uint8_t prefixlen
+);
 
 // get the default address for a given interface
 struct nexthop *ip6_addr_get_preferred(uint16_t iface_id, const struct rte_ipv6_addr *);
@@ -40,4 +50,30 @@ struct hoplist *ip6_addr_get_all(uint16_t iface_id);
 // determine if the given interface is member of the provided multicast address group
 struct nexthop *ip6_mcast_get_member(uint16_t iface_id, const struct rte_ipv6_addr *mcast);
 
+static inline const struct rte_ipv6_addr *ip6_addr_linklocal_scope(
+	const struct rte_ipv6_addr *ip,
+	struct rte_ipv6_addr *scoped_ip,
+	uint16_t iface_id
+) {
+	if (rte_ipv6_addr_is_linklocal(ip)) {
+		*scoped_ip = *ip;
+		scoped_ip->a[2] = (iface_id >> 8) & 0xff;
+		scoped_ip->a[3] = iface_id & 0xff;
+		return scoped_ip;
+	} else {
+		return ip;
+	}
+}
+
+static inline const struct rte_ipv6_addr *
+ip6_addr_linklocal_unscope(const struct rte_ipv6_addr *ip, struct rte_ipv6_addr *unscoped_ip) {
+	if (rte_ipv6_addr_is_linklocal(ip)) {
+		*unscoped_ip = *ip;
+		unscoped_ip->a[2] = 0;
+		unscoped_ip->a[3] = 0;
+		return unscoped_ip;
+	} else {
+		return ip;
+	}
+}
 #endif

--- a/modules/ip6/control/route.c
+++ b/modules/ip6/control/route.c
@@ -305,6 +305,7 @@ static int route6_count(uint16_t vrf_id) {
 static void route6_rib_to_api(struct gr_ip6_route_list_resp *resp, uint16_t vrf_id) {
 	struct rte_ipv6_addr zero = RTE_IPV6_ADDR_UNSPEC;
 	struct rte_rib6_node *rn = NULL;
+	struct rte_ipv6_addr tmp;
 	struct gr_ip6_route *r;
 	struct rte_fib6 *fib;
 	struct rte_rib6 *rib;
@@ -321,6 +322,7 @@ static void route6_rib_to_api(struct gr_ip6_route_list_resp *resp, uint16_t vrf_
 		rte_rib6_get_depth(rn, &r->dest.prefixlen);
 		r->nh = nh_id_to_ptr(nh_id)->ipv6;
 		r->vrf_id = vrf_id;
+		r->dest.ip = *ip6_addr_linklocal_unscope(&r->dest.ip, &tmp);
 	}
 	// check if there is a default route configured
 	if ((rn = rte_rib6_lookup_exact(rib, &zero, 0)) != NULL) {

--- a/modules/ip6/datapath/icmp6_output.c
+++ b/modules/ip6/datapath/icmp6_output.c
@@ -57,8 +57,7 @@ static uint16_t icmp6_output_process(
 			struct icmp6 *t = gr_mbuf_trace_add(mbuf, node, trace_len);
 			memcpy(t, icmp6, trace_len);
 		}
-
-		if ((nh = ip6_route_lookup(d->iface->vrf_id, &d->dst)) == NULL) {
+		if ((nh = ip6_route_lookup(d->iface->vrf_id, d->iface->id, &d->dst)) == NULL) {
 			edge = NO_ROUTE;
 			goto next;
 		}

--- a/modules/ip6/datapath/ip6_input.c
+++ b/modules/ip6/datapath/ip6_input.c
@@ -97,7 +97,7 @@ ip6_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 			goto next;
 		}
 
-		nh = ip6_route_lookup(iface->vrf_id, &ip->dst_addr);
+		nh = ip6_route_lookup(iface->vrf_id, iface->id, &ip->dst_addr);
 		if (nh == NULL) {
 			edge = DEST_UNREACH;
 			goto next;

--- a/modules/ip6/datapath/ndp_na_input.c
+++ b/modules/ip6/datapath/ndp_na_input.c
@@ -80,7 +80,7 @@ static uint16_t ndp_na_input_process(
 		// There is no need to create an entry if none exists, since the
 		// recipient has apparently not initiated any communication with the
 		// target.
-		remote = ip6_nexthop_lookup(iface->vrf_id, &na->target);
+		remote = ip6_nexthop_lookup(iface->vrf_id, iface->id, &na->target);
 		ASSERT_NDP(remote != NULL);
 
 		lladdr_found = icmp6_get_opt(

--- a/modules/ip6/datapath/ndp_ns_input.c
+++ b/modules/ip6/datapath/ndp_ns_input.c
@@ -83,6 +83,8 @@ static uint16_t ndp_ns_input_process(
 		local = ip6_nexthop_lookup(iface->vrf_id, &ns->target);
 		if (local == NULL || !(local->flags & GR_NH_F_LOCAL)) {
 			next = IGNORE;
+			if (gr_mbuf_is_traced(mbuf))
+				gr_mbuf_trace_add(mbuf, node, 0);
 			goto next;
 		}
 
@@ -116,6 +118,8 @@ static uint16_t ndp_ns_input_process(
 				);
 				if (copy == NULL) {
 					next = ERROR;
+					if (gr_mbuf_is_traced(mbuf))
+						gr_mbuf_trace_add(mbuf, node, 0);
 					goto next;
 				}
 				if (gr_mbuf_is_traced(mbuf))

--- a/smoke/ip6_forward_test.sh
+++ b/smoke/ip6_forward_test.sh
@@ -26,8 +26,8 @@ done
 
 sleep 3  # wait for DAD
 
-ip netns exec $p1 ping6 -i0.01 -c3 fe80::d2f0:c00:1ba:a411
-ip netns exec $p2 ping6 -i0.01 -c3 fe80::d2f0:c00:1ba:a412
+ip netns exec $p1 ping6 -i0.01 -c3 fe80::d2f0:cff:feba:a411
+ip netns exec $p2 ping6 -i0.01 -c3 fe80::d2f0:cff:feba:a412
 ip netns exec $p1 ping6 -i0.01 -c3 fd00:ba4:2::2
 ip netns exec $p2 ping6 -i0.01 -c3 fd00:ba4:1::2
 ip netns exec $p1 ping6 -i0.01 -c3 fd00:ba4:1::1

--- a/smoke/ip6_same_peer_test.sh
+++ b/smoke/ip6_same_peer_test.sh
@@ -28,9 +28,9 @@ done
 
 sleep 3  # wait for DAD
 
-ip netns exec $p1 ping6 -i0.01 -c3 fe80::d2f0:c00:1ba:a411
-ip netns exec $p2 ping6 -i0.01 -c3 fe80::d2f0:c00:1ba:a412
-ip netns exec $p1 ping6 -i0.01 -c3 fe80::d2f0:c00:1ba:a411 && fail "Unexpected answer from foreign link local address"
+ip netns exec $p1 ping6 -i0.01 -c3 fe80::d2f0:cff:feba:a411
+ip netns exec $p2 ping6 -i0.01 -c3 fe80::d2f0:cff:feba:a412
+ip netns exec $p1 ping6 -i0.01 -c3 fe80::d2f0:cff:feba:a412 && fail "Unexpected answer from foreign link local address"
 ip netns exec $p1 ping6 -i0.01 -c3 fd00:ba4:2::2
 ip netns exec $p2 ping6 -i0.01 -c3 fd00:ba4:1::2
 ip netns exec $p1 ping6 -i0.01 -c3 fd00:ba4:1::1

--- a/smoke/ip6_same_peer_test.sh
+++ b/smoke/ip6_same_peer_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Robin Jarry
+# Copyright (c) 2025 Christophe Fontaine
 
 . $(dirname $0)/_init.sh
 
@@ -9,6 +9,7 @@ p2=${run_id}2
 
 grcli add interface port $p1 devargs net_tap0,iface=$p1 mac d2:f0:0c:ba:a4:11
 grcli add interface port $p2 devargs net_tap1,iface=$p2 mac d2:f0:0c:ba:a4:12
+
 grcli add ip6 address fd00:ba4:1::1/64 iface $p1
 grcli add ip6 address fd00:ba4:2::1/64 iface $p2
 
@@ -17,9 +18,10 @@ for n in 1 2; do
 	ip netns add $p
 	echo ip netns del $p >> $tmp/cleanup
 	ip link set $p netns $p
-	ip -n $p link set $p address d2:ad:ca:ca:a4:1$n
+	ip -n $p link set $p address d2:ad:ca:ca:a4:1
 	ip -n $p link set $p up
 	ip -n $p addr add fd00:ba4:$n::2/64 dev $p
+#	ip -n $p addr add fe80::beef:2/64 dev $p
 	ip -n $p route add default via fd00:ba4:$n::1
 	ip -n $p addr show
 done
@@ -28,6 +30,7 @@ sleep 3  # wait for DAD
 
 ip netns exec $p1 ping6 -i0.01 -c3 fe80::d2f0:c00:1ba:a411
 ip netns exec $p2 ping6 -i0.01 -c3 fe80::d2f0:c00:1ba:a412
+ip netns exec $p1 ping6 -i0.01 -c3 fe80::d2f0:c00:1ba:a411 && fail "Unexpected answer from foreign link local address"
 ip netns exec $p1 ping6 -i0.01 -c3 fd00:ba4:2::2
 ip netns exec $p2 ping6 -i0.01 -c3 fd00:ba4:1::2
 ip netns exec $p1 ping6 -i0.01 -c3 fd00:ba4:1::1


### PR DESCRIPTION
Scoped link local addresses implementation

Still has some issues:
```
grout# add ip6 route ::0/0 via fe80::4e77:6dff:fe7d:1cc7
error: command failed: No route to host
```

This link local address doesn't exist in the FIB, but fe80:100::4e77:6dff:fe7d:1cc7 and fe80:300::4e77:6dff:fe7d:1cc7 are present internally.

```
grout# add ip6 route ::0/0 via fe80:100::4e77:6dff:fe7d:1cc7
grout# show ip6 route
VRF  DESTINATION                    NEXT_HOP
0    fe80::209:c000:17e:f6b/128     fe80::209:c000:17e:f6b
0    fe80::4e77:6dff:fe7d:1cc7/128  fe80::4e77:6dff:fe7d:1cc7
0    fe80::1:1/128                  fe80::1:1
0    fe80::4e77:6dff:fe7d:1cc7/128  fe80::4e77:6dff:fe7d:1cc7
0    fe80::90e2:ba00:314:2f8c/128   fe80::90e2:ba00:314:2f8c
0    ::/0                           fe80::4e77:6dff:fe7d:1cc7
```
