### PR TITLE
cli: use locale from environment

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -130,8 +130,8 @@ int main(int argc, char **argv) {
 	int ret, c;
 
 	ret = EXIT_FAILURE;
-	if (setlocale(LC_CTYPE, "C.UTF-8") == NULL) {
-		perror("setlocale(LC_CTYPE, C.UTF-8)");
+	if (setlocale(LC_ALL, "") == NULL) {
+		perror("setlocale(LC_ALL)");
 		goto end;
 	}
 	tty_init();


### PR DESCRIPTION
setlocale(LC_CTYPE, "C.UTF-8") has been replaced setlocale(LC_ALL, "") for grout, but not for grcli. Let's fix it.

Fixes: 66e067f91e57 ("main: use locale from environment")