### PR TITLE
infra: export interface statistics through DPDK telemetry socket

### DIFF
--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -309,4 +309,36 @@ struct gr_infra_cpu_affinity_set_req {
 
 // struct gr_infra_cpu_affinity_set_resp { };
 
+// Helper function to convert iface type enum to string
+static inline const char *iface_type_to_str(gr_iface_type_t type) {
+	switch (type) {
+	case GR_IFACE_TYPE_UNDEF:
+		return "undef";
+	case GR_IFACE_TYPE_LOOPBACK:
+		return "loopback";
+	case GR_IFACE_TYPE_PORT:
+		return "port";
+	case GR_IFACE_TYPE_VLAN:
+		return "vlan";
+	case GR_IFACE_TYPE_IPIP:
+		return "ipip";
+	case GR_IFACE_TYPE_COUNT:
+		break;
+	}
+	return "?";
+}
+
+// Helper function to convert iface mode enum to string
+static inline const char *iface_mode_to_str(gr_iface_mode_t mode) {
+	switch (mode) {
+	case GR_IFACE_MODE_L3:
+		return "l3";
+	case GR_IFACE_MODE_L1_XC:
+		return "l1-xc";
+	case GR_IFACE_MODE_COUNT:
+		break;
+	}
+	return "?";
+}
+
 #endif

--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -195,6 +195,23 @@ struct gr_infra_iface_set_req {
 
 // struct gr_infra_iface_set_resp { };
 
+#define GR_INFRA_IFACE_STATS_GET REQUEST_TYPE(GR_INFRA_MODULE, 0x0006)
+
+// struct gr_infra_iface_stats_get_req { };
+
+struct gr_iface_stats {
+	uint16_t iface_id;
+	uint64_t rx_packets;
+	uint64_t rx_bytes;
+	uint64_t tx_packets;
+	uint64_t tx_bytes;
+};
+
+struct gr_infra_iface_stats_get_resp {
+	uint16_t n_stats;
+	struct gr_iface_stats stats[/* n_stats */];
+};
+
 // port rxqs ///////////////////////////////////////////////////////////////////
 #define GR_INFRA_RXQ_LIST REQUEST_TYPE(GR_INFRA_MODULE, 0x0010)
 

--- a/modules/infra/cli/iface.c
+++ b/modules/infra/cli/iface.c
@@ -327,12 +327,75 @@ err:
 	return CMD_ERROR;
 }
 
+static cmd_status_t iface_stats(const struct gr_api_client *c, const struct ec_pnode * /*p*/) {
+	struct gr_infra_iface_stats_get_resp *resp = NULL;
+	struct libscols_table *table = NULL;
+	cmd_status_t status = CMD_ERROR;
+	void *resp_ptr = NULL;
+	int ret;
+
+	// Send the new API request and wait for the response
+	ret = gr_api_client_send_recv(c, GR_INFRA_IFACE_STATS_GET, 0, NULL, &resp_ptr);
+	if (ret < 0) {
+		errorf("failed to get interface stats: %s", strerror(-ret));
+		goto end;
+	}
+
+	resp = resp_ptr;
+
+	table = scols_new_table();
+	if (table == NULL) {
+		errorf("failed to create table: %s", strerror(errno));
+		goto end;
+	}
+
+	scols_table_new_column(table, "INTERFACE", 0, 0);
+	scols_table_new_column(table, "RX_PACKETS", SCOLS_FL_RIGHT, 0);
+	scols_table_new_column(table, "RX_BYTES", SCOLS_FL_RIGHT, 0);
+	scols_table_new_column(table, "TX_PACKETS", SCOLS_FL_RIGHT, 0);
+	scols_table_new_column(table, "TX_BYTES", SCOLS_FL_RIGHT, 0);
+	scols_table_set_column_separator(table, "  ");
+
+	for (uint16_t i = 0; i < resp->n_stats; i++) {
+		struct libscols_line *line = scols_table_new_line(table, NULL);
+		struct gr_iface iface;
+		if (line == NULL) {
+			errorf("failed to create line: %s", strerror(errno));
+			goto end;
+		}
+
+		if (iface_from_id(c, resp->stats[i].iface_id, &iface) == 0)
+			scols_line_set_data(line, 0, iface.name);
+		else
+			scols_line_set_data(line, 0, "?");
+
+		scols_line_sprintf(line, 1, "%lu", resp->stats[i].rx_packets);
+		scols_line_sprintf(line, 2, "%lu", resp->stats[i].rx_bytes);
+		scols_line_sprintf(line, 3, "%lu", resp->stats[i].tx_packets);
+		scols_line_sprintf(line, 4, "%lu", resp->stats[i].tx_bytes);
+	}
+
+	scols_print_table(table);
+	status = CMD_SUCCESS;
+
+end:
+	if (table)
+		scols_unref_table(table);
+	free(resp_ptr);
+	return status;
+}
+
 static cmd_status_t iface_show(const struct gr_api_client *c, const struct ec_pnode *p) {
 	const struct cli_iface_type *type;
 	struct gr_iface iface;
 
-	if (arg_str(p, "NAME") == NULL || arg_str(p, "TYPE") != NULL)
+	if (arg_str(p, "stats") != NULL) {
+		return iface_stats(c, p);
+	}
+
+	if (arg_str(p, "NAME") == NULL || arg_str(p, "TYPE") != NULL) {
 		return iface_list(c, p);
+	}
 
 	if (iface_from_name(c, arg_str(p, "NAME"), &iface) < 0)
 		return CMD_ERROR;
@@ -385,7 +448,7 @@ static int ctx_init(struct ec_node *root) {
 		return ret;
 	ret = CLI_COMMAND(
 		CLI_CONTEXT(root, CTX_SHOW, CTX_ARG("interface", "Display interface details.")),
-		"[(name NAME)|(type TYPE)]",
+		"[(name NAME)|(type TYPE)|stats]",
 		iface_show,
 		"Show interface details.",
 		with_help(
@@ -395,7 +458,8 @@ static int ctx_init(struct ec_node *root) {
 		with_help(
 			"Show only this type of interface.",
 			ec_node_dyn("TYPE", complete_iface_types, NULL)
-		)
+		),
+		with_help("Show interface statistics.", ec_node_str("stats", "stats"))
 	);
 
 	return ret;

--- a/modules/infra/control/gr_iface.h
+++ b/modules/infra/control/gr_iface.h
@@ -72,6 +72,15 @@ struct iface *get_vrf_iface(uint16_t vrf_id);
 struct iface *iface_loopback_create(uint16_t vrf_id);
 int iface_loopback_delete(uint16_t vrf_id);
 
+struct __rte_cache_aligned iface_stats {
+	uint64_t rx_packets[RTE_MAX_LCORE];
+	uint64_t rx_bytes[RTE_MAX_LCORE];
+	uint64_t tx_packets[RTE_MAX_LCORE];
+	uint64_t tx_bytes[RTE_MAX_LCORE];
+};
+
+struct iface_stats *iface_get_stats(uint16_t ifid);
+
 #define MAX_IFACES 1024
 #define MAX_VRFS 256
 

--- a/modules/infra/control/iface.c
+++ b/modules/infra/control/iface.c
@@ -21,6 +21,8 @@
 
 static STAILQ_HEAD(, iface_type) types = STAILQ_HEAD_INITIALIZER(types);
 
+static struct iface_stats stats[MAX_IFACES];
+
 struct iface_type *iface_type_get(gr_iface_type_t type_id) {
 	struct iface_type *t;
 	STAILQ_FOREACH (t, &types, next)
@@ -89,6 +91,8 @@ struct iface *iface_create(const struct gr_iface *conf, const void *api_info) {
 		goto fail;
 
 	ifaces[ifid] = iface;
+
+	memset(&stats[ifid], 0, sizeof(stats[ifid]));
 
 	gr_event_push(GR_EVENT_IFACE_POST_ADD, iface);
 
@@ -170,6 +174,10 @@ struct iface *iface_from_id(uint16_t ifid) {
 	if (iface == NULL)
 		errno = ENODEV;
 	return iface;
+}
+
+struct iface_stats *iface_get_stats(uint16_t ifid) {
+	return &stats[ifid];
 }
 
 int iface_get_eth_addr(uint16_t ifid, struct rte_ether_addr *mac) {

--- a/modules/infra/datapath/eth_input.c
+++ b/modules/infra/datapath/eth_input.c
@@ -84,6 +84,11 @@ eth_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 			}
 			iface = eth_in->iface;
 		}
+
+		struct iface_stats *stats = iface_get_stats(eth_in->iface->id);
+		stats->rx_packets[rte_lcore_id()] += 1;
+		stats->rx_bytes[rte_lcore_id()] += rte_pktmbuf_pkt_len(m);
+
 		if (unlikely(rte_is_multicast_ether_addr(&eth->dst_addr))) {
 			if (rte_is_broadcast_ether_addr(&eth->dst_addr))
 				eth_in->domain = ETH_DOMAIN_BROADCAST;

--- a/modules/infra/datapath/l1_xconnect.c
+++ b/modules/infra/datapath/l1_xconnect.c
@@ -28,10 +28,19 @@ l1_xconnect_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 		mbuf = objs[i];
 		iface = mbuf_data(mbuf)->iface;
 		peer = iface_from_id(iface->domain_id);
+
+		struct iface_stats *rx_stats = iface_get_stats(iface->id);
+		rx_stats->rx_packets[rte_lcore_id()]++;
+		rx_stats->rx_bytes[rte_lcore_id()] += rte_pktmbuf_pkt_len(mbuf);
+
 		if (peer->type == GR_IFACE_TYPE_PORT) {
 			port = (const struct iface_info_port *)peer->info;
 			mbuf->port = port->port_id;
 			edge = TX;
+
+			struct iface_stats *tx_stats = iface_get_stats(peer->id);
+			tx_stats->tx_packets[rte_lcore_id()]++;
+			tx_stats->tx_bytes[rte_lcore_id()] += rte_pktmbuf_pkt_len(mbuf);
 		} else {
 			edge = NO_PORT;
 		}

--- a/modules/ipip/datapath_in.c
+++ b/modules/ipip/datapath_in.c
@@ -35,8 +35,9 @@ ipip_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 	struct eth_input_mbuf_data *eth_data;
 	struct ip_local_mbuf_data *ip_data;
 	ip4_addr_t last_src, last_dst;
-	uint16_t last_vrf_id;
+	struct iface_stats *stats;
 	struct rte_mbuf *mbuf;
+	uint16_t last_vrf_id;
 	struct iface *ipip;
 	rte_edge_t edge;
 
@@ -67,6 +68,9 @@ ipip_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 		eth_data->iface = ipip;
 		eth_data->domain = ETH_DOMAIN_LOCAL;
 		edge = IP_INPUT;
+		stats = iface_get_stats(ipip->id);
+		stats->rx_packets[rte_lcore_id()] += 1;
+		stats->rx_bytes[rte_lcore_id()] += rte_pktmbuf_pkt_len(mbuf);
 next:
 		if (gr_mbuf_is_traced(mbuf) || (ipip && ipip->flags & GR_IFACE_F_PACKET_TRACE)) {
 			struct trace_ipip_data *t = gr_mbuf_trace_add(mbuf, node, sizeof(*t));

--- a/modules/ipip/datapath_out.c
+++ b/modules/ipip/datapath_out.c
@@ -69,6 +69,10 @@ ipip_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 		}
 		ip_set_fields(outer, &tunnel);
 
+		struct iface_stats *stats = iface_get_stats(iface->id);
+		stats->tx_packets[rte_lcore_id()] += 1;
+		stats->tx_bytes[rte_lcore_id()] += rte_pktmbuf_pkt_len(mbuf);
+
 		// Resolve nexthop for the encapsulated packet.
 		ip_data->nh = fib4_lookup(iface->vrf_id, ipip->remote);
 		edge = IP_OUTPUT;


### PR DESCRIPTION
- Implement per interface statistics
- Export them via DPDK telemetry socket
- Export them via grcli with `show interface stats`
- Implement clear stats with `clear stats`
