### PR TITLE
port: allow attaching already probed devices

### DIFF
--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -326,21 +326,31 @@ static int iface_port_init(struct iface *iface, const void *api_info) {
 	const struct gr_iface_info_port *api = api_info;
 	uint16_t port_id = RTE_MAX_ETHPORTS;
 	struct rte_dev_iterator iterator;
+	const struct iface *i;
 	struct gr_iface conf;
 	int ret;
 
-	RTE_ETH_FOREACH_MATCHING_DEV(port_id, api->devargs, &iterator) {
-		rte_eth_iterator_cleanup(&iterator);
-		return errno_set(EEXIST);
+	i = NULL;
+	while ((i = iface_next(GR_IFACE_TYPE_PORT, i)) != NULL) {
+		const struct iface_info_port *p = (const struct iface_info_port *)i->info;
+		if (strncmp(p->devargs, api->devargs, sizeof(api->devargs)) == 0)
+			return errno_set(EEXIST);
 	}
-
-	if ((ret = rte_dev_probe(api->devargs)) < 0)
-		return errno_set(-ret);
 
 	RTE_ETH_FOREACH_MATCHING_DEV(port_id, api->devargs, &iterator) {
 		rte_eth_iterator_cleanup(&iterator);
 		break;
 	}
+
+	if (!rte_eth_dev_is_valid_port(port_id)) {
+		if ((ret = rte_dev_probe(api->devargs)) < 0)
+			return errno_set(-ret);
+		RTE_ETH_FOREACH_MATCHING_DEV(port_id, api->devargs, &iterator) {
+			rte_eth_iterator_cleanup(&iterator);
+			break;
+		}
+	}
+
 	if (!rte_eth_dev_is_valid_port(port_id))
 		return errno_set(EIDRM);
 


### PR DESCRIPTION
At startup, we pass -a 0000:00:00.0 to rte_eal_init() to disable automatic PCI probing. However, this only affects the PCI bus devices. Other buses (e.g. FSMLC) are not affected by this argument and are always probed in rte_eal_init().

When configuring a port with such a device, we get an error from the API saying that the port is already attached to another interface:

	grout# add interface port dpni2 devargs fslmc:dpni.2
	error: File exists

Instead of iterating over the DPDK probed devices, look at grout ports to determine whether a port matching this devargs value is already configured.

If we cannot find one, check if the device has already been probed and only probe it if it was not.