### PR TITLE
treewide: fix clang-format errors with 20.1.5

### DIFF
--- a/modules/ip6/datapath/ip6_input.c
+++ b/modules/ip6/datapath/ip6_input.c
@@ -231,8 +231,10 @@ static void ip6_input_invalid_src_mcast_addr(void **) {
 
 	ipv6_init_default_mbuf(&fake_mbuf);
 
-	fake_mbuf.ipv6_hdr.src_addr = (struct rte_ipv6_addr
-	)RTE_IPV6(0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff);
+	// clang-format off
+	fake_mbuf.ipv6_hdr.src_addr = (struct rte_ipv6_addr)
+		RTE_IPV6(0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff);
+	// clang-format on
 	expect_value(rte_node_enqueue_x1, next, BAD_ADDR);
 	ip6_input_process(NULL, NULL, &obj, 1);
 }
@@ -243,8 +245,10 @@ static void ip6_input_invalid_dst_unspec_addr(void **) {
 
 	ipv6_init_default_mbuf(&fake_mbuf);
 
-	fake_mbuf.ipv6_hdr.dst_addr = (struct rte_ipv6_addr
-	)RTE_IPV6(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0);
+	// clang-format off
+	fake_mbuf.ipv6_hdr.dst_addr = (struct rte_ipv6_addr)
+		RTE_IPV6(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0);
+	// clang-format on
 	expect_value(rte_node_enqueue_x1, next, BAD_ADDR);
 	ip6_input_process(NULL, NULL, &obj, 1);
 }
@@ -256,14 +260,18 @@ static void ip6_input_invalid_dst_mcast_addr(void **) {
 	ipv6_init_default_mbuf(&fake_mbuf);
 
 	// Multicast scope none
-	fake_mbuf.ipv6_hdr.dst_addr = (struct rte_ipv6_addr
-	)RTE_IPV6(0xff00, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1);
+	// clang-format off
+	fake_mbuf.ipv6_hdr.dst_addr = (struct rte_ipv6_addr)
+		RTE_IPV6(0xff00, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1);
+	// clang-format on
 	expect_value(rte_node_enqueue_x1, next, BAD_ADDR);
 	ip6_input_process(NULL, NULL, &obj, 1);
 
 	// Multicast iface local
-	fake_mbuf.ipv6_hdr.dst_addr = (struct rte_ipv6_addr
-	)RTE_IPV6(0xff00, 0x01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1);
+	// clang-format off
+	fake_mbuf.ipv6_hdr.dst_addr = (struct rte_ipv6_addr)
+		RTE_IPV6(0xff00, 0x01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1);
+	// clang-format on
 	expect_value(rte_node_enqueue_x1, next, BAD_ADDR);
 	ip6_input_process(NULL, NULL, &obj, 1);
 }

--- a/modules/ip6/datapath/ip6_output.c
+++ b/modules/ip6/datapath/ip6_output.c
@@ -90,13 +90,15 @@ ip6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 		if (edge != ETH_OUTPUT)
 			goto next;
 
+		// clang-format off
 		if (!rte_ipv6_addr_is_mcast(&ip->dst_addr)
 		    && (!(nh->flags & GR_NH_F_REACHABLE)
-			|| (nh->flags & GR_NH_F_LINK && !rte_ipv6_addr_eq(&ip->dst_addr, &nh->ipv6))
-		    )) {
+			|| (nh->flags & GR_NH_F_LINK
+			    && !rte_ipv6_addr_eq(&ip->dst_addr, &nh->ipv6)))) {
 			edge = HOLD;
 			goto next;
 		}
+		// clang-format on
 
 		// Prepare ethernet layer info.
 		eth_data = eth_output_mbuf_data(mbuf);

--- a/modules/srv6/control_headend.c
+++ b/modules/srv6/control_headend.c
@@ -381,8 +381,10 @@ static struct api_out srv6_steer_list(const void *request, void **response) {
 		if (req->vrf_id == UINT16_MAX || req->vrf_id == nh->vrf_id) {
 			gr_vec_add(nh_list, nh);
 			gr_vec_add(d_listlist, data_ptr);
-			len += sizeof(struct gr_srv6_steer_entry
-			       ) + gr_vec_len(d_list) * sizeof(struct rte_ipv6_addr);
+			// clang-format off
+			len += sizeof(struct gr_srv6_steer_entry)
+				+ gr_vec_len(d_list) * sizeof(struct rte_ipv6_addr);
+			// clang-format on
 		}
 	}
 	if ((resp = calloc(1, len)) == NULL) {


### PR DESCRIPTION
Since clang-format 20.1.5, some inconsistencies have been fixed and poorly formatted code is now triggering lint errors.

Fix the formatting and guard the code with clang-format off/on comments to prevent issues with older versions.

Link: https://github.com/llvm/llvm-project/commit/e7ae5532bc27
Link: https://github.com/llvm/llvm-project/issues/135977