### PR TITLE
iface: use base structures for copying to api

### DIFF
--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -559,12 +559,8 @@ static void port_to_api(void *info, const struct iface *iface) {
 	struct gr_iface_info_port *api = info;
 	struct rte_eth_dev_info dev_info;
 
+	api->base = port->base;
 	memccpy(api->devargs, port->devargs, 0, sizeof(api->devargs));
-	api->mac = port->mac;
-	api->n_rxq = port->n_rxq;
-	api->n_txq = port->n_txq;
-	api->rxq_size = port->rxq_size;
-	api->txq_size = port->txq_size;
 
 	if (rte_eth_dev_info_get(port->port_id, &dev_info) == 0) {
 		memccpy(api->driver_name, dev_info.driver_name, 0, sizeof(api->driver_name));

--- a/modules/infra/control/vlan.c
+++ b/modules/infra/control/vlan.c
@@ -218,9 +218,7 @@ static void vlan_to_api(void *info, const struct iface *iface) {
 	const struct iface_info_vlan *vlan = (const struct iface_info_vlan *)iface->info;
 	struct gr_iface_info_vlan *api = info;
 
-	api->parent_id = vlan->parent_id;
-	api->vlan_id = vlan->vlan_id;
-	api->mac = vlan->mac;
+	*api = vlan->base;
 }
 
 static struct iface_type iface_type_vlan = {

--- a/modules/ipip/control.c
+++ b/modules/ipip/control.c
@@ -120,8 +120,7 @@ static void ipip_to_api(void *info, const struct iface *iface) {
 	const struct iface_info_ipip *ipip = (const struct iface_info_ipip *)iface->info;
 	struct gr_iface_info_ipip *api = info;
 
-	api->local = ipip->local;
-	api->remote = ipip->remote;
+	*api = ipip->base;
 }
 
 static struct iface_type iface_type_ipip = {


### PR DESCRIPTION
There is no need to copy individual fields. Use the base structures to copy common fields from the internal and public API messages.

Fixes: c5f94a9386ae ("iface: reuse public structures")