### PR TITLE
cli: use scols_line_sprintf if available

### DIFF
--- a/cli/gr_table.h
+++ b/cli/gr_table.h
@@ -4,9 +4,13 @@
 #ifndef _GR_TABLE
 #define _GR_TABLE
 
+#ifndef NEED_SCOLS_LINE_SPRINTF
+#include <libsmartcols.h>
+#else
 struct libscols_line;
 
 int scols_line_sprintf(struct libscols_line *, int column, const char *fmt, ...)
 	__attribute__((format(printf, 3, 4)));
+#endif
 
 #endif

--- a/cli/meson.build
+++ b/cli/meson.build
@@ -11,7 +11,15 @@ cli_src += files(
   'log.c',
   'main.c',
   'quit.c',
-  'table.c',
 )
+
+if not compiler.has_function(
+  'scols_line_sprintf',
+  prefix: '#include <libsmartcols.h>',
+  dependencies: [smartcols_dep],
+)
+  cli_src += files('table.c')
+  cli_cflags += ['-DNEED_SCOLS_LINE_SPRINTF']
+endif
 
 cli_inc += include_directories('.')

--- a/meson.build
+++ b/meson.build
@@ -100,6 +100,7 @@ api_headers = []
 
 cli_src = []
 cli_inc = []
+cli_cflags = []
 
 tests = []
 
@@ -121,6 +122,7 @@ grcli_exe = executable(
   'grcli', cli_src,
   include_directories: cli_inc + api_inc,
   dependencies: [ecoli_dep, smartcols_dep],
+  c_args: cli_cflags,
   install: true,
 )
 


### PR DESCRIPTION
Since libsmartcols 2.41, scols_line_sprintf is available and does not need to be implemented by grout. Add the required meson code to avoid building our local version when the symbol is available in the library.

Link: https://github.com/util-linux/util-linux/commit/f0d0817c37931b504a7