### PR TITLE
container: multistage build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Robin Jarry
+# Copyright (c) 2025 Christophe Fontaine
 
-FROM registry.access.redhat.com/ubi9/ubi:latest
-COPY grout*.rpm /tmp
-RUN rm -f /tmp/grout-debug*.rpm
-RUN dnf -y install --nodocs --setopt=install_weak_deps=0 /tmp/grout*.rpm
-RUN dnf -y --enablerepo='*' clean all
-RUN rm -f /tmp/grout*.rpm
+FROM registry.access.redhat.com/ubi9 as ubi-builder
+COPY grout.*.rpm /tmp
+RUN mkdir -p /tmp/null
+RUN dnf -y install --nodocs --setopt=install_weak_deps=0 --releasever 9 --installroot /tmp/null /tmp/grout.$(arch).rpm
+RUN dnf -y --installroot /tmp/null clean all
+RUN rm -rf /tmp/null/var/cache/* /tmp/null/var/log/dnf* /tmp/null/var/log/yum.*
+
+FROM registry.access.redhat.com/ubi9-micro
+COPY --from=ubi-builder /tmp/null/ /
 CMD ["/usr/bin/grout"]


### PR DESCRIPTION
Use ubi-micro to reduce container image size.
Yet, we can't run dnf directly, so switch to multistage build to install all dependencies in a tmp rootfs.