### PR TITLE
graph: fix hash init when no memory is available on numa 0

### DIFF
--- a/modules/infra/control/graph.c
+++ b/modules/infra/control/graph.c
@@ -304,6 +304,7 @@ static void graph_init(struct event_base *) {
 		.name = "node_data",
 		.entries = 1024,
 		.key_len = sizeof(struct node_data_key),
+		.socket_id = SOCKET_ID_ANY,
 	};
 	hash = rte_hash_create(&params);
 	if (hash == NULL)


### PR DESCRIPTION
When no hugepages are available on numa 0, the rte_hash initialization fails:

```
INFO: GROUT: dpdk_init: EAL arguments: -l 3 -a 0000:00:00.0 --in-memory
NOTICE: EAL: 8000 hugepages of size 2097152 reserved, but no mounted hugetlbfs found for that size
INFO: GROUT: dpdk_init: running control plane on CPU 3
INFO: GROUT: dpdk_init: datapath workers allowed on CPUs 5,51,53
ERR: EAL: set_mempolicy failed: Invalid argument
ERR: EAL: set_mempolicy failed: Invalid argument
ERR: RING: Cannot reserve memory
ERR: HASH: memory allocation failed
EMERG: GROUT: graph_init: rte_hash_create: Cannot allocate memory
```

This happens because the socket_id field is left to its "default" value which happens to be 0. Replace it with SOCKET_ID_ANY which will cause the allocator to use whatever is available.

Closes: https://github.com/DPDK/grout/issues/198