### PR TITLE
infra: simplify show interface cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ del                  Delete objects from the configuration.
 show                 Display information about the configuration.
 clear                Clear counters or temporary entries.
 set                  Modify existing objects in the configuration.
-grout# show interface all
+grout# show interface
 NAME  ID  FLAGS       VRF  TYPE  INFO
 p0    1   up running  0    port  devargs=0000:8a:00.0 mac=30:3e:a7:0b:eb:c0
 p1    2   up running  0    port  devargs=0000:8a:00.1 mac=30:3e:a7:0b:eb:c1

--- a/modules/infra/cli/iface.c
+++ b/modules/infra/cli/iface.c
@@ -317,7 +317,7 @@ static cmd_status_t iface_show(const struct gr_api_client *c, const struct ec_pn
 	const struct cli_iface_type *type;
 	struct gr_iface iface;
 
-	if (arg_str(p, "all") != NULL || arg_str(p, "TYPE") != NULL)
+	if (arg_str(p, "NAME") == NULL || arg_str(p, "TYPE") != NULL)
 		return iface_list(c, p);
 
 	if (iface_from_name(c, arg_str(p, "NAME"), &iface) < 0)
@@ -371,10 +371,9 @@ static int ctx_init(struct ec_node *root) {
 		return ret;
 	ret = CLI_COMMAND(
 		CLI_CONTEXT(root, CTX_SHOW, CTX_ARG("interface", "Display interface details.")),
-		"all|(name NAME)|(type TYPE)",
+		"[(name NAME)|(type TYPE)]",
 		iface_show,
 		"Show interface details.",
-		with_help("Show all interfaces.", ec_node_str("all", "all")),
 		with_help(
 			"Show only this interface.",
 			ec_node_dyn("NAME", complete_iface_names, INT2PTR(GR_IFACE_TYPE_UNDEF))

--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -14,13 +14,13 @@ cleanup() {
 	sh -x $tmp/cleanup
 
 	# delete all non-port interfaces first
-	grcli show interface all |
+	grcli show interface |
 	grep -Ev -e ^NAME -e '\<port[[:space:]]+devargs=' -e '\<loopback\>' |
 	while read -r name _; do
 		grcli del interface "$name"
 	done
 	# then delete all ports
-	grcli show interface all |
+	grcli show interface |
 	grep -ve ^NAME -e '\<loopback\>' |
 	while read -r name _; do
 		grcli del interface "$name"
@@ -53,7 +53,7 @@ export PATH=$builddir:$PATH
 
 cat > $tmp/cleanup <<EOF
 grcli show stats software
-grcli show interface all
+grcli show interface
 grcli show ip nexthop
 grcli show ip route
 grcli show ip6 nexthop

--- a/smoke/config_test.sh
+++ b/smoke/config_test.sh
@@ -12,7 +12,7 @@ grcli add ip route 0.0.0.0/0 via 10.0.0.2
 grcli add ip6 address 2345::1/24 iface p0
 grcli add ip6 address 2346::1/24 iface p1
 grcli add ip6 route ::/0 via 2345::2
-grcli show interface all
+grcli show interface
 grcli show ip route
 grcli show ip nexthop
 grcli show ip6 route


### PR DESCRIPTION
Instead of using 'show interface all' to list all interfaces, we can just type 'show interface'.
Update doc and tests.