### PR TITLE
modules/ip[6]: fix uninitialized nexthop in "addr del" event

### DIFF
--- a/modules/ip/control/address.c
+++ b/modules/ip/control/address.c
@@ -123,10 +123,11 @@ static struct api_out addr_del(const void *request, void ** /*response*/) {
 		return api_out(ENOENT, 0);
 	}
 
+	gr_event_push(IP_EVENT_ADDR_DEL, nh);
+
 	rib4_cleanup(nh);
 
 	gr_vec_del(addrs->nh, i);
-	gr_event_push(IP_EVENT_ADDR_DEL, nh);
 
 	return api_out(0, 0);
 }

--- a/modules/ip6/control/address.c
+++ b/modules/ip6/control/address.c
@@ -233,6 +233,8 @@ static struct api_out addr6_del(const void *request, void ** /*response*/) {
 		return api_out(ENOENT, 0);
 	}
 
+	gr_event_push(IP6_EVENT_ADDR_DEL, nh);
+
 	rib6_cleanup(nh);
 
 	// shift the remaining addresses
@@ -242,8 +244,6 @@ static struct api_out addr6_del(const void *request, void ** /*response*/) {
 	rte_ipv6_solnode_from_addr(&solicited_node, &req->addr.addr.ip);
 	if (mcast6_addr_del(iface_from_id(req->addr.iface_id), &solicited_node) < 0)
 		return api_out(errno, 0);
-
-	gr_event_push(IP6_EVENT_ADDR_DEL, nh);
 
 	return api_out(0, 0);
 }


### PR DESCRIPTION
When an IP address is removed, the RIB cleanup process (rib4/6_cleanup) resets associated nexthop memory before the addr del event is sent. As a result, the event includes a nexthop structure with all fields set to zero, even though a valid nexthop was previously in use.

To reproduce:

grcli show events
> addr add: iface[1] 9.6.6.7
> route del: 9.6.6.7/24 via 9.6.6.7 origin link
> nh del: iface 1 vrf 0 9.6.6.7 d2:f0:0c:bc:a4:10
> addr del: iface[0] 0x5d279f4eb1ac

Or from another instance:

grout# add ip address 9.6.6.7/24 iface p4
grout# del ip address 9.6.6.7/24 iface p4

Fix this by emitting the addr del event before the nexthop is cleaned up, ensuring the event still carries valid nexthop information.