### PR TITLE
ci: add clang and older gcc checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,14 +25,14 @@ jobs:
       MESON_EXTRA_OPTS: "-Ddpdk:platform=generic"
       DEBIAN_FRONTEND: noninteractive
       NEEDRESTART_MODE: l
-      CC: gcc-14
+      CC: ccache gcc-14
     steps:
       - name: install system dependencies
         run: |
           set -xe
           sudo apt-get update -qy
           sudo apt-get install -qy --no-install-recommends \
-            make gcc ninja-build meson git go-md2man libibverbs-dev \
+            make gcc ccache ninja-build meson git go-md2man libibverbs-dev \
             libasan8 libcmocka-dev libedit-dev libarchive-dev \
             libevent-dev libsmartcols-dev libnuma-dev python3-pyelftools \
             socat tcpdump traceroute graphviz iproute2 iputils-ping ndisc6
@@ -42,10 +42,20 @@ jobs:
           fetch-depth: 0 # force fetch all history
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - run: git config --global --add safe.directory $PWD
+      - run: ccache -p | sed -En 's/.* cache_dir = (.*)/CCACHE_DIR=\1/p' >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-x86_64-${{ github.ref }}
+          restore-keys: |
+            ccache-x86_64-refs/heads/main
+            ccache-x86_64-
+      - run: ccache -sv
       - run: git rebase -x "git --no-pager log --oneline -1 && make all unit-tests && sudo smoke/run.sh build" "HEAD~${{ github.event.pull_request.commits }}"
         if: ${{ github.event.pull_request.commits }}
       - run: make all unit-tests && sudo smoke/run.sh build
         if: ${{ ! github.event.pull_request.commits }}
+      - run: ccache -sv
 
   build-cross-aarch64:
     runs-on: ubuntu-24.04
@@ -61,7 +71,7 @@ jobs:
           dpkg --add-architecture arm64
           apt update -qy
           apt install -qy --no-install-recommends \
-            make gcc git meson go-md2man python3-pyelftools ca-certificates pkg-config \
+            make gcc ccache git meson go-md2man python3-pyelftools ca-certificates pkg-config \
             crossbuild-essential-arm64 libcmocka-dev:arm64 libedit-dev:arm64 \
             libevent-dev:arm64 libnuma-dev:arm64 libsmartcols-dev:arm64
       - uses: actions/checkout@v4
@@ -70,10 +80,20 @@ jobs:
           fetch-depth: 0 # force fetch all history
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - run: git config --global --add safe.directory $PWD
+      - run: ccache -p | sed -En 's/.* cache_dir = (.*)/CCACHE_DIR=\1/p' >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-aarch64-${{ github.ref }}
+          restore-keys: |
+            ccache-aarch64-refs/heads/main
+            ccache-aarch64-
+      - run: ccache -sv
       - run: git rebase -x "git --no-pager log --oneline -1 && make" "HEAD~${{ github.event.pull_request.commits }}"
         if: ${{ github.event.pull_request.commits }}
       - run: make
         if: ${{ ! github.event.pull_request.commits }}
+      - run: ccache -sv
 
   lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,14 +18,29 @@ concurrency:
 
 jobs:
   build-and-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        conf:
+          - compiler: gcc-13
+            sanitize: none
+            buildtype: debugoptimized
+          - compiler: gcc-14
+            sanitize: address
+            buildtype: debug
+          - compiler: clang-16
+            sanitize: none
+            buildtype: debugoptimized
+          - compiler: clang-18
+            sanitize: none
+            buildtype: debugoptimized
     runs-on: ubuntu-24.04
     env:
-      SANITIZE: address
-      BUILDTYPE: debugoptimized
-      MESON_EXTRA_OPTS: "-Ddpdk:platform=generic"
+      SANITIZE: ${{ matrix.conf.sanitize }}
+      BUILDTYPE: ${{ matrix.conf.buildtype }}
       DEBIAN_FRONTEND: noninteractive
       NEEDRESTART_MODE: l
-      CC: ccache gcc-14
+      CC: ccache ${{ matrix.conf.compiler }}
     steps:
       - name: install system dependencies
         run: |
@@ -46,10 +61,10 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-x86_64-${{ github.ref }}
+          key: ccache-x86_64-${{ matrix.conf.compiler }}-${{ github.ref }}
           restore-keys: |
-            ccache-x86_64-refs/heads/main
-            ccache-x86_64-
+            ccache-x86_64-${{ matrix.conf.compiler }}-refs/heads/main
+            ccache-x86_64-${{ matrix.conf.compiler }}-
       - run: ccache -sv
       - run: git rebase -x "git --no-pager log --oneline -1 && make all unit-tests && sudo smoke/run.sh build" "HEAD~${{ github.event.pull_request.commits }}"
         if: ${{ github.event.pull_request.commits }}

--- a/devtools/cross/aarch64.ini
+++ b/devtools/cross/aarch64.ini
@@ -2,8 +2,8 @@
 # Copyright (c) 2025 Robin Jarry
 
 [binaries]
-c = 'aarch64-linux-gnu-gcc'
-cpp = 'aarch64-linux-gnu-g++'
+c = ['ccache', 'aarch64-linux-gnu-gcc']
+cpp = ['ccache', 'aarch64-linux-gnu-g++']
 ar = 'aarch64-linux-gnu-ar'
 strip = 'aarch64-linux-gnu-strip'
 pkg-config = '/usr/bin/pkg-config'

--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,6 @@ project(
 add_project_arguments('-DALLOW_EXPERIMENTAL_API', language: 'c')
 add_project_arguments('-D_GNU_SOURCE', language: 'c')
 add_project_arguments('-Wmissing-prototypes', language: 'c')
-add_project_arguments('-Wno-format-truncation', language: 'c')
 add_project_arguments('-Wno-microsoft', language: 'c')
 add_project_arguments('-Wstrict-aliasing=2', language: 'c')
 add_project_arguments('-fms-extensions', language: 'c')
@@ -33,6 +32,7 @@ add_project_arguments('-fstrict-aliasing', language: 'c')
 optional_c_args = [
   '-Wcalloc-transposed-args',
   '-Wmissing-variable-declarations',
+  '-Wno-format-truncation',
 ]
 compiler = meson.get_compiler('c')
 foreach arg : optional_c_args
@@ -112,13 +112,19 @@ install_headers(api_headers)
 cmocka_dep = dependency('cmocka', required: get_option('tests'))
 if cmocka_dep.found()
   fs = import('fs')
+  coverage_c_args = []
+  coverage_link_args = []
+  if compiler.get_id() == 'gcc'
+    coverage_c_args += ['-coverage']
+    coverage_link_args += ['-lgcov']
+  endif
   foreach t : tests
     name = fs.replace_suffix(t['sources'].get(0), '').underscorify()
     t += {
       'sources': t['sources'] + files('main/string.c'),
       'include_directories': inc + api_inc,
-      'c_args': ['-coverage', '-D__GROUT_MAIN__'],
-      'link_args': t['link_args'] + ['-lgcov'],
+      'c_args': ['-D__GROUT_MAIN__'] + coverage_c_args,
+      'link_args': t['link_args'] + coverage_link_args,
       'dependencies': [dpdk_dep, ev_core_dep, ev_thread_dep, numa_dep, ecoli_dep, cmocka_dep],
     }
     test(name, executable(name, kwargs: t), suite: 'unit')

--- a/modules/l4/l4_input_local.c
+++ b/modules/l4/l4_input_local.c
@@ -24,11 +24,12 @@ enum edges {
 static rte_edge_t udp_edges[65536] = {MANAGEMENT};
 
 void l4_input_register_port(uint8_t proto, rte_be16_t port, const char *next_node) {
-	LOG(DEBUG, "l4_input_register_port: proto=%hhu port=%hu-> %s", proto, port, next_node);
+	uint16_t p = rte_be_to_cpu_16(port);
+	LOG(DEBUG, "l4_input_register_port: proto=%hhu port=%hu -> %s", proto, p, next_node);
 	switch (proto) {
 	case IPPROTO_UDP:
 		if (udp_edges[port] != MANAGEMENT)
-			ABORT("next node already registered for udp port=%hhu", port);
+			ABORT("next node already registered for udp port=%hu", p);
 		udp_edges[proto] = gr_node_attach_parent("ip_input_local", next_node);
 		gr_node_attach_parent("ip6_input_local", next_node);
 		break;


### PR DESCRIPTION
Add multiple jobs to ensure that the compilation works on gcc 11, 14 and clang 13 and 18.

Enable ccache to get results faster.