### PR TITLE
ip6: add source interface on ping6 command.

### DIFF
--- a/modules/ip6/api/gr_ip6.h
+++ b/modules/ip6/api/gr_ip6.h
@@ -174,6 +174,7 @@ struct gr_ip6_ra_show_resp {
 
 struct gr_ip6_icmp_send_req {
 	struct rte_ipv6_addr addr;
+	uint16_t iface;
 	uint16_t vrf;
 	uint16_t id;
 	uint16_t seq_num;

--- a/modules/ip6/control/icmp6.c
+++ b/modules/ip6/control/icmp6.c
@@ -94,8 +94,7 @@ static struct api_out icmp6_send(const void *request, void ** /* response */) {
 	const struct nexthop *nh;
 	int ret;
 
-	// XXX won't be able to ping linklocal addresses.
-	if ((nh = rib6_lookup(req->vrf, GR_IFACE_ID_UNDEF, &req->addr)) == NULL)
+	if ((nh = rib6_lookup(req->vrf, req->iface, &req->addr)) == NULL)
 		return api_out(errno, 0);
 
 	ret = icmp6_local_send(&req->addr, nh, req->id, req->seq_num, req->ttl);


### PR DESCRIPTION
Add a new optional parameter on ping6/traceroute6 api: source interface.

It allows correct route selection when ip6 destination address is link-local.

If ip6 destination address is not link-local, this new parameter will be ignored.