### PR TITLE
nh: cleanup on interface deletion

### DIFF
--- a/modules/infra/control/gr_nh_control.h
+++ b/modules/infra/control/gr_nh_control.h
@@ -46,6 +46,9 @@ bool nexthop_equal(const struct nexthop *, const struct nexthop *);
 struct nexthop *
 nexthop_new(gr_nh_type_t type, uint16_t vrf_id, uint16_t iface_id, const void *addr);
 
+// Clean all next hop related to an interface.
+void nexthop_cleanup(uint16_t iface_id);
+
 // Increment the reference counter of a nexthop.
 void nexthop_incref(struct nexthop *);
 

--- a/modules/infra/control/iface.c
+++ b/modules/infra/control/iface.c
@@ -6,6 +6,7 @@
 #include <gr_log.h>
 #include <gr_macro.h>
 #include <gr_module.h>
+#include <gr_nh_control.h>
 #include <gr_rcu.h>
 #include <gr_string.h>
 #include <gr_vec.h>
@@ -251,6 +252,7 @@ int iface_destroy(uint16_t ifid) {
 		gr_event_push(GR_EVENT_IFACE_STATUS_DOWN, iface);
 	}
 	gr_event_push(GR_EVENT_IFACE_PRE_REMOVE, iface);
+	nexthop_cleanup(ifid);
 
 	ifaces[ifid] = NULL;
 


### PR DESCRIPTION
When an interface is removed, associated next hop remains with an unknown interface id:

grout# show ip6 nexthop
VRF  IP                         MAC                IFACE    QUEUE  AGE   STATE
0    fe80::d2f0:cff:feba:a411   d2:f0:0c:ba:a4:11  gmztio1  0      -     reachable static local link
0    fe80::d2f0:cff:feba:a412   d2:f0:0c:ba:a4:12  gmztio2  0      -     reachable static local link
0    fd00:ba4:1::1              d2:f0:0c:ba:a4:11  gmztio1  0      -     reachable static local link
0    fd00:ba4:2::1              d2:f0:0c:ba:a4:12  gmztio2  0      -     reachable static local link
0    fe80::d0ad:caff:feca:a401  d2:ad:ca:ca:a4:01  gmztio1  0      3     reachable
0    fe80::d0ad:caff:feca:a401  d2:ad:ca:ca:a4:01  gmztio2  0      3     reachable

--> remove interfaces gmztio1 and gmztio2

grout# show ip6 nexthop
VRF  IP                         MAC                IFACE  QUEUE  AGE   STATE
0    fe80::d0ad:caff:feca:a401  d2:ad:ca:ca:a4:01  1      0      6     reachable
0    fe80::d0ad:caff:feca:a401  d2:ad:ca:ca:a4:01  3      0      6     reachable
0    fd00:ba4:1::2              d2:ad:ca:ca:a4:01  1      0      2     reachable
0    fd00:ba4:2::2              d2:ad:ca:ca:a4:01  3      0      2     reachable

Then, when an other interface is added, we may abort in modules/ip6/control/nexthop.c:58
    if (remote->iface_id != nh->iface_id)
        ABORT(IP6_F " nexthop lookup gives wrong interface", &ip);

This can be reproduced by running the test smoke/ip6_forward_test.sh several times on the same grout instance.

To avoid this situation, cleanup the nexthops associated to the interface on removal.