### PR TITLE
c2x: enum types

### DIFF
--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -14,27 +14,27 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-typedef enum {
+typedef enum : uint8_t {
 	GR_IFACE_TYPE_UNDEF = 0x00,
 	GR_IFACE_TYPE_PORT = 0x01,
 	GR_IFACE_TYPE_VLAN = 0x02,
 	GR_IFACE_TYPE_IPIP = 0x03,
 	GR_IFACE_TYPE_LOOPBACK = 0xfe,
 	GR_IFACE_TYPE_MAX = 255
-} __attribute__((mode(QI))) gr_iface_type_t;
+} gr_iface_type_t;
 
 // Interface configure flags
-typedef enum {
+typedef enum : uint16_t {
 	GR_IFACE_F_UP = GR_BIT16(0),
 	GR_IFACE_F_PROMISC = GR_BIT16(1),
 	GR_IFACE_F_ALLMULTI = GR_BIT16(2),
 	GR_IFACE_F_PACKET_TRACE = GR_BIT16(3),
-} __attribute__((mode(HI))) gr_iface_flags_t;
+} gr_iface_flags_t;
 
 // Interface state flags
-typedef enum {
+typedef enum : uint16_t {
 	GR_IFACE_S_RUNNING = GR_BIT16(0),
-} __attribute__((mode(HI))) gr_iface_state_t;
+} gr_iface_state_t;
 
 // Interface reconfig attributes
 #define GR_IFACE_SET_FLAGS GR_BIT64(0)
@@ -48,11 +48,11 @@ typedef enum {
 
 #define GR_VRF_ID_ALL UINT16_MAX
 
-typedef enum gr_iface_mode {
+typedef enum : uint8_t {
 	GR_IFACE_MODE_L3 = 0,
 	GR_IFACE_MODE_L1_XC,
 	GR_IFACE_MODE_COUNT
-} __attribute__((mode(QI))) gr_iface_mode_t;
+} gr_iface_mode_t;
 
 // Generic struct for all network interfaces.
 struct gr_iface {

--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -15,12 +15,12 @@
 #include <sys/types.h>
 
 typedef enum : uint8_t {
-	GR_IFACE_TYPE_UNDEF = 0x00,
-	GR_IFACE_TYPE_PORT = 0x01,
-	GR_IFACE_TYPE_VLAN = 0x02,
-	GR_IFACE_TYPE_IPIP = 0x03,
-	GR_IFACE_TYPE_LOOPBACK = 0xfe,
-	GR_IFACE_TYPE_MAX = 255
+	GR_IFACE_TYPE_UNDEF = 0,
+	GR_IFACE_TYPE_LOOPBACK,
+	GR_IFACE_TYPE_PORT,
+	GR_IFACE_TYPE_VLAN,
+	GR_IFACE_TYPE_IPIP,
+	GR_IFACE_TYPE_COUNT
 } gr_iface_type_t;
 
 // Interface configure flags

--- a/modules/infra/api/gr_nexthop.h
+++ b/modules/infra/api/gr_nexthop.h
@@ -26,7 +26,7 @@ typedef enum : uint16_t {
 typedef enum : uint8_t {
 	GR_NH_IPV4 = 1,
 	GR_NH_IPV6,
-	_GR_NH_TYPE_MAX,
+	GR_NH_TYPE_COUNT
 } gr_nh_type_t;
 
 //! Nexthop structure exposed to the API.
@@ -85,7 +85,7 @@ static inline uint8_t nh_af(const struct gr_nexthop *nh) {
 		return AF_INET;
 	case GR_NH_IPV6:
 		return AF_INET6;
-	case _GR_NH_TYPE_MAX:
+	case GR_NH_TYPE_COUNT:
 		break;
 	}
 	return 0;

--- a/modules/infra/api/gr_nexthop.h
+++ b/modules/infra/api/gr_nexthop.h
@@ -11,7 +11,7 @@
 #include <gr_net_types.h>
 
 // Supported flags on a nexthop.
-typedef enum {
+typedef enum : uint16_t {
 	GR_NH_F_PENDING = GR_BIT16(0), // Probe sent
 	GR_NH_F_REACHABLE = GR_BIT16(1), // Probe reply received
 	GR_NH_F_STALE = GR_BIT16(2), // Reachable lifetime expired, need refresh
@@ -21,13 +21,13 @@ typedef enum {
 	GR_NH_F_GATEWAY = GR_BIT16(6), // Gateway route
 	GR_NH_F_LINK = GR_BIT16(7), // Connected link route
 	GR_NH_F_MCAST = GR_BIT16(8), // Multicast address
-} __attribute__((mode(HI))) gr_nh_flags_t;
+} gr_nh_flags_t;
 
-typedef enum {
+typedef enum : uint8_t {
 	GR_NH_IPV4 = 1,
 	GR_NH_IPV6,
 	_GR_NH_TYPE_MAX,
-} __attribute__((mode(QI))) gr_nh_type_t;
+} gr_nh_type_t;
 
 //! Nexthop structure exposed to the API.
 struct gr_nexthop {

--- a/modules/infra/control/gr_iface.h
+++ b/modules/infra/control/gr_iface.h
@@ -23,7 +23,7 @@ struct __rte_cache_aligned iface {
 		uint16_t vrf_id; // L3 addressing and routing domain
 		uint16_t domain_id;
 	};
-	enum gr_iface_mode mode;
+	gr_iface_mode_t mode;
 	const struct iface **subinterfaces;
 	char *name;
 	alignas(alignof(void *)) uint8_t info[/* size depends on type */];

--- a/modules/infra/control/iface.c
+++ b/modules/infra/control/iface.c
@@ -31,7 +31,7 @@ struct iface_type *iface_type_get(gr_iface_type_t type_id) {
 void iface_type_register(struct iface_type *type) {
 	if (iface_type_get(type->id) != NULL)
 		ABORT("duplicate iface type id: %u", type->id);
-	if (type->id >= GR_IFACE_TYPE_MAX)
+	if (type->id >= GR_IFACE_TYPE_COUNT)
 		ABORT("invalid iface type id: %u", type->id);
 	STAILQ_INSERT_TAIL(&types, type, next);
 }

--- a/modules/infra/control/nexthop.c
+++ b/modules/infra/control/nexthop.c
@@ -15,7 +15,7 @@
 
 static struct rte_mempool *pool;
 static struct event *ageing_timer;
-static const struct nexthop_ops *nh_ops[_GR_NH_TYPE_MAX];
+static const struct nexthop_ops *nh_ops[GR_NH_TYPE_COUNT];
 
 void nexthop_ops_register(gr_nh_type_t type, const struct nexthop_ops *ops) {
 	switch (type) {
@@ -111,7 +111,7 @@ static void nh_lookup_cb(struct nexthop *nh, void *priv) {
 				filter->nh = nh;
 		}
 		break;
-	case _GR_NH_TYPE_MAX:
+	case GR_NH_TYPE_COUNT:
 		break;
 	}
 }

--- a/modules/infra/datapath/gr_icmp6.h
+++ b/modules/infra/datapath/gr_icmp6.h
@@ -15,7 +15,7 @@
 #include <stdint.h>
 
 // ICMP6 packet types
-typedef enum {
+typedef enum : uint8_t {
 	ICMP6_ERR_DEST_UNREACH = UINT8_C(1),
 	ICMP6_ERR_PKT_TOO_BIG = UINT8_C(2),
 	ICMP6_ERR_TTL_EXCEEDED = UINT8_C(3),
@@ -29,7 +29,7 @@ typedef enum {
 	ICMP6_TYPE_NEIGH_ADVERT = UINT8_C(136),
 
 	_ICMP6_TYPE_MAX = UINT8_C(0xff),
-} __attribute__((mode(QI))) icmp6_type_t;
+} icmp6_type_t;
 
 #define GR_ICMP6_HDR_LEN 8
 
@@ -111,14 +111,14 @@ struct icmp6_neigh_advert {
 // ICMP6 options
 
 // option types
-typedef enum {
+typedef enum : uint8_t {
 	ICMP6_OPT_SRC_LLADDR = UINT8_C(1),
 	ICMP6_OPT_TARGET_LLADDR = UINT8_C(2),
 	ICMP6_OPT_PREFIX = UINT8_C(3),
 	ICMP6_OPT_REDIRECT = UINT8_C(4),
 	ICMP6_OPT_MTU = UINT8_C(5),
 	_ICMP6_OPT_MAX = UINT8_C(0xff),
-} __attribute__((mode(QI))) icmp6_opt_t;
+} icmp6_opt_t;
 
 struct icmp6_opt {
 	icmp6_opt_t type;

--- a/modules/infra/datapath/gr_icmp6.h
+++ b/modules/infra/datapath/gr_icmp6.h
@@ -27,8 +27,6 @@ typedef enum : uint8_t {
 	ICMP6_TYPE_ROUTER_ADVERT = UINT8_C(134),
 	ICMP6_TYPE_NEIGH_SOLICIT = UINT8_C(135),
 	ICMP6_TYPE_NEIGH_ADVERT = UINT8_C(136),
-
-	_ICMP6_TYPE_MAX = UINT8_C(0xff),
 } icmp6_type_t;
 
 #define GR_ICMP6_HDR_LEN 8
@@ -116,8 +114,7 @@ typedef enum : uint8_t {
 	ICMP6_OPT_TARGET_LLADDR = UINT8_C(2),
 	ICMP6_OPT_PREFIX = UINT8_C(3),
 	ICMP6_OPT_REDIRECT = UINT8_C(4),
-	ICMP6_OPT_MTU = UINT8_C(5),
-	_ICMP6_OPT_MAX = UINT8_C(0xff),
+	ICMP6_OPT_MTU = UINT8_C(5)
 } icmp6_opt_t;
 
 struct icmp6_opt {

--- a/modules/ip/datapath/ip_output.c
+++ b/modules/ip/datapath/ip_output.c
@@ -28,7 +28,7 @@ enum {
 	EDGE_COUNT,
 };
 
-static rte_edge_t edges[GR_IFACE_TYPE_MAX] = {ETH_OUTPUT};
+static rte_edge_t edges[GR_IFACE_TYPE_COUNT] = {ETH_OUTPUT};
 
 void ip_output_register_interface(gr_iface_type_t iface_type_id, const char *next_node) {
 	LOG(DEBUG, "ip_output: iface_type=%u -> %s", iface_type_id, next_node);

--- a/modules/ip6/datapath/ip6_output.c
+++ b/modules/ip6/datapath/ip6_output.c
@@ -25,7 +25,7 @@ enum {
 	EDGE_COUNT,
 };
 
-static rte_edge_t edges[GR_IFACE_TYPE_MAX] = {ETH_OUTPUT};
+static rte_edge_t edges[GR_IFACE_TYPE_COUNT] = {ETH_OUTPUT};
 
 void ip6_output_register_interface(gr_iface_type_t iface_type_id, const char *next_node) {
 	LOG(DEBUG, "ip6_output: iface_type=%u -> %s", iface_type_id, next_node);


### PR DESCRIPTION
- update enum types

This increases minimum gcc version to gcc 13.