### PR TITLE
infra: fix bogus assert in nexthop_lookup

### DIFF
--- a/modules/infra/control/nexthop.c
+++ b/modules/infra/control/nexthop.c
@@ -154,7 +154,8 @@ static void nh_pool_iter_cb(struct rte_mempool *, void *priv, void *obj, unsigne
 	if (nh->ref_count != 0)
 		it->user_cb(nh, it->priv);
 	else
-		assert(rte_ipv6_addr_is_unspec(&nh->ipv6));
+		assert(rte_lcore_has_role(rte_lcore_id(), ROLE_NON_EAL)
+		       || rte_ipv6_addr_is_unspec(&nh->ipv6));
 }
 
 void nh_pool_iter(struct nh_pool *nhp, nh_iter_cb_t nh_cb, void *priv) {


### PR DESCRIPTION
nexthop_lookup uses nh_pool_iter() with nh_pool_iter_cb to walk through all nexthops that are referenced by a route. Nexthops are only created and modified by the control thread but nexthop_lookup can be called by data plane workers as well (e.g. when receiving ARP and NDP packets).

There can be a race condition where a nexthop was allocated by the control thread, the address field has been set but the nexthop is not yet referenced by a route when a data plane thread calls nexthop_lookup().

Adjust the assert condition to ignore the address field contents when called from a data path thread.

Fixes: 7d6a8d6296d2 ("ip: split rib and fib")