### PR TITLE
nexthop: fix mcast/bcast solicit

### DIFF
--- a/modules/ip/datapath/arp_output_request.c
+++ b/modules/ip/datapath/arp_output_request.c
@@ -96,7 +96,7 @@ static uint16_t arp_output_request_process(
 
 		// Prepare ethernet layer info.
 		eth_data = eth_output_mbuf_data(mbuf);
-		if (nh->ucast_probes <= NH_UCAST_PROBES)
+		if (nh->bcast_probes == 0)
 			eth_data->dst = arp->arp_data.arp_tha;
 		else
 			memset(&eth_data->dst, 0xff, sizeof(eth_data->dst));

--- a/modules/ip6/datapath/ndp_ns_output.c
+++ b/modules/ip6/datapath/ndp_ns_output.c
@@ -93,7 +93,7 @@ static uint16_t ndp_ns_output_process(
 		d = ip6_local_mbuf_data(mbuf);
 		d->iface = iface_from_id(local->iface_id);
 		d->src = local->ipv6;
-		if (nh->last_reply != 0 && nh->ucast_probes <= NH_UCAST_PROBES)
+		if (nh->last_reply != 0 && nh->bcast_probes == 0)
 			d->dst = nh->ipv6;
 		else
 			rte_ipv6_solnode_from_addr(&d->dst, &nh->ipv6);


### PR DESCRIPTION
After a nexthop expired, and when the peer doesn't respond to unicast probes, grout never switched back to broadcast (ip) or multicast (ip6) probes.

Instead of checking on the ucast probe counter, check the bcast probe counter.