### PR TITLE
meson: allow forcing version via environment variable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project(
   'grout',
   'c',
   version: run_command(
-    'sh', '-c', 'git describe --long --abbrev=8 --dirty 2>/dev/null || echo v0.8.3',
+    'sh', '-c', 'echo ${GROUT_VERSION:-$(git describe --long --abbrev=8 --dirty 2>/dev/null || echo v0.8.3)}',
     check: false,
     capture: true,
   ).stdout().strip(),


### PR DESCRIPTION
When building from outside of grout repository for downstream packaging, we cannot rely on git to get the version from the latest tag.

Allow building with a GROUT_VERSION variable that will be used in meson.build.