### PR TITLE
sdk: add missing header

### DIFF
--- a/modules/infra/api/meson.build
+++ b/modules/infra/api/meson.build
@@ -9,5 +9,8 @@ src += files(
   'trace.c',
 )
 
-api_headers += files('gr_infra.h')
+api_headers += files(
+  'gr_infra.h',
+  'gr_nexthop.h',
+)
 api_inc += include_directories('.')


### PR DESCRIPTION
"gr_nexthop.h" is missing, preventing the proper build of management applications.

Fixes: fa0019c ("nexthop: factorize api objects between v4 and v6")