### PR TITLE
main: use locale from environment

### DIFF
--- a/api/gr_string.h
+++ b/api/gr_string.h
@@ -9,7 +9,7 @@
 
 char *astrcat(char *buf, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 char *strjoin(char **array, size_t len, const char *sep);
-int utf8_check(const char *buf, size_t maxlen);
+int charset_check(const char *buf, size_t maxlen);
 
 // Return human readable representation of a cpuset. The output format is
 // a list of CPUs with ranges (for example, "0,1,3-9").

--- a/api/string.c
+++ b/api/string.c
@@ -65,7 +65,7 @@ char *strjoin(char **array, size_t len, const char *sep) {
 	return out;
 }
 
-int utf8_check(const char *buf, size_t maxlen) {
+int charset_check(const char *buf, size_t maxlen) {
 	mbstate_t mb;
 	size_t len;
 

--- a/main/main.c
+++ b/main/main.c
@@ -240,8 +240,8 @@ int main(int argc, char **argv) {
 	int ret = EXIT_FAILURE;
 	int err = 0;
 
-	if (setlocale(LC_CTYPE, "C.UTF-8") == NULL) {
-		perror("setlocale(LC_CTYPE, C.UTF-8)");
+	if (setlocale(LC_ALL, "") == NULL) {
+		perror("setlocale(LC_ALL)");
 		goto end;
 	}
 	if (evthread_use_pthreads() < 0) {

--- a/modules/infra/control/iface.c
+++ b/modules/infra/control/iface.c
@@ -58,7 +58,7 @@ struct iface *iface_create(const struct gr_iface *conf, const void *api_info) {
 
 	if (type == NULL)
 		goto fail;
-	if (utf8_check(conf->name, GR_IFACE_NAME_SIZE) < 0)
+	if (charset_check(conf->name, GR_IFACE_NAME_SIZE) < 0)
 		goto fail;
 	while ((iface = iface_next(GR_IFACE_TYPE_UNDEF, iface)) != NULL) {
 		if (strcmp(conf->name, iface->name) == 0) {
@@ -112,7 +112,7 @@ int iface_reconfig(
 	if ((iface = iface_from_id(ifid)) == NULL)
 		return -errno;
 	if (set_attrs & GR_IFACE_SET_NAME) {
-		if (utf8_check(conf->name, GR_IFACE_NAME_SIZE) < 0)
+		if (charset_check(conf->name, GR_IFACE_NAME_SIZE) < 0)
 			return -errno;
 
 		const struct iface *i = NULL;


### PR DESCRIPTION
Change explicit setlocale(LC_CTYPE, "C.UTF-8") to setlocale(LC_ALL, "") to initialize the wide char encoding to whatever locale is enabled in the environment.

Rename utf8_check to charset_check to avoid confusion since the encoding may now be a non-UTF-8 charset.