### PR TITLE
ip/ip6: fix ip(6) address deletion

### DIFF
--- a/modules/ip/control/address.c
+++ b/modules/ip/control/address.c
@@ -123,7 +123,7 @@ static struct api_out addr_del(const void *request, void ** /*response*/) {
 		return api_out(ENOENT, 0);
 	}
 
-	if ((nh->flags & (GR_NH_F_LOCAL | GR_NH_F_LINK)) || nh->ref_count > 1)
+	if (nh->ref_count > 1)
 		return api_out(EBUSY, 0);
 
 	rib4_cleanup(nh);

--- a/modules/ip6/control/address.c
+++ b/modules/ip6/control/address.c
@@ -217,7 +217,7 @@ static struct api_out addr6_del(const void *request, void ** /*response*/) {
 		return api_out(ENOENT, 0);
 	}
 
-	if ((nh->flags & (GR_NH_F_LOCAL | GR_NH_F_LINK)) || nh->ref_count > 1)
+	if (nh->ref_count > 1)
 		return api_out(EBUSY, 0);
 
 	rib6_cleanup(nh);

--- a/smoke/ip6_add_del_test.sh
+++ b/smoke/ip6_add_del_test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Christophe Fontaine
+
+. $(dirname $0)/_init.sh
+
+p0=${run_id}0
+
+grcli add interface port $p0 devargs net_tap0,iface=$p0 mac f0:0d:ac:dc:00:00
+
+grcli add ip6 address 2001::1/64 iface $p0
+grcli show ip6 address
+grcli del ip6 address 2001::1/64 iface $p0
+grcli show ip6 address

--- a/smoke/ip_add_del_test.sh
+++ b/smoke/ip_add_del_test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Christophe Fontaine
+
+. $(dirname $0)/_init.sh
+
+p0=${run_id}0
+
+grcli add interface port $p0 devargs net_tap0,iface=$p0 mac f0:0d:ac:dc:00:00
+
+grcli add ip address 172.16.0.1/24 iface $p0
+grcli show ip address
+grcli del ip address 172.16.0.1/24 iface $p0
+grcli show ip address


### PR DESCRIPTION
ip and ip6 address deletion never worked, and returned EBUSY.
Only check that the nexthop isn't referenced by another entity instead of checking the flags.