### PR TITLE
main: add flag to redirect to syslog

### DIFF
--- a/docs/grout.8.md
+++ b/docs/grout.8.md
@@ -18,6 +18,7 @@ Grout is a software router based on DPDK __rte_graph__.
 [**-L** _TYPE_:_LEVEL_]
 [**-M** _MODE_]
 [**-p**]
+[**-S**]
 [**-s** _PATH_]
 [**-t**]
 [**-T** _REGEXP_]
@@ -79,6 +80,10 @@ Default mode is _overwrite_ and parameter must be specified once only.
 #### **-p**, **--poll-mode**
 
 Disable automatic micro-sleep.
+
+#### **-S**, **--syslog**
+
+Redirect logs to syslog.
 
 #### **-s**, **--socket** _PATH_
 

--- a/main/dpdk.c
+++ b/main/dpdk.c
@@ -23,11 +23,10 @@
 
 int gr_rte_log_type;
 static FILE *log_stream;
-static bool log_syslog;
 
 static ssize_t log_write(void * /*cookie*/, const char *buf, size_t size) {
 	ssize_t n;
-	if (log_syslog) {
+	if (gr_args()->log_syslog) {
 		// Syslog error levels are from 0 to 7, so subtract 1 to convert.
 		syslog(rte_log_cur_msg_loglevel() - 1, "%.*s", (int)size, buf);
 		n = size;
@@ -70,11 +69,8 @@ static ssize_t log_write(void * /*cookie*/, const char *buf, size_t size) {
 int dpdk_log_init(const struct gr_args *args) {
 	cookie_io_functions_t log_functions = {.write = log_write};
 
-	if (getenv("INVOCATION_ID")) {
-		// executed by systemd
-		log_syslog = true;
+	if (args->log_syslog)
 		openlog("grout", LOG_PID | LOG_ODELAY, LOG_DAEMON);
-	}
 
 	gr_rte_log_type = rte_log_register_type_and_pick_level("grout", RTE_LOG_NOTICE);
 	if (gr_rte_log_type < 0)

--- a/main/gr.h
+++ b/main/gr.h
@@ -11,6 +11,7 @@ struct gr_args {
 	unsigned log_level;
 	bool test_mode;
 	bool poll_mode;
+	bool log_syslog;
 	char **eal_extra_args;
 };
 

--- a/main/grout.default
+++ b/main/grout.default
@@ -3,4 +3,4 @@
 # vim: ft=sh
 
 # Add grout command line flags here and restart grout.service.
-GROUT_OPTS=''
+GROUT_OPTS='--syslog'

--- a/main/main.c
+++ b/main/main.c
@@ -39,6 +39,7 @@ static void usage(const char *prog) {
 	puts("  -h, --help                     Display this help message and exit.");
 	puts("  -L, --log-level <type>:<lvl>   Specify log level for a specific component.");
 	puts("  -p, --poll-mode                Disable automatic micro-sleep.");
+	puts("  -S, --syslog                   Redirect logs to syslog.");
 	puts("  -s, --socket <path>            Path the control plane API socket.");
 	puts("                                 Default: GROUT_SOCK_PATH from env or");
 	printf("                                 %s).\n", GR_DEFAULT_SOCK_PATH);
@@ -61,11 +62,12 @@ const struct gr_args *gr_args(void) {
 static int parse_args(int argc, char **argv) {
 	int c;
 
-#define FLAGS ":B:D:L:M:T:Vhps:tvx"
+#define FLAGS ":B:D:L:M:T:VhpSs:tvx"
 	static struct option long_options[] = {
 		{"help", no_argument, NULL, 'h'},
 		{"log-level", required_argument, NULL, 'L'},
 		{"poll-mode", no_argument, NULL, 'p'},
+		{"syslog", no_argument, NULL, 'S'},
 		{"socket", required_argument, NULL, 's'},
 		{"test-mode", no_argument, NULL, 't'},
 		{"trace", required_argument, NULL, 'T'},
@@ -97,6 +99,9 @@ static int parse_args(int argc, char **argv) {
 			break;
 		case 'p':
 			args.poll_mode = true;
+			break;
+		case 'S':
+			args.log_syslog = true;
 			break;
 		case 's':
 			args.api_sock_path = optarg;


### PR DESCRIPTION
Relying on environment variables to determine whether logs should be redirected to syslog/journald is unreliable.

For example, desktop environments may be started as systemd transient services with systemd-cat and INVOCATION_ID may be present in the environment variables without the user/developer having any control over it.

Instead of trying to guess in which context grout is executed, add a new --syslog flag that will explicitly redirect logs to syslog.