### PR TITLE
port: avoid truncating link speed values above 64gb/s

### DIFF
--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -90,7 +90,7 @@ struct __gr_iface_info_port_base {
 	uint16_t n_txq;
 	uint16_t rxq_size;
 	uint16_t txq_size;
-	uint16_t link_speed; //!< Physical link speed in Megabit/sec.
+	uint32_t link_speed; //!< Physical link speed in Megabit/sec.
 	struct rte_ether_addr mac;
 };
 

--- a/modules/infra/cli/port.c
+++ b/modules/infra/cli/port.c
@@ -21,7 +21,7 @@ static void port_show(const struct gr_api_client *c, const struct gr_iface *ifac
 	printf("devargs: %s\n", port->devargs);
 	printf("driver:  %s\n", port->driver_name);
 	printf("mac: " ETH_F "\n", &port->mac);
-	if (port->link_speed == UINT16_MAX)
+	if (port->link_speed == UINT32_MAX)
 		printf("speed: unknown\n");
 	else
 		printf("speed: %u Mb/s\n", port->link_speed);

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -605,7 +605,7 @@ static void link_event_cb(evutil_socket_t, short /*what*/, void * /*priv*/) {
 				LOG(WARNING, "rte_eth_link_get_nowait: %s", strerror(rte_errno));
 				continue;
 			}
-			port->link_speed = (uint16_t)link.link_speed;
+			port->link_speed = link.link_speed;
 
 			if (link.link_status == RTE_ETH_LINK_UP) {
 				if (!(iface->state & GR_IFACE_S_RUNNING)) {


### PR DESCRIPTION
Ports with higher speeds (100gb/s and 400gb/s) are not represented in the API. The field is only a 16bit wide integer. These values are truncated.

Change the field to use 32 bits as it is in the DPDK API.

Fixes: 5a25e184cb1d ("port: expose link_speed to the api")