### PR TITLE
stats: fix reset when workers are sleeping

### DIFF
--- a/modules/infra/api/stats.c
+++ b/modules/infra/api/stats.c
@@ -196,8 +196,10 @@ static struct api_out stats_reset(const void * /*request*/, void ** /*response*/
 	struct iface *iface;
 	int ret;
 
-	STAILQ_FOREACH (worker, &workers, next)
+	STAILQ_FOREACH (worker, &workers, next) {
 		atomic_store(&worker->stats_reset, true);
+		worker_signal_ready(worker);
+	}
 
 	iface = NULL;
 	while ((iface = iface_next(GR_IFACE_TYPE_PORT, iface)) != NULL) {

--- a/modules/infra/datapath/main_loop.c
+++ b/modules/infra/datapath/main_loop.c
@@ -166,6 +166,8 @@ reconfig:
 
 	if (graph == NULL) {
 		worker_wait_ready(w);
+		if (ctx.w_stats != NULL && atomic_exchange(&w->stats_reset, false))
+			stats_reset(ctx.w_stats);
 		goto reconfig;
 	}
 


### PR DESCRIPTION
Since commit 480f653f57e2 ("worker: keep threads running all the time"), workers are no longer destroyed when not assigned any interfaces.

Make sure to wake up sleeping workers so that they reset their own statistics.

Fixes: 480f653f57e2 ("worker: keep threads running all the time")