### PR TITLE
github: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATES/bug_report.yml
+++ b/.github/ISSUE_TEMPLATES/bug_report.yml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Robin Jarry
+---
+name: Bug Report
+description: File a bug report.
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+        Make sure to check if a similar bug wasn't already reported and/or
+        fixed by searching through existing issues and pull requests (including
+        closed ones).
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Please describe what is the issue with as much detail as possible.
+        Include any relevant logs, error messages and/or core dump backtraces.
+        Also include what are the steps to reproduce the problem.
+      placeholder: Bug description...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of grout is the bug observed on?
+      placeholder: grout --version
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATES/config.yml
+++ b/.github/ISSUE_TEMPLATES/config.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Robin Jarry
+---
+blank_issues_enabled: false
+contact_links:
+  - name: Mailing List
+    url: mailto:grout@dpdk.org
+    about: Please ask and answer questions here (subscription not required).
+  - name: Mailing List Archives
+    url: https://mails.dpdk.org/archives/grout/
+    about: Browse through previous discussions.

--- a/.github/ISSUE_TEMPLATES/feature_request.yml
+++ b/.github/ISSUE_TEMPLATES/feature_request.yml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Robin Jarry
+---
+name: Feature Request
+description: Request for a new feature.
+labels: ["feature", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to request a new feature!
+
+        Make sure to check if a similar feature wasn't already requested and/or
+        implemented by searching through existing issues and pull requests
+        (including closed ones).
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Please describe what feature is missing. You can include as much detail
+        as you want, including code snippets and external links.
+      placeholder: Feature description...
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context and Use Cases
+      description: |
+        Explain why you need this feature and how it will be used.
+      placeholder: Context and use-cases...
+    validations:
+      required: true

--- a/README.md
+++ b/README.md
@@ -280,6 +280,11 @@ Use ? for help and <tab> for command completion.
 grout#
 ```
 
+## Contact
+
+* Mailing list: grout@dpdk.org ([archives](http://mails.dpdk.org/archives/grout/))
+* Slack channel: [#grout @ dpdkproject.slack.com](https://dpdkproject.slack.com/archives/C07NAFWE1MG)
+
 ## Contributing
 
 Anyone can contribute to `grout`. See [`CONTRIBUTING.md`](/CONTRIBUTING.md).


### PR DESCRIPTION
Add two templates for new issues: bug report and feature request.

Make it explicit that questions should be sent either to the mailing list or to the slack channel.

Add references to the mailing list and slack channel to the README.