### PR TITLE
ci: fix rebase error when source branch is not up to date with target

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,11 +40,12 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0 # force fetch all history
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - run: git config --global --add safe.directory $PWD
-      - run: git rebase -x "git --no-pager log --oneline -1 && make all unit-tests && sudo smoke/run.sh build" "${{ github.event.pull_request.base.sha }}"
-        if: ${{ github.event.pull_request.base.sha }}
+      - run: git rebase -x "git --no-pager log --oneline -1 && make all unit-tests && sudo smoke/run.sh build" "HEAD~${{ github.event.pull_request.commits }}"
+        if: ${{ github.event.pull_request.commits }}
       - run: make all unit-tests && sudo smoke/run.sh build
-        if: ${{ ! github.event.pull_request.base.sha }}
+        if: ${{ ! github.event.pull_request.commits }}
 
   build-cross-aarch64:
     runs-on: ubuntu-24.04
@@ -67,11 +68,12 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0 # force fetch all history
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - run: git config --global --add safe.directory $PWD
-      - run: git rebase -x "git --no-pager log --oneline -1 && make" "${{ github.event.pull_request.base.sha }}"
-        if: ${{ github.event.pull_request.base.sha }}
+      - run: git rebase -x "git --no-pager log --oneline -1 && make" "HEAD~${{ github.event.pull_request.commits }}"
+        if: ${{ github.event.pull_request.commits }}
       - run: make
-        if: ${{ ! github.event.pull_request.base.sha }}
+        if: ${{ ! github.event.pull_request.commits }}
 
   lint:
     runs-on: ubuntu-24.04
@@ -82,23 +84,25 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0 # force fetch all history
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - run: git config --global --add safe.directory $PWD
-      - run: git rebase -x "git --no-pager log --oneline -1 && make lint" "${{ github.event.pull_request.base.sha }}"
-        if: ${{ github.event.pull_request.base.sha }}
+      - run: git rebase -x "git --no-pager log --oneline -1 && make lint" "HEAD~${{ github.event.pull_request.commits }}"
+        if: ${{ github.event.pull_request.commits }}
       - run: make lint
-        if: ${{ ! github.event.pull_request.base.sha }}
+        if: ${{ ! github.event.pull_request.commits }}
 
   commits:
     runs-on: ubuntu-24.04
-    if: ${{ github.event.pull_request.base.sha && github.event.pull_request.head.sha }}
+    if: ${{ github.event.pull_request.commits }}
     container: fedora:latest
     env:
-      REVISION_RANGE: "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+      REVISION_RANGE: "HEAD~${{ github.event.pull_request.commits }}.."
     steps:
       - run: dnf install -y make git jq curl codespell
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0 # force fetch all history
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - run: git config --global --add safe.directory $PWD
       - run: make check-patches


### PR DESCRIPTION
When the source branch of a pull request (e.g. rjarry/grout:foobar) is not up to date with the target branch (e.g. DPDK/grout:main), the rebase command does nonsense.

```
~# git rebase -x "git --no-pager log --oneline -1 && make lint" \
	"46b14b01748c7a8ea31bce76e3e100f0432ff20f"
Rebasing (1/14)
Committer identity unknown
...
fatal: unable to auto-detect email address (got 'root@a6b854a16cce.(none)')
```

In that case 46b14b01748c7a8ea31bce76e3e100f0432ff20f is a merge commit id (e.g. `refs/pulls/$num/merge`) generated automatically by GitHub when the pull request source branch has diverged from the target main branch.

Unfortunately, `actions/checkout` does use `${{ github.ref }}` to determine the checked out revision. Depending on the context in which the jobs are executed, `${{ github.ref }}` is set to either `refs/heads/main`, `refs/pulls/$num/head` or `refs/pulls/$num/merge`. Explicitly set the checked out revision to either `refs/heads/main` or `refs/pulls/$num/head` regardless of the status of the source branch.

Fix all revisions used to check every commit of a pull request to use the number of commits in the pull request instead of using the base revision.

Fixes: 0679e3518a15 ("ci: check build lint and tests on every commit")