### PR TITLE
infra: set iova mode

### DIFF
--- a/main/dpdk.c
+++ b/main/dpdk.c
@@ -15,6 +15,7 @@
 #include <rte_log.h>
 #include <rte_mempool.h>
 #include <rte_version.h>
+#include <rte_vfio.h>
 
 #include <pthread.h>
 #include <sched.h>
@@ -164,6 +165,9 @@ int dpdk_init(const struct gr_args *args) {
 	} else {
 		gr_vec_add(eal_args, "--in-memory");
 	}
+
+	if (rte_vfio_noiommu_is_enabled())
+		gr_vec_add(eal_args, "--iova-mode=pa");
 
 	gr_vec_foreach (arg, args->eal_extra_args)
 		gr_vec_add(eal_args, arg);


### PR DESCRIPTION
When running grout in a VM and hotplugging a port, the IOVA mode used is always VA, which leads to the impossibility to bind the port.

ERR: PCI_BUS:   Expecting 'PA' IOVA mode but current mode is 'VA', not initializing

Check if 'noiommu' is enabled, and sets iovamode to "PA".

Suggested-by: David Marchand <david.marchand@redhat.com>