### PR TITLE
ip6_local: fix extension header parsing

### DIFF
--- a/modules/ip6/datapath/ip6_local.c
+++ b/modules/ip6/datapath/ip6_local.c
@@ -59,10 +59,10 @@ static uint16_t ip6_input_local_process(
 		while (true) {
 			size_t ext_size = 0;
 			const uint8_t *ext;
+			uint8_t _ext[2];
 			int next_proto;
-			uint8_t _ext[4];
 
-			ext = rte_pktmbuf_read(m, l3_hdr_size, sizeof(&_ext), &_ext);
+			ext = rte_pktmbuf_read(m, l3_hdr_size, sizeof(_ext), _ext);
 			if (ext == NULL)
 				break;
 			next_proto = rte_ipv6_get_next_ext(ext, d->proto, &ext_size);


### PR DESCRIPTION
rte_pktmbuf_read() needs a buffer length and a pointer to the buffer. _ext is an array of uint8_t of size 4. sizeof(&_ext) returns the size of a pointer (8 bytes). This means that rte_pktmbuf_read() will potentially overflow on the stack if the packet is not contiguous.

Fix the call to rte_pktmbuf_read() by passing sizeof(_ext) and _ext without prefixing them with &.

Also, rte_ipv6_get_next_ext only reads 2 bytes at most from the ext parameter. Change the size of _ext to be a 2 bytes array.

If reading from the mbuf fails, stop processing immediately and drop the packet with an explicit ip6_input_local_error stat.

Fixes: 520047d56e4c ("ip6: fix IPv6 extension header parsing")