### PR TITLE
ip,ip6: handle nexthop types

### DIFF
--- a/modules/infra/datapath/loop_output.c
+++ b/modules/infra/datapath/loop_output.c
@@ -45,8 +45,8 @@ static struct rte_node_register loopback_output_node = {
 };
 
 static void loopback_output_register(void) {
-	ip_output_register_interface(GR_IFACE_TYPE_LOOPBACK, "loopback_output");
-	ip6_output_register_interface(GR_IFACE_TYPE_LOOPBACK, "loopback_output");
+	ip_output_register_interface_type(GR_IFACE_TYPE_LOOPBACK, "loopback_output");
+	ip6_output_register_interface_type(GR_IFACE_TYPE_LOOPBACK, "loopback_output");
 }
 
 static struct gr_node_info info = {

--- a/modules/ip/datapath/gr_ip4_datapath.h
+++ b/modules/ip/datapath/gr_ip4_datapath.h
@@ -31,6 +31,7 @@ GR_MBUF_PRIV_DATA_TYPE(ip_local_mbuf_data, {
 
 void ip_input_local_add_proto(uint8_t proto, const char *next_node);
 void ip_output_register_interface_type(gr_iface_type_t type, const char *next_node);
+void ip_output_register_nexthop_type(gr_nh_type_t type, const char *next_node);
 int arp_output_request_solicit(struct nexthop *nh);
 void arp_update_nexthop(struct rte_graph *, struct rte_node *, struct nexthop *, const struct iface *, const struct rte_ether_addr *);
 

--- a/modules/ip/datapath/gr_ip4_datapath.h
+++ b/modules/ip/datapath/gr_ip4_datapath.h
@@ -30,7 +30,7 @@ GR_MBUF_PRIV_DATA_TYPE(ip_local_mbuf_data, {
 });
 
 void ip_input_local_add_proto(uint8_t proto, const char *next_node);
-void ip_output_register_interface(gr_iface_type_t iface_type_id, const char *next_node);
+void ip_output_register_interface_type(gr_iface_type_t type, const char *next_node);
 int arp_output_request_solicit(struct nexthop *nh);
 void arp_update_nexthop(struct rte_graph *, struct rte_node *, struct nexthop *, const struct iface *, const struct rte_ether_addr *);
 

--- a/modules/ip/datapath/ip_output.c
+++ b/modules/ip/datapath/ip_output.c
@@ -28,15 +28,15 @@ enum {
 	EDGE_COUNT,
 };
 
-static rte_edge_t edges[GR_IFACE_TYPE_COUNT] = {ETH_OUTPUT};
+static rte_edge_t iface_type_edges[GR_IFACE_TYPE_COUNT] = {ETH_OUTPUT};
 
-void ip_output_register_interface(gr_iface_type_t iface_type_id, const char *next_node) {
-	LOG(DEBUG, "ip_output: iface_type=%u -> %s", iface_type_id, next_node);
-	if (iface_type_id == GR_IFACE_TYPE_UNDEF || iface_type_id >= ARRAY_DIM(edges))
-		ABORT("invalid iface type=%u", iface_type_id);
-	if (edges[iface_type_id] != ETH_OUTPUT)
-		ABORT("next node already registered for iface type=%u", iface_type_id);
-	edges[iface_type_id] = gr_node_attach_parent("ip_output", next_node);
+void ip_output_register_interface_type(gr_iface_type_t type, const char *next_node) {
+	LOG(DEBUG, "ip_output: iface_type=%u -> %s", type, next_node);
+	if (type == GR_IFACE_TYPE_UNDEF || type >= ARRAY_DIM(iface_type_edges))
+		ABORT("invalid iface type=%u", type);
+	if (iface_type_edges[type] != ETH_OUTPUT)
+		ABORT("next node already registered for iface type=%u", type);
+	iface_type_edges[type] = gr_node_attach_parent("ip_output", next_node);
 }
 
 static uint16_t
@@ -67,7 +67,7 @@ ip_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 		}
 		// Determine what is the next node based on the output interface type
 		// By default, it will be eth_output unless another output node was registered.
-		edge = edges[iface->type_id];
+		edge = iface_type_edges[iface->type_id];
 		mbuf_data(mbuf)->iface = iface;
 
 		if (edge != ETH_OUTPUT)

--- a/modules/ip6/datapath/gr_ip6_datapath.h
+++ b/modules/ip6/datapath/gr_ip6_datapath.h
@@ -35,7 +35,7 @@ GR_MBUF_PRIV_DATA_TYPE(ndp_na_output_mbuf_data, {
 });
 
 void ip6_input_local_add_proto(uint8_t proto, const char *next_node);
-void ip6_output_register_interface(gr_iface_type_t iface_type_id, const char *next_node);
+void ip6_output_register_interface_type(gr_iface_type_t type, const char *next_node);
 int nh6_solicit(struct nexthop *nh);
 
 #define IP6_DEFAULT_HOP_LIMIT 255

--- a/modules/ip6/datapath/gr_ip6_datapath.h
+++ b/modules/ip6/datapath/gr_ip6_datapath.h
@@ -36,6 +36,7 @@ GR_MBUF_PRIV_DATA_TYPE(ndp_na_output_mbuf_data, {
 
 void ip6_input_local_add_proto(uint8_t proto, const char *next_node);
 void ip6_output_register_interface_type(gr_iface_type_t type, const char *next_node);
+void ip6_output_register_nexthop_type(gr_nh_type_t type, const char *next_node);
 int nh6_solicit(struct nexthop *nh);
 
 #define IP6_DEFAULT_HOP_LIMIT 255

--- a/modules/ip6/datapath/ip6_output.c
+++ b/modules/ip6/datapath/ip6_output.c
@@ -25,15 +25,15 @@ enum {
 	EDGE_COUNT,
 };
 
-static rte_edge_t edges[GR_IFACE_TYPE_COUNT] = {ETH_OUTPUT};
+static rte_edge_t iface_type_edges[GR_IFACE_TYPE_COUNT] = {ETH_OUTPUT};
 
-void ip6_output_register_interface(gr_iface_type_t iface_type_id, const char *next_node) {
-	LOG(DEBUG, "ip6_output: iface_type=%u -> %s", iface_type_id, next_node);
-	if (iface_type_id == GR_IFACE_TYPE_UNDEF || iface_type_id >= ARRAY_DIM(edges))
-		ABORT("invalid iface type=%u", iface_type_id);
-	if (edges[iface_type_id] != ETH_OUTPUT)
-		ABORT("next node already registered for iface type=%u", iface_type_id);
-	edges[iface_type_id] = gr_node_attach_parent("ip6_output", next_node);
+void ip6_output_register_interface_type(gr_iface_type_t type, const char *next_node) {
+	LOG(DEBUG, "ip6_output: iface type=%u -> %s", type, next_node);
+	if (type == GR_IFACE_TYPE_UNDEF || type >= ARRAY_DIM(iface_type_edges))
+		ABORT("invalid iface type=%u", type);
+	if (iface_type_edges[type] != ETH_OUTPUT)
+		ABORT("next node already registered for iface type=%u", type);
+	iface_type_edges[type] = gr_node_attach_parent("ip6_output", next_node);
 }
 
 static uint16_t
@@ -69,7 +69,7 @@ ip6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 		}
 		// Determine what is the next node based on the output interface type
 		// By default, it will be eth_output unless another output node was registered.
-		edge = edges[iface->type_id];
+		edge = iface_type_edges[iface->type_id];
 		mbuf_data(mbuf)->iface = iface;
 		if (edge != ETH_OUTPUT)
 			goto next;

--- a/modules/ipip/datapath_out.c
+++ b/modules/ipip/datapath_out.c
@@ -82,7 +82,7 @@ next:
 }
 
 static void ipip_output_register(void) {
-	ip_output_register_interface(GR_IFACE_TYPE_IPIP, "ipip_output");
+	ip_output_register_interface_type(GR_IFACE_TYPE_IPIP, "ipip_output");
 }
 
 static struct rte_node_register ipip_output_node = {


### PR DESCRIPTION
Allow registering dynamic next nodes after ip_output and ip6_output based on the nexthop type.

This will allow redirecting packets to different nodes for special processing, such as SRv6.