### PR TITLE
address: always allow deleting addresses

### DIFF
--- a/modules/ip/control/address.c
+++ b/modules/ip/control/address.c
@@ -123,9 +123,6 @@ static struct api_out addr_del(const void *request, void ** /*response*/) {
 		return api_out(ENOENT, 0);
 	}
 
-	if (nh->ref_count > 1)
-		return api_out(EBUSY, 0);
-
 	rib4_cleanup(nh);
 
 	gr_vec_del(addrs->nh, i);

--- a/modules/ip6/control/address.c
+++ b/modules/ip6/control/address.c
@@ -232,9 +232,6 @@ static struct api_out addr6_del(const void *request, void ** /*response*/) {
 		return api_out(ENOENT, 0);
 	}
 
-	if (nh->ref_count > 1)
-		return api_out(EBUSY, 0);
-
 	rib6_cleanup(nh);
 
 	// shift the remaining addresses


### PR DESCRIPTION
If a local address nexthop has routes referencing it (other than the connected route created when the address is configured), it should be allowed to delete the address in any case.

Remove the check for the ref_count value. rib4_cleanup and rib6_cleanup will take care of removing any routes that are referencing the nexthop.