### PR TITLE
quay: build and publish container

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
 
 jobs:
   check:
@@ -90,6 +92,27 @@ jobs:
         with:
           pattern: "*-packages"
           merge-multiple: true
+      - uses: docker/metadata-action@v5
+        name: Extract metadata for the Docker image
+        id: meta
+        with:
+          images: "quay.io/grout/grout"
+          tags: |
+              type=edge,branch=main
+              type=semver,pattern={{version}}
+              type=semver,pattern={{major}}.{{minor}}
+      - uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Containerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
       - uses: pyTooling/Actions/releaser@r0
         with:
           token: ${{ github.token }}

--- a/main/main.c
+++ b/main/main.c
@@ -176,6 +176,7 @@ int main(int argc, char **argv) {
 		goto end;
 
 	LOG(NOTICE, "starting grout version %s", GROUT_VERSION);
+	LOG(NOTICE, "License available at https://git.dpdk.org/apps/grout/plain/LICENSE");
 
 	if (dpdk_init(&args) < 0) {
 		err = errno;


### PR DESCRIPTION
This reverts commit 719935e775fcdb1649e0b2f17814c547d2725426, using quay.io instead of github to host container images.

Container is available at:
quay.io/grout/grout
Available tags are:
- edge: latest build, including all merged changes
- latest: latest stable release
- v0.X: tagged versions