### PR TITLE
smoke: prevent any address to name resolution

### DIFF
--- a/smoke/ip6_forward_test.sh
+++ b/smoke/ip6_forward_test.sh
@@ -30,15 +30,15 @@ done
 
 sleep 3  # wait for DAD
 
-ip netns exec $p1 ping6 -i0.01 -c3 fe80::d2f0:cff:feba:a411
-ip netns exec $p2 ping6 -i0.01 -c3 fe80::d2f0:cff:feba:a412
-ip netns exec $p1 ping6 -i0.01 -c3 fd00:f00:2::2
-ip netns exec $p2 ping6 -i0.01 -c3 fd00:f00:1::2
-ip netns exec $p1 ping6 -i0.01 -c3 fd00:ba4:2::2
-ip netns exec $p2 ping6 -i0.01 -c3 fd00:ba4:1::2
-ip netns exec $p1 ping6 -i0.01 -c3 fd00:ba4:1::1
-ip netns exec $p2 ping6 -i0.01 -c3 fd00:ba4:2::1
-ip netns exec $p1 traceroute -N1 fd00:ba4:2::2
-ip netns exec $p2 traceroute -N1 fd00:ba4:1::2
-ip netns exec $p1 traceroute -N1 fd00:f00:2::2
-ip netns exec $p2 traceroute -N1 fd00:f00:1::2
+ip netns exec $p1 ping6 -i0.01 -c3 -n fe80::d2f0:cff:feba:a411
+ip netns exec $p2 ping6 -i0.01 -c3 -n fe80::d2f0:cff:feba:a412
+ip netns exec $p1 ping6 -i0.01 -c3 -n fd00:f00:2::2
+ip netns exec $p2 ping6 -i0.01 -c3 -n fd00:f00:1::2
+ip netns exec $p1 ping6 -i0.01 -c3 -n fd00:ba4:2::2
+ip netns exec $p2 ping6 -i0.01 -c3 -n fd00:ba4:1::2
+ip netns exec $p1 ping6 -i0.01 -c3 -n fd00:ba4:1::1
+ip netns exec $p2 ping6 -i0.01 -c3 -n fd00:ba4:2::1
+ip netns exec $p1 traceroute -N1 -n fd00:ba4:2::2
+ip netns exec $p2 traceroute -N1 -n fd00:ba4:1::2
+ip netns exec $p1 traceroute -N1 -n fd00:f00:2::2
+ip netns exec $p2 traceroute -N1 -n fd00:f00:1::2

--- a/smoke/ip6_rs_ra_test.sh
+++ b/smoke/ip6_rs_ra_test.sh
@@ -22,4 +22,4 @@ done
 
 sleep 3  # wait for DAD
 
-ip netns exec $p1 rdisc6 $p1
+ip netns exec $p1 rdisc6 -n $p1

--- a/smoke/ip6_same_peer_test.sh
+++ b/smoke/ip6_same_peer_test.sh
@@ -28,12 +28,12 @@ done
 
 sleep 3  # wait for DAD
 
-ip netns exec $p1 ping6 -i0.01 -c3 fe80::d2f0:cff:feba:a411
-ip netns exec $p2 ping6 -i0.01 -c3 fe80::d2f0:cff:feba:a412
-ip netns exec $p1 ping6 -i0.01 -c3 fe80::d2f0:cff:feba:a412 && fail "Unexpected answer from foreign link local address"
-ip netns exec $p1 ping6 -i0.01 -c3 fd00:ba4:2::2
-ip netns exec $p2 ping6 -i0.01 -c3 fd00:ba4:1::2
-ip netns exec $p1 ping6 -i0.01 -c3 fd00:ba4:1::1
-ip netns exec $p2 ping6 -i0.01 -c3 fd00:ba4:2::1
-ip netns exec $p1 traceroute -N1 fd00:ba4:2::2
-ip netns exec $p2 traceroute -N1 fd00:ba4:1::2
+ip netns exec $p1 ping6 -i0.01 -c3 -n fe80::d2f0:cff:feba:a411
+ip netns exec $p2 ping6 -i0.01 -c3 -n fe80::d2f0:cff:feba:a412
+ip netns exec $p1 ping6 -i0.01 -c3 -n fe80::d2f0:cff:feba:a412 && fail "Unexpected answer from foreign link local address"
+ip netns exec $p1 ping6 -i0.01 -c3 -n fd00:ba4:2::2
+ip netns exec $p2 ping6 -i0.01 -c3 -n fd00:ba4:1::2
+ip netns exec $p1 ping6 -i0.01 -c3 -n fd00:ba4:1::1
+ip netns exec $p2 ping6 -i0.01 -c3 -n fd00:ba4:2::1
+ip netns exec $p1 traceroute -N1 -n fd00:ba4:2::2
+ip netns exec $p2 traceroute -N1 -n fd00:ba4:1::2

--- a/smoke/ip_forward_test.sh
+++ b/smoke/ip_forward_test.sh
@@ -29,13 +29,13 @@ for n in 0 1; do
 	ip -n $p addr show
 done
 
-ip netns exec $p0 ping -i0.01 -c3 16.1.0.1
-ip netns exec $p1 ping -i0.01 -c3 16.0.0.1
-ip netns exec $p0 ping -i0.01 -c3 172.16.1.2
-ip netns exec $p1 ping -i0.01 -c3 172.16.0.2
-ip netns exec $p0 ping -i0.01 -c3 172.16.0.1
-ip netns exec $p1 ping -i0.01 -c3 172.16.1.1
-ip netns exec $p0 traceroute -N1 16.1.0.1
-ip netns exec $p1 traceroute -N1 16.0.0.1
-ip netns exec $p0 traceroute -N1 172.16.1.2
-ip netns exec $p1 traceroute -N1 172.16.0.2
+ip netns exec $p0 ping -i0.01 -c3 -n 16.1.0.1
+ip netns exec $p1 ping -i0.01 -c3 -n 16.0.0.1
+ip netns exec $p0 ping -i0.01 -c3 -n 172.16.1.2
+ip netns exec $p1 ping -i0.01 -c3 -n 172.16.0.2
+ip netns exec $p0 ping -i0.01 -c3 -n 172.16.0.1
+ip netns exec $p1 ping -i0.01 -c3 -n 172.16.1.1
+ip netns exec $p0 traceroute -N1 -n 16.1.0.1
+ip netns exec $p1 traceroute -N1 -n 16.0.0.1
+ip netns exec $p0 traceroute -N1 -n 172.16.1.2
+ip netns exec $p1 traceroute -N1 -n 172.16.0.2

--- a/smoke/ipip_encap_test.sh
+++ b/smoke/ipip_encap_test.sh
@@ -36,5 +36,5 @@ ip -n $p1 addr add 10.98.0.2/24 dev $iptun
 ip -n $p1 route add default via 10.98.0.1
 ip -n $p1 addr show
 
-ip netns exec $p0 ping -i0.01 -c3 10.98.0.2
-ip netns exec $p1 ping -i0.01 -c3 10.99.0.2
+ip netns exec $p0 ping -i0.01 -c3 -n 10.98.0.2
+ip netns exec $p1 ping -i0.01 -c3 -n 10.99.0.2

--- a/smoke/vlan_forward_test.sh
+++ b/smoke/vlan_forward_test.sh
@@ -31,5 +31,5 @@ for n in 0 1; do
 	ip -n $p addr show
 done
 
-ip netns exec $p0 ping -i0.01 -c3 172.16.1.2
-ip netns exec $p1 ping -i0.01 -c3 172.16.0.2
+ip netns exec $p0 ping -i0.01 -c3 -n 172.16.1.2
+ip netns exec $p1 ping -i0.01 -c3 -n 172.16.0.2

--- a/smoke/vrf_forward_test.sh
+++ b/smoke/vrf_forward_test.sh
@@ -29,7 +29,7 @@ for n in 0 1; do
 	ip -n $p route add default via 172.16.$((n % 2)).1
 	ip -n $p addr show
 done
-ip netns exec $p0 ping -i0.01 -c3 172.16.1.2
+ip netns exec $p0 ping -i0.01 -c3 -n 172.16.1.2
 
 for n in 2 3; do
 	p=$run_id$n
@@ -42,4 +42,4 @@ for n in 2 3; do
 	ip -n $p route add default via 172.16.$((n % 2)).1
 	ip -n $p addr show
 done
-ip netns exec $p2 ping -i0.01 -c3 172.16.1.2
+ip netns exec $p2 ping -i0.01 -c3 -n 172.16.1.2


### PR DESCRIPTION
We have tests that use publicly routable addresses (16.0.0.0/8). By default, ping and traceroute will try to resolve any IP address to a hostname via the configured name server method for getnameinfo(3).

We certainly don't want that to happen as these programs will at best give up after the default timeout, or at worse print a garbage host name.

Force numeric output only with the -n flag which is supported by all ping, traceroute and ndisc6.

This has the side benefit of making the smoke tests a lot faster:

	before:  ip_forward_test.sh ... OK (01m08s)
	after:   ip_forward_test.sh ... OK (00m06s)

Fixes: 75286b77c3df ("ip: ensure no nexthop is created with invalid iface id")