### PR TITLE
ip6: demonstrate DPDK issue with IPv6 version field encoding

### DIFF
--- a/modules/ip6/datapath/meson.build
+++ b/modules/ip6/datapath/meson.build
@@ -19,3 +19,10 @@ src += files(
   'ndp_rs_input.c',
 )
 inc += include_directories('.')
+
+tests += [
+  {
+    'sources': files('ip6_input.c'),
+    'link_args': [],
+  }
+]


### PR DESCRIPTION
This patch is intended to highlight a problem when setting the version field of the IPv6 header using DPDK. Specifically, it reveals unexpected behavior potentially related to byte-order conversion or compiler handling on certain architectures.

**The patch is not intended for merging.** It serves purely as a diagnostic tool to reproduce the issue on ARM platforms and across different compilers in the GitHub CI infrastructure.

This will help in reporting and reproducing the issue on DPDK Bugzilla.