### PR TITLE
nexthop: add more route origin values

### DIFF
--- a/modules/infra/api/gr_nexthop.h
+++ b/modules/infra/api/gr_nexthop.h
@@ -111,13 +111,31 @@ typedef enum : uint8_t {
 	GR_RT_ORIGIN_BOOT = 3, //!< Installed at boot?? (NH_ORIGIN_BOOT).
 	GR_RT_ORIGIN_USER = 4, //!< Installed explicitly by user (NH_ORIGIN_STATIC).
 	// Values 5 to 254 are allowed and are used by routing daemons.
+	GR_RT_ORIGIN_GATED = 8, // (RTPROT_GATED)
+	GR_RT_ORIGIN_RA = 9, // (RTPROT_RA)
+	GR_RT_ORIGIN_MRT = 10, // (RTPROT_MRT)
+	GR_RT_ORIGIN_ZEBRA = 11, // (RTPROT_ZEBRA)
+	GR_RT_ORIGIN_BIRD = 12, // (RTPROT_BIRD)
+	GR_RT_ORIGIN_DNROUTED = 13, // (RTPROT_DNROUTED)
+	GR_RT_ORIGIN_XORP = 14, // (RTPROT_XORP)
+	GR_RT_ORIGIN_NTK = 15, // (RTPROT_NTK)
+	GR_RT_ORIGIN_DHCP = 16, // (RTPROT_DHCP)
+	GR_RT_ORIGIN_MROUTED = 17, // (RTPROT_MROUTED)
+	GR_RT_ORIGIN_KEEPALIVED = 18, // (RTPROT_KEEPALIVED)
+	GR_RT_ORIGIN_BABEL = 42, // (RTPROT_BABEL)
+	GR_RT_ORIGIN_OPENR = 99, // (RTPROT_OPENR)
+	GR_RT_ORIGIN_BGP = 186, // (RTPROT_BGP)
+	GR_RT_ORIGIN_ISIS = 187, // (RTPROT_ISIS)
+	GR_RT_ORIGIN_OSPF = 188, // (RTPROT_OSPF)
+	GR_RT_ORIGIN_RIP = 189, // (RTPROT_RIP)
+	GR_RT_ORIGIN_EIGRP = 192, // (RTPROT_EIGRP)
 	GR_RT_ORIGIN_INTERNAL = 255, //!< Reserved for internal use by grout.
 } gr_rt_origin_t;
 
 static inline const char *gr_rt_origin_name(gr_rt_origin_t origin) {
 	switch (origin) {
 	case GR_RT_ORIGIN_UNSPEC:
-		return "unspec";
+		return "";
 	case GR_RT_ORIGIN_REDIRECT:
 		return "redirect";
 	case GR_RT_ORIGIN_LINK:
@@ -126,6 +144,42 @@ static inline const char *gr_rt_origin_name(gr_rt_origin_t origin) {
 		return "boot";
 	case GR_RT_ORIGIN_USER:
 		return "user";
+	case GR_RT_ORIGIN_GATED:
+		return "gated";
+	case GR_RT_ORIGIN_RA:
+		return "ra";
+	case GR_RT_ORIGIN_MRT:
+		return "mrt";
+	case GR_RT_ORIGIN_ZEBRA:
+		return "zebra";
+	case GR_RT_ORIGIN_BIRD:
+		return "bird";
+	case GR_RT_ORIGIN_DNROUTED:
+		return "dnrouted";
+	case GR_RT_ORIGIN_XORP:
+		return "xorp";
+	case GR_RT_ORIGIN_NTK:
+		return "ntk";
+	case GR_RT_ORIGIN_DHCP:
+		return "dhcp";
+	case GR_RT_ORIGIN_MROUTED:
+		return "mrouted";
+	case GR_RT_ORIGIN_KEEPALIVED:
+		return "keepalived";
+	case GR_RT_ORIGIN_BABEL:
+		return "babel";
+	case GR_RT_ORIGIN_OPENR:
+		return "openr";
+	case GR_RT_ORIGIN_BGP:
+		return "bgp";
+	case GR_RT_ORIGIN_ISIS:
+		return "isis";
+	case GR_RT_ORIGIN_OSPF:
+		return "ospf";
+	case GR_RT_ORIGIN_RIP:
+		return "rip";
+	case GR_RT_ORIGIN_EIGRP:
+		return "eigrp";
 	case GR_RT_ORIGIN_INTERNAL:
 		return "INTERNAL";
 	}


### PR DESCRIPTION
These values were taken from Linux. We only need them for display purposes in the CLI.

Link: https://github.com/torvalds/linux/blob/v6.14/include/uapi/linux/rtnetlink.h#L298-L315