### PR TITLE
Replace defines with enums

### DIFF
--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -14,20 +14,27 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-// Value for gr_iface.type
-#define GR_IFACE_TYPE_UNDEF 0x00
-#define GR_IFACE_TYPE_PORT 0x01
-#define GR_IFACE_TYPE_VLAN 0x02
-#define GR_IFACE_TYPE_LOOPBACK 0xFF
-#define GR_IFACE_TYPE_MAX 256
+typedef enum {
+	GR_IFACE_TYPE_UNDEF = 0x00,
+	GR_IFACE_TYPE_PORT = 0x01,
+	GR_IFACE_TYPE_VLAN = 0x02,
+	GR_IFACE_TYPE_IPIP = 0x03,
+	GR_IFACE_TYPE_LOOPBACK = 0xff,
+	GR_IFACE_TYPE_MAX = 256
+} __attribute__((mode(HI))) gr_iface_type_t;
 
 // Interface configure flags
-#define GR_IFACE_F_UP GR_BIT16(0)
-#define GR_IFACE_F_PROMISC GR_BIT16(1)
-#define GR_IFACE_F_ALLMULTI GR_BIT16(2)
-#define GR_IFACE_F_PACKET_TRACE GR_BIT16(3)
+typedef enum {
+	GR_IFACE_F_UP = GR_BIT16(0),
+	GR_IFACE_F_PROMISC = GR_BIT16(1),
+	GR_IFACE_F_ALLMULTI = GR_BIT16(2),
+	GR_IFACE_F_PACKET_TRACE = GR_BIT16(3),
+} __attribute__((mode(HI))) gr_iface_flags_t;
+
 // Interface state flags
-#define GR_IFACE_S_RUNNING GR_BIT16(0)
+typedef enum {
+	GR_IFACE_S_RUNNING = GR_BIT16(0),
+} __attribute__((mode(HI))) gr_iface_state_t;
 
 // Interface reconfig attributes
 #define GR_IFACE_SET_FLAGS GR_BIT64(0)
@@ -42,9 +49,9 @@
 // Generic struct for all network interfaces.
 struct gr_iface {
 	uint16_t id; // Interface unique index.
-	uint16_t type; // Interface type. Uses values from GR_IFACE_TYPE_*.
-	uint16_t flags; // Interface flags. Bit mask of GR_IFACE_F_*.
-	uint16_t state; // Interface state. Bit mask of GR_IFACE_S_*.
+	gr_iface_type_t type; // Interface type. Uses values from GR_IFACE_TYPE_*.
+	gr_iface_flags_t flags; // Interface flags. Bit mask of GR_IFACE_F_*.
+	gr_iface_state_t state; // Interface state. Bit mask of GR_IFACE_S_*.
 	uint16_t mtu; // Maximum transmission unit size (incl. headers).
 	uint16_t vrf_id; // L3 addressing and routing domain
 #define GR_IFACE_NAME_SIZE 64
@@ -136,7 +143,7 @@ struct gr_infra_iface_get_resp {
 #define GR_INFRA_IFACE_LIST REQUEST_TYPE(GR_INFRA_MODULE, 0x0004)
 
 struct gr_infra_iface_list_req {
-	uint16_t type; // use GR_IFACE_TYPE_UNDEF for all
+	gr_iface_type_t type; // use GR_IFACE_TYPE_UNDEF for all
 };
 
 struct gr_infra_iface_list_resp {

--- a/modules/infra/api/gr_nexthop.h
+++ b/modules/infra/api/gr_nexthop.h
@@ -11,17 +11,17 @@
 #include <gr_net_types.h>
 
 // Supported flags on a nexthop.
-#define GR_NH_F_PENDING GR_BIT16(0) // Probe sent
-#define GR_NH_F_REACHABLE GR_BIT16(1) // Probe reply received
-#define GR_NH_F_STALE GR_BIT16(2) // Reachable lifetime expired, need refresh
-#define GR_NH_F_FAILED GR_BIT16(3) // All probes sent without reply
-#define GR_NH_F_STATIC GR_BIT16(4) // Configured by user
-#define GR_NH_F_LOCAL GR_BIT16(5) // Local address
-#define GR_NH_F_GATEWAY GR_BIT16(6) // Gateway route
-#define GR_NH_F_LINK GR_BIT16(7) // Connected link route
-#define GR_NH_F_MCAST GR_BIT16(8) // Multicast address
-
-typedef uint16_t gr_nh_flags_t;
+typedef enum {
+	GR_NH_F_PENDING = GR_BIT16(0), // Probe sent
+	GR_NH_F_REACHABLE = GR_BIT16(1), // Probe reply received
+	GR_NH_F_STALE = GR_BIT16(2), // Reachable lifetime expired, need refresh
+	GR_NH_F_FAILED = GR_BIT16(3), // All probes sent without reply
+	GR_NH_F_STATIC = GR_BIT16(4), // Configured by user
+	GR_NH_F_LOCAL = GR_BIT16(5), // Local address
+	GR_NH_F_GATEWAY = GR_BIT16(6), // Gateway route
+	GR_NH_F_LINK = GR_BIT16(7), // Connected link route
+	GR_NH_F_MCAST = GR_BIT16(8), // Multicast address
+} __attribute__((mode(HI))) gr_nh_flags_t;
 
 //! Nexthop structure exposed to the API.
 struct gr_nexthop {

--- a/modules/infra/cli/gr_cli_iface.h
+++ b/modules/infra/cli/gr_cli_iface.h
@@ -13,7 +13,7 @@
 
 struct cli_iface_type {
 	STAILQ_ENTRY(cli_iface_type) next;
-	uint16_t type_id;
+	gr_iface_type_t type_id;
 	const char *name;
 	void (*show)(const struct gr_api_client *c, const struct gr_iface *);
 	void (*list_info)(const struct gr_api_client *c, const struct gr_iface *, char *, size_t);
@@ -22,7 +22,7 @@ struct cli_iface_type {
 void register_iface_type(struct cli_iface_type *);
 
 const struct cli_iface_type *type_from_name(const char *name);
-const struct cli_iface_type *type_from_id(uint16_t type_id);
+const struct cli_iface_type *type_from_id(gr_iface_type_t type_id);
 int iface_from_name(const struct gr_api_client *c, const char *name, struct gr_iface *iface);
 int iface_from_id(const struct gr_api_client *c, uint16_t ifid, struct gr_iface *iface);
 

--- a/modules/infra/cli/iface.c
+++ b/modules/infra/cli/iface.c
@@ -54,7 +54,7 @@ int complete_iface_types(
 	}
 	return 0;
 }
-const struct cli_iface_type *type_from_id(uint16_t type_id) {
+const struct cli_iface_type *type_from_id(gr_iface_type_t type_id) {
 	const struct cli_iface_type *type;
 
 	STAILQ_FOREACH (type, &types, next) {

--- a/modules/infra/control/gr_iface.h
+++ b/modules/infra/control/gr_iface.h
@@ -15,9 +15,9 @@
 
 struct __rte_cache_aligned iface {
 	uint16_t id;
-	uint16_t type_id;
-	uint16_t flags;
-	uint16_t state;
+	gr_iface_type_t type_id;
+	gr_iface_flags_t flags;
+	gr_iface_state_t state;
 	uint16_t mtu;
 	uint16_t vrf_id; // L3 addressing and routing domain
 	const struct iface **subinterfaces;
@@ -31,7 +31,7 @@ typedef int (*iface_init_t)(struct iface *, const void *api_info);
 typedef int (*iface_reconfig_t)(
 	struct iface *,
 	uint64_t set_attrs,
-	uint16_t flags,
+	gr_iface_flags_t flags,
 	uint16_t mtu,
 	uint16_t vrf_id,
 	const void *api_info
@@ -56,10 +56,10 @@ struct iface_type {
 };
 
 void iface_type_register(struct iface_type *);
-struct iface_type *iface_type_get(uint16_t type_id);
+struct iface_type *iface_type_get(gr_iface_type_t type_id);
 struct iface *iface_create(
-	uint16_t type_id,
-	uint16_t flags,
+	gr_iface_type_t type_id,
+	gr_iface_flags_t flags,
 	uint16_t mtu,
 	uint16_t vrf_id,
 	const char *name,
@@ -68,7 +68,7 @@ struct iface *iface_create(
 int iface_reconfig(
 	uint16_t ifid,
 	uint64_t set_attrs,
-	uint16_t flags,
+	gr_iface_flags_t flags,
 	uint16_t mtu,
 	uint16_t vrf_id,
 	const char *name,
@@ -81,8 +81,8 @@ void iface_del_subinterface(struct iface *parent, const struct iface *sub);
 int iface_get_eth_addr(uint16_t ifid, struct rte_ether_addr *);
 int iface_add_eth_addr(uint16_t ifid, const struct rte_ether_addr *);
 int iface_del_eth_addr(uint16_t ifid, const struct rte_ether_addr *);
-uint16_t ifaces_count(uint16_t type_id);
-struct iface *iface_next(uint16_t type_id, const struct iface *prev);
+uint16_t ifaces_count(gr_iface_type_t type_id);
+struct iface *iface_next(gr_iface_type_t type_id, const struct iface *prev);
 
 struct iface *get_vrf_iface(uint16_t vrf_id);
 struct iface *iface_loopback_create(uint16_t vrf_id);

--- a/modules/infra/control/gr_port.h
+++ b/modules/infra/control/gr_port.h
@@ -47,7 +47,7 @@ uint32_t port_get_rxq_buffer_us(uint16_t port_id, uint16_t rxq_id);
 int iface_port_reconfig(
 	struct iface *iface,
 	uint64_t set_attrs,
-	uint16_t flags,
+	gr_iface_flags_t flags,
 	uint16_t mtu,
 	uint16_t vrf_id,
 	const void *api_info

--- a/modules/infra/control/iface.c
+++ b/modules/infra/control/iface.c
@@ -19,7 +19,7 @@
 
 static STAILQ_HEAD(, iface_type) types = STAILQ_HEAD_INITIALIZER(types);
 
-struct iface_type *iface_type_get(uint16_t type_id) {
+struct iface_type *iface_type_get(gr_iface_type_t type_id) {
 	struct iface_type *t;
 	STAILQ_FOREACH (t, &types, next)
 		if (t->id == type_id)
@@ -52,8 +52,8 @@ static int next_ifid(uint16_t *ifid) {
 }
 
 struct iface *iface_create(
-	uint16_t type_id,
-	uint16_t flags,
+	gr_iface_type_t type_id,
+	gr_iface_flags_t flags,
 	uint16_t mtu,
 	uint16_t vrf_id,
 	const char *name,
@@ -111,7 +111,7 @@ fail:
 int iface_reconfig(
 	uint16_t ifid,
 	uint64_t set_attrs,
-	uint16_t flags,
+	gr_iface_flags_t flags,
 	uint16_t mtu,
 	uint16_t vrf_id,
 	const char *name,
@@ -145,7 +145,7 @@ int iface_reconfig(
 	return type->reconfig(iface, set_attrs, flags, mtu, vrf_id, api_info);
 }
 
-uint16_t ifaces_count(uint16_t type_id) {
+uint16_t ifaces_count(gr_iface_type_t type_id) {
 	uint16_t count = 0;
 
 	for (uint16_t ifid = IFACE_ID_FIRST; ifid < MAX_IFACES; ifid++) {
@@ -157,7 +157,7 @@ uint16_t ifaces_count(uint16_t type_id) {
 	return count;
 }
 
-struct iface *iface_next(uint16_t type_id, const struct iface *prev) {
+struct iface *iface_next(gr_iface_type_t type_id, const struct iface *prev) {
 	uint16_t start_id;
 
 	if (prev == NULL)

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -208,7 +208,7 @@ static int port_configure(struct iface_info_port *p) {
 int iface_port_reconfig(
 	struct iface *iface,
 	uint64_t set_attrs,
-	uint16_t flags,
+	gr_iface_flags_t flags,
 	uint16_t mtu,
 	uint16_t vrf_id,
 	const void *api_info

--- a/modules/infra/control/vlan.c
+++ b/modules/infra/control/vlan.c
@@ -50,7 +50,7 @@ static int get_parent_port_id(uint16_t parent_id, uint16_t *port_id) {
 static int iface_vlan_reconfig(
 	struct iface *iface,
 	uint64_t set_attrs,
-	uint16_t flags,
+	gr_iface_flags_t flags,
 	uint16_t mtu,
 	uint16_t vrf_id,
 	const void *api_info

--- a/modules/infra/control/worker_test.c
+++ b/modules/infra/control/worker_test.c
@@ -43,7 +43,7 @@ struct iface *iface_from_id(uint16_t ifid) {
 	return ifid < ARRAY_DIM(ifaces) ? ifaces[ifid] : NULL;
 }
 
-struct iface *iface_next(uint16_t /*type_id*/, const struct iface *prev) {
+struct iface *iface_next(gr_iface_type_t /*type_id*/, const struct iface *prev) {
 	uint16_t ifid;
 	if (prev == NULL)
 		ifid = 0;

--- a/modules/infra/datapath/gr_icmp6.h
+++ b/modules/infra/datapath/gr_icmp6.h
@@ -29,7 +29,7 @@ typedef enum {
 	ICMP6_TYPE_NEIGH_ADVERT = UINT8_C(136),
 
 	_ICMP6_TYPE_MAX = UINT8_C(0xff),
-} __rte_packed icmp6_type_t;
+} __attribute__((mode(QI))) icmp6_type_t;
 
 #define GR_ICMP6_HDR_LEN 8
 
@@ -118,7 +118,7 @@ typedef enum {
 	ICMP6_OPT_REDIRECT = UINT8_C(4),
 	ICMP6_OPT_MTU = UINT8_C(5),
 	_ICMP6_OPT_MAX = UINT8_C(0xff),
-} __rte_packed icmp6_opt_t;
+} __attribute__((mode(QI))) icmp6_opt_t;
 
 struct icmp6_opt {
 	icmp6_opt_t type;

--- a/modules/ip/datapath/gr_ip4_datapath.h
+++ b/modules/ip/datapath/gr_ip4_datapath.h
@@ -30,7 +30,7 @@ GR_MBUF_PRIV_DATA_TYPE(ip_local_mbuf_data, {
 });
 
 void ip_input_local_add_proto(uint8_t proto, const char *next_node);
-void ip_output_register_interface(uint16_t iface_type_id, const char *next_node);
+void ip_output_register_interface(gr_iface_type_t iface_type_id, const char *next_node);
 int arp_output_request_solicit(struct nexthop *nh);
 void arp_update_nexthop(struct rte_graph *, struct rte_node *, struct nexthop *, const struct iface *, const struct rte_ether_addr *);
 

--- a/modules/ip/datapath/ip_output.c
+++ b/modules/ip/datapath/ip_output.c
@@ -30,7 +30,7 @@ enum {
 
 static rte_edge_t edges[GR_IFACE_TYPE_MAX] = {ETH_OUTPUT};
 
-void ip_output_register_interface(uint16_t iface_type_id, const char *next_node) {
+void ip_output_register_interface(gr_iface_type_t iface_type_id, const char *next_node) {
 	LOG(DEBUG, "ip_output: iface_type=%u -> %s", iface_type_id, next_node);
 	if (iface_type_id == GR_IFACE_TYPE_UNDEF || iface_type_id >= ARRAY_DIM(edges))
 		ABORT("invalid iface type=%u", iface_type_id);

--- a/modules/ip6/datapath/gr_ip6_datapath.h
+++ b/modules/ip6/datapath/gr_ip6_datapath.h
@@ -35,7 +35,7 @@ GR_MBUF_PRIV_DATA_TYPE(ndp_na_output_mbuf_data, {
 });
 
 void ip6_input_local_add_proto(uint8_t proto, const char *next_node);
-void ip6_output_register_interface(uint16_t iface_type_id, const char *next_node);
+void ip6_output_register_interface(gr_iface_type_t iface_type_id, const char *next_node);
 int nh6_solicit(struct nexthop *nh);
 
 #define IP6_DEFAULT_HOP_LIMIT 255

--- a/modules/ip6/datapath/ip6_output.c
+++ b/modules/ip6/datapath/ip6_output.c
@@ -27,7 +27,7 @@ enum {
 
 static rte_edge_t edges[GR_IFACE_TYPE_MAX] = {ETH_OUTPUT};
 
-void ip6_output_register_interface(uint16_t iface_type_id, const char *next_node) {
+void ip6_output_register_interface(gr_iface_type_t iface_type_id, const char *next_node) {
 	LOG(DEBUG, "ip6_output: iface_type=%u -> %s", iface_type_id, next_node);
 	if (iface_type_id == GR_IFACE_TYPE_UNDEF || iface_type_id >= ARRAY_DIM(edges))
 		ABORT("invalid iface type=%u", iface_type_id);

--- a/modules/ipip/control.c
+++ b/modules/ipip/control.c
@@ -47,7 +47,7 @@ struct iface *ipip_get_iface(ip4_addr_t local, ip4_addr_t remote, uint16_t vrf_i
 static int iface_ipip_reconfig(
 	struct iface *iface,
 	uint64_t set_attrs,
-	uint16_t flags,
+	gr_iface_flags_t flags,
 	uint16_t mtu,
 	uint16_t vrf_id,
 	const void *api_info

--- a/modules/ipip/gr_ipip.h
+++ b/modules/ipip/gr_ipip.h
@@ -10,8 +10,6 @@
 #include <gr_macro.h>
 #include <gr_net_types.h>
 
-#define GR_IFACE_TYPE_IPIP 0x03
-
 // IPIP reconfig attributes
 #define GR_IPIP_SET_LOCAL GR_BIT64(32)
 #define GR_IPIP_SET_REMOTE GR_BIT64(33)


### PR DESCRIPTION
Make our lives a bit easier when debugging, switching from opaque flags value to an explicit enum.

Instead of 
```
(gdb) p nh->flags
$7 = 178
```
We have now:
```
(gdb) p nh->flags
$7 = (GR_NH_F_REACHABLE | GR_NH_F_STATIC | GR_NH_F_LOCAL | GR_NH_F_LINK)
```