### PR TITLE
cli: autocomplete support on fslmc CPUs (QorIQ)

### DIFF
--- a/docs/grcli.1.md
+++ b/docs/grcli.1.md
@@ -48,6 +48,17 @@ Print version and exit.
 
 Print executed commands.
 
+# ENVIRONMENT
+
+#### **DPRC**
+
+Set the DPRC - Datapath Resource Container: This value should match the
+one used by DPDK during the scan of the fslmc bus. It is recommended to
+set this on any NXP QorIQ targets. This serves as the entry point for
+grcli to enable autocompletion of fslmc devices manageable by grout.
+While grcli can configure grout without this environment setting,
+autocompletion of the devargs will not be available.
+
 # SEE ALSO
 
 **grout**(8)


### PR DESCRIPTION
Add support for parsing and adding to the autocomplete the contents of the fslmc bus (for example for a LX2160 QorIQ CPU).

Example:
```
 grout# add interface port dpni.2 devargs <?>
 fslmc:dpni.2       net_null           net_tap            net_tun
 net_vhost          net_virtio_user
 grout# add interface port dpni.2 devargs f<tab>
 grout# add interface port dpni.2 devargs fslmc:dpni.2
```

The bus cases (PCI, fslmc, vdev) have not been redesigned.