### PR TITLE
graph: enforce early node register

### DIFF
--- a/modules/infra/control/graph.c
+++ b/modules/infra/control/graph.c
@@ -338,6 +338,7 @@ static void graph_fini(struct event_base *) {
 static struct gr_module graph_module = {
 	.name = "graph",
 	.init = graph_init,
+	.init_prio = -999,
 	.fini = graph_fini,
 	.fini_prio = -999,
 };


### PR DESCRIPTION
At initialization, grout modules are ordered by their init_prio value. The default value is 0 unless overridden. At the moment, no module specifies its init_prio so they are all "equal". The order in which modules are initialized is therefore decided at link time and is non-deterministic.

Since commit a610da9bdaa9 ("infra: add generic ctrlplane to dataplane node"), gr_control_input_register_handler can be called by any module to register a children node after "control_input". Unfortunately, this function needs the "control_input" node to have been registered first which is only done when the "graph" module is initialized.

Depending on the link time ordering of `__attribute__((constructor))` functions, we may see grout crash on startup as follows:

 DEBUG: GROUT: modules_init: srv6_headend prio 0
 DEBUG: GROUT: modules_init: srv6_local prio 0
 DEBUG: GROUT: modules_init: ipip prio 0
 DEBUG: GROUT: modules_init: fib6 prio 0
 DEBUG: GROUT: modules_init: icmp6 prio 0
 DEBUG: GROUT: modules_init: ipv6 router advertisement prio 0
 DEBUG: GROUT: gr_control_input_register_handler: control_input: type=0 -> ip6_output
 EMERG: GROUT: gr_node_attach_parent: 'control_input' parent node not found

The "graph" module was not registered yet, and therefore, no "control_input" node exists.

Set an init_prio value for the graph module to be -999 to ensure it will be done first, regardless of the link time ordering of object files.

Reported-by: Christophe Fontaine <cfontain@redhat.com>