### PR TITLE
ip: add unit tests to validate ip header

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -123,7 +123,7 @@ if cmocka_dep.found()
     t += {
       'sources': t['sources'] + files('api/string.c'),
       'include_directories': inc + api_inc,
-      'c_args': ['-D__GROUT_MAIN__'] + coverage_c_args,
+      'c_args': ['-D__GROUT_MAIN__', '-D__GROUT_UNIT_TEST__'] + coverage_c_args,
       'link_args': t['link_args'] + coverage_link_args,
       'dependencies': [dpdk_dep, ev_core_dep, ev_thread_dep, numa_dep, ecoli_dep, cmocka_dep],
     }

--- a/modules/ip/datapath/ip_input.c
+++ b/modules/ip/datapath/ip_input.c
@@ -59,9 +59,6 @@ ip_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, ui
 		nh = NULL;
 		mbuf = objs[i];
 		ip = rte_pktmbuf_mtod(mbuf, struct rte_ipv4_hdr *);
-		e = eth_input_mbuf_data(mbuf);
-		d = ip_output_mbuf_data(mbuf);
-		iface = e->iface;
 
 		// RFC 1812 section 5.2.2 IP Header Validation
 		//
@@ -114,6 +111,7 @@ ip_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, ui
 			goto next;
 		}
 
+		e = eth_input_mbuf_data(mbuf);
 		switch (e->domain) {
 		case ETH_DOMAIN_LOOPBACK:
 		case ETH_DOMAIN_LOCAL:
@@ -131,6 +129,7 @@ ip_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, ui
 			goto next;
 		}
 
+		iface = e->iface;
 		nh = fib4_lookup(iface->vrf_id, ip->dst_addr);
 		if (nh == NULL) {
 			edge = NO_ROUTE;
@@ -151,6 +150,7 @@ next:
 			*t = *ip;
 		}
 		// Store the resolved next hop for ip_output to avoid a second route lookup.
+		d = ip_output_mbuf_data(mbuf);
 		d->nh = nh;
 		d->iface = iface;
 		rte_node_enqueue_x1(graph, node, edge, mbuf);

--- a/modules/ip/datapath/meson.build
+++ b/modules/ip/datapath/meson.build
@@ -19,3 +19,10 @@ src += files(
   'ip_output.c',
 )
 inc += include_directories('.')
+
+tests += [
+  {
+    'sources': files('ip_input.c'),
+    'link_args': [],
+  }
+]


### PR DESCRIPTION
This patch introduces unit tests to validate the correctness of the IPv4 header processing in the ip_process_input function. The tests check for key properties such as IP version, checksum calculation, packet length, etc ...