### PR TITLE
nexthop: fix disappearing addresses and routes after expiration

### DIFF
--- a/modules/infra/control/nexthop.c
+++ b/modules/infra/control/nexthop.c
@@ -164,8 +164,8 @@ static void nexthop_ageing_cb(struct nexthop *nh, void *) {
 	max_probes = NH_UCAST_PROBES + NH_BCAST_PROBES;
 	probes = nh->ucast_probes + nh->bcast_probes;
 
-	if (nh->flags & (GR_NH_F_PENDING | GR_NH_F_STALE) && request_age > probes) {
-		if (probes >= max_probes && !(nh->flags & GR_NH_F_GATEWAY)) {
+	if (nh->flags & (GR_NH_F_PENDING | GR_NH_F_STALE)) {
+		if (probes >= max_probes) {
 			LOG(DEBUG,
 			    ADDR_F " vrf=%u failed_probes=%u held_pkts=%u: %s -> failed",
 			    ADDR_W(nh_af(&nh->base)),


### PR DESCRIPTION
After a fixed period of time (20 minutes), grout will mark non-static nexthops that were resolved earlier (with ARP or NDP) as STALE and will try to probe them to refresh their mac addresses.

After 6 probes have been sent (3 unicast using the previously known mac address of the nexthop, and 3 broadcast/multicast) without any reply from the nexthop, it is marked as FAILED.

After 1 minute in the FAILED state, it is "freed" using the callback specified in the nexthop_ops per family (at the moment, only IPv4 and IPv6).

The current callbacks are rib4_cleanup and rib6_cleanup which are very aggressive. They effectively delete everything related to the nexthop. Including any local address, routes, etc.

Replace these callbacks with simpler ones which only delete /32 and /128 routes and decrement the reference counter on the nexthop. If the nexthop still has routes referencing it (for example, it is used as a gateway for a route), scrub its flags and mac address fields so that
it can reused later.

Fixes: https://github.com/DPDK/grout/commit/fe3e408851ceb929771a4eb9f984623334f1a102 ("route: rework route cleanup routine")