### PR TITLE
dpaa2: do not close devices

### DIFF
--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -307,10 +307,15 @@ static int iface_port_fini(struct iface *iface) {
 		LOG(ERR, "rte_eth_dev_info_get: %s", rte_strerror(-ret));
 	if ((ret = rte_eth_dev_stop(port->port_id)) < 0)
 		LOG(ERR, "rte_eth_dev_stop: %s", rte_strerror(-ret));
+	// XXX DPDK bus/fslmc VFIO constraint for dpaa2
+	if (strcmp(info.driver_name, "net_dpaa2") == 0)
+		goto fini;
 	if ((ret = rte_eth_dev_close(port->port_id)) < 0)
 		LOG(ERR, "rte_eth_dev_close: %s", rte_strerror(-ret));
 	if (info.device != NULL && (ret = rte_dev_remove(info.device)) < 0)
 		LOG(ERR, "rte_dev_remove: %s", rte_strerror(-ret));
+
+fini:
 	if (port->pool != NULL) {
 		gr_pktmbuf_pool_release(port->pool, port->pool_size);
 		port->pool = NULL;


### PR DESCRIPTION
The dpaa2 devices do not support close/re-open with the current DPDK. Let's work around this limitation for the time being.

Fix:
```
 grout# add interface port dpni.2 devargs fslmc:dpni.2 up mode l3
 Created interface 1
 grout# del interface dpni.2
 grout# add interface port dpni.2 devargs fslmc:dpni.2 up mode l3
 error: command failed: Identifier removed
```

Fixes: 9ca93361aea1 ("port: allow attaching already probed device")