### PR TITLE
rx,tx: enable multi segment to support higher mtu

### DIFF
--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -72,7 +72,12 @@ static struct rte_eth_conf default_port_config = {
 		},
 	},
 	.rxmode = {
-		.offloads = RTE_ETH_RX_OFFLOAD_CHECKSUM | RTE_ETH_RX_OFFLOAD_VLAN,
+		.offloads = RTE_ETH_RX_OFFLOAD_CHECKSUM
+			| RTE_ETH_RX_OFFLOAD_VLAN
+			| RTE_ETH_RX_OFFLOAD_SCATTER,
+	},
+	.txmode = {
+		.offloads = RTE_ETH_TX_OFFLOAD_MULTI_SEGS,
 	},
 };
 
@@ -123,6 +128,7 @@ int port_configure(struct iface_info_port *p, uint16_t n_txq_min) {
 	else
 		conf.rxmode.mq_mode = RTE_ETH_MQ_RX_RSS;
 	conf.rxmode.offloads &= info.rx_offload_capa;
+	conf.txmode.offloads &= info.tx_offload_capa;
 	if (info.dev_flags != NULL && *info.dev_flags & RTE_ETH_DEV_INTR_LSC) {
 		conf.intr_conf.lsc = 1;
 	}

--- a/smoke/ip_forward_test.sh
+++ b/smoke/ip_forward_test.sh
@@ -7,8 +7,8 @@
 p0=${run_id}0
 p1=${run_id}1
 
-grcli add interface port $p0 devargs net_tap0,iface=$p0 mac f0:0d:ac:dc:00:00
-grcli add interface port $p1 devargs net_tap1,iface=$p1 mac f0:0d:ac:dc:00:01
+grcli add interface port $p0 devargs net_tap0,iface=$p0 mac f0:0d:ac:dc:00:00 mtu 9000
+grcli add interface port $p1 devargs net_tap1,iface=$p1 mac f0:0d:ac:dc:00:01 mtu 9000
 grcli add ip address 172.16.0.1/24 iface $p0
 grcli add ip address 172.16.1.1/24 iface $p1
 grcli add ip route 16.0.0.0/16 via 172.16.0.2
@@ -19,7 +19,7 @@ for n in 0 1; do
 	p=$run_id$n
 	netns_add $p
 	ip link set $p netns $p
-	ip -n $p link set $p address ba:d0:ca:ca:00:0$n
+	ip -n $p link set $p address ba:d0:ca:ca:00:0$n mtu 9000
 	ip -n $p link set $p up
 	ip -n $p link set lo up
 	ip -n $p addr add 172.16.$n.2/24 dev $p
@@ -28,8 +28,8 @@ for n in 0 1; do
 	ip -n $p addr show
 done
 
-ip netns exec $p0 ping -i0.01 -c3 -n 16.1.0.1
-ip netns exec $p1 ping -i0.01 -c3 -n 16.0.0.1
+ip netns exec $p0 ping -i0.01 -c3 -n 16.1.0.1 -s 5000
+ip netns exec $p1 ping -i0.01 -c3 -n 16.0.0.1 -s 5000
 ip netns exec $p0 ping -i0.01 -c3 -n 172.16.1.2
 ip netns exec $p1 ping -i0.01 -c3 -n 172.16.0.2
 ip netns exec $p0 ping -i0.01 -c3 -n 172.16.0.1


### PR DESCRIPTION
In order to support receiving packets larger than 2048 bytes, we need to enable multi-segment rx and tx offload in the drivers.

Enable RTE_ETH_RX_OFFLOAD_SCATTER and RTE_ETH_TX_OFFLOAD_MULTI_SEGS in the requested offload flags when configuring DPDK ports.

Update the basic IP forward test to check we are indeed receiving 5000 bytes packets with a configured MTU of 9000 bytes.

Suggested-by: David Marchand <david.marchand@redhat.com>