### PR TITLE
Implement statistics collection of routes and nexthops per VRF and expose via telemetry socket

### DIFF
--- a/modules/infra/api/gr_nexthop.h
+++ b/modules/infra/api/gr_nexthop.h
@@ -15,6 +15,7 @@ typedef enum : uint8_t {
 	GR_NH_S_REACHABLE, // Probe reply received
 	GR_NH_S_STALE, // Reachable lifetime expired, need refresh
 	GR_NH_S_FAILED, // All probes sent without reply
+#define _GR_NH_S_COUNT (GR_NH_S_FAILED + 1)
 } gr_nh_state_t;
 
 typedef enum : uint8_t {
@@ -70,6 +71,7 @@ typedef enum : uint8_t {
 	GR_NH_ORIGIN_OPENFABRIC = 197, // (RTPROT_OPENFABIC from zebra)
 	GR_NH_ORIGIN_SRTE = 198, // (RTPROT_SRTE from zebra)
 	GR_NH_ORIGIN_INTERNAL = 255, //!< Reserved for internal use by grout.
+#define _GR_NH_ORIGIN_COUNT (GR_NH_ORIGIN_INTERNAL + 1)
 } gr_nh_origin_t;
 
 #define GR_NH_ID_UNSET UINT32_C(0)

--- a/modules/infra/control/gr_nh_control.h
+++ b/modules/infra/control/gr_nh_control.h
@@ -97,3 +97,15 @@ struct nexthop_type_ops {
 
 void nexthop_type_ops_register(gr_nh_type_t type, const struct nexthop_type_ops *);
 const struct nexthop_type_ops *nexthop_type_ops_get(gr_nh_type_t type);
+
+// Nexthop statistics structure
+struct nh_stats {
+	uint32_t total;
+	uint32_t by_state[_GR_NH_S_COUNT];
+};
+
+// Get nexthop statistics for a given VRF and address family
+const struct nh_stats *nexthop_get_stats(uint16_t vrf_id, addr_family_t af);
+
+// Update nexthop stats when state changes
+void nh_stats_update(struct nexthop *nh, gr_nh_state_t new_state);

--- a/modules/infra/control/nexthop.c
+++ b/modules/infra/control/nexthop.c
@@ -4,6 +4,7 @@
 #include <gr_clock.h>
 #include <gr_event.h>
 #include <gr_id_pool.h>
+#include <gr_iface.h>
 #include <gr_log.h>
 #include <gr_mbuf.h>
 #include <gr_module.h>
@@ -13,6 +14,7 @@
 #include <rte_hash.h>
 #include <rte_malloc.h>
 #include <rte_mempool.h>
+#include <rte_telemetry.h>
 
 #include <stdint.h>
 
@@ -30,6 +32,20 @@ static struct rte_hash *hash_by_id;
 static struct event *ageing_timer;
 static const struct nexthop_af_ops *af_ops[256];
 static const struct nexthop_type_ops *type_ops[256];
+
+static struct nh_stats nh_stats[MAX_VRFS][2]; // [vrf_id][af_index]
+
+static int af_to_index(addr_family_t af) {
+	switch (af) {
+	case GR_AF_IP4:
+		return 0;
+	case GR_AF_IP6:
+		return 1;
+	default:
+		return -1;
+	}
+}
+
 struct gr_nexthop_config nh_conf = {
 	.max_count = DEFAULT_MAX_COUNT,
 	.lifetime_reachable_sec = DEFAULT_LIFETIME_REACHABLE,
@@ -367,6 +383,14 @@ struct nexthop *nexthop_new(const struct gr_nexthop *base) {
 		return errno_set_null(-ret);
 	}
 
+	// Initialize stats for new nexthop
+	int af_index = af_to_index(nh->af);
+	if (af_index >= 0 && nh->vrf_id < MAX_VRFS) {
+		struct nh_stats *stats = &nh_stats[nh->vrf_id][af_index];
+		stats->total++;
+		stats->by_state[GR_NH_S_NEW]++;
+	}
+
 	if (nh->origin != GR_NH_ORIGIN_INTERNAL)
 		gr_event_push(GR_EVENT_NEXTHOP_NEW, nh);
 
@@ -525,6 +549,16 @@ void nexthop_decref(struct nexthop *nh) {
 		if (ops != NULL && ops->free != NULL)
 			ops->free(nh);
 
+		// Update stats for deleted nexthop
+		int af_index = af_to_index(nh->af);
+		if (af_index >= 0 && nh->vrf_id < MAX_VRFS) {
+			struct nh_stats *stats = &nh_stats[nh->vrf_id][af_index];
+			if (nh->state < _GR_NH_S_COUNT && stats->by_state[nh->state] > 0)
+				stats->by_state[nh->state]--;
+			if (stats->total > 0)
+				stats->total--;
+		}
+
 		memset(nh, 0, sizeof(*nh));
 		rte_mempool_put(pool, nh);
 	} else {
@@ -564,6 +598,7 @@ static void nexthop_ageing_cb(struct nexthop *nh, void *) {
 			    nh->held_pkts,
 			    gr_nh_state_name(&nh->base));
 
+			nh_stats_update(nh, GR_NH_S_FAILED);
 			nh->state = GR_NH_S_FAILED;
 		} else {
 			if (ops->solicit(nh) < 0)
@@ -576,8 +611,10 @@ static void nexthop_ageing_cb(struct nexthop *nh, void *) {
 		}
 		break;
 	case GR_NH_S_REACHABLE:
-		if (reply_age > nh_conf.lifetime_reachable_sec)
+		if (reply_age > nh_conf.lifetime_reachable_sec) {
+			nh_stats_update(nh, GR_NH_S_STALE);
 			nh->state = GR_NH_S_STALE;
+		}
 		break;
 	case GR_NH_S_FAILED:
 		break;
@@ -586,6 +623,31 @@ static void nexthop_ageing_cb(struct nexthop *nh, void *) {
 
 static void do_ageing(evutil_socket_t, short /*what*/, void * /*priv*/) {
 	nexthop_iter(nexthop_ageing_cb, NULL);
+}
+
+const struct nh_stats *nexthop_get_stats(uint16_t vrf_id, addr_family_t af) {
+	int af_index = af_to_index(af);
+	if (af_index < 0 || vrf_id >= MAX_VRFS)
+		return NULL;
+	return &nh_stats[vrf_id][af_index];
+}
+
+void nh_stats_update(struct nexthop *nh, gr_nh_state_t new_state) {
+	int af_index = af_to_index(nh->af);
+	if (af_index < 0 || nh->vrf_id >= MAX_VRFS)
+		return;
+
+	struct nh_stats *stats = &nh_stats[nh->vrf_id][af_index];
+
+	if (nh->state != new_state) {
+		// Decrease old state count
+		if (nh->state < _GR_NH_S_COUNT && stats->by_state[nh->state] > 0)
+			stats->by_state[nh->state]--;
+
+		// Increase new state count
+		if (new_state < _GR_NH_S_COUNT)
+			stats->by_state[new_state]++;
+	}
 }
 
 static void nh_init(struct event_base *ev_base) {
@@ -638,6 +700,46 @@ static struct gr_module module = {
 	.fini = nh_fini,
 };
 
+static int
+telemetry_nexthop_stats_get(const char * /*cmd*/, const char * /*params*/, struct rte_tel_data *d) {
+	rte_tel_data_start_dict(d);
+
+	for (uint16_t vrf_id = 0; vrf_id < MAX_VRFS; vrf_id++) {
+		const struct nh_stats *ipv4_stats = nexthop_get_stats(vrf_id, GR_AF_IP4);
+		const struct nh_stats *ipv6_stats = nexthop_get_stats(vrf_id, GR_AF_IP6);
+
+		// Always show VRF 0, and show other VRFs if they have any nexthops
+		if (vrf_id != 0 && (ipv4_stats == NULL || ipv4_stats->total == 0)
+		    && (ipv6_stats == NULL || ipv6_stats->total == 0))
+			continue;
+
+		char vrf_key[32];
+		snprintf(vrf_key, sizeof(vrf_key), "%u", vrf_id);
+
+		struct rte_tel_data *vrf_data = rte_tel_data_alloc();
+		if (vrf_data == NULL)
+			continue;
+
+		rte_tel_data_start_dict(vrf_data);
+		rte_tel_data_add_dict_uint(vrf_data, "vrf_id", vrf_id);
+		rte_tel_data_add_dict_uint(vrf_data, "ipv4", ipv4_stats ? ipv4_stats->total : 0);
+		rte_tel_data_add_dict_uint(vrf_data, "ipv6", ipv6_stats ? ipv6_stats->total : 0);
+		rte_tel_data_add_dict_uint(
+			vrf_data,
+			"new",
+			(ipv4_stats ? ipv4_stats->by_state[GR_NH_S_NEW] : 0)
+				+ (ipv6_stats ? ipv6_stats->by_state[GR_NH_S_NEW] : 0)
+		);
+
+		if (rte_tel_data_add_dict_container(d, vrf_key, vrf_data, 0) != 0) {
+			rte_tel_data_free(vrf_data);
+			continue;
+		}
+	}
+
+	return 0;
+}
+
 static int nh_unspec_add(struct nexthop *nh) {
 	nexthop_incref(nh);
 	return 0;
@@ -663,4 +765,7 @@ RTE_INIT(init) {
 	gr_event_register_serializer(&nh_serializer);
 	gr_register_module(&module);
 	nexthop_af_ops_register(GR_AF_UNSPEC, &nh_ops);
+	rte_telemetry_register_cmd(
+		"/grout/nexthop/stats", telemetry_nexthop_stats_get, "Get nexthop statistics"
+	);
 }

--- a/modules/ip/control/gr_ip4_control.h
+++ b/modules/ip/control/gr_ip4_control.h
@@ -42,3 +42,11 @@ void rib4_cleanup(struct nexthop *);
 struct nexthop *addr4_get_preferred(uint16_t iface_id, ip4_addr_t dst);
 // get all addresses for a given interface
 struct hoplist *addr4_get_all(uint16_t iface_id);
+
+struct rib4_stats {
+	uint32_t total_routes;
+	uint32_t by_origin[_GR_NH_ORIGIN_COUNT];
+};
+
+// Get route stats for IPv4 (exposed for telemetry)
+const struct rib4_stats *rib4_get_stats(uint16_t vrf_id);

--- a/modules/ip/control/nexthop.c
+++ b/modules/ip/control/nexthop.c
@@ -92,6 +92,7 @@ void nh4_unreachable_cb(struct rte_mbuf *m) {
 		nh->held_pkts++;
 		if (nh->state != GR_NH_S_PENDING) {
 			arp_output_request_solicit(nh);
+			nh_stats_update(nh, GR_NH_S_PENDING);
 			nh->state = GR_NH_S_PENDING;
 		}
 		return;
@@ -145,6 +146,7 @@ void arp_probe_input_cb(struct rte_mbuf *m) {
 	if (!(nh->flags & GR_NH_F_STATIC)) {
 		// Refresh all fields.
 		nh->last_reply = gr_clock_us();
+		nh_stats_update(nh, GR_NH_S_REACHABLE);
 		nh->state = GR_NH_S_REACHABLE;
 		nh->ucast_probes = 0;
 		nh->bcast_probes = 0;
@@ -193,6 +195,7 @@ static int nh4_add(struct nexthop *nh) {
 static void nh4_del(struct nexthop *nh) {
 	rib4_cleanup(nh);
 	if (nh->ref_count > 0) {
+		nh_stats_update(nh, GR_NH_S_NEW);
 		nh->state = GR_NH_S_NEW;
 		memset(&nh->mac, 0, sizeof(nh->mac));
 	}

--- a/modules/ip6/control/gr_ip6_control.h
+++ b/modules/ip6/control/gr_ip6_control.h
@@ -56,3 +56,11 @@ struct nexthop *addr6_get_linklocal(uint16_t iface_id);
 struct hoplist *addr6_get_all(uint16_t iface_id);
 // determine if the given interface is member of the provided multicast address group
 struct nexthop *mcast6_get_member(uint16_t iface_id, const struct rte_ipv6_addr *mcast);
+
+struct rib6_stats {
+	uint32_t total_routes;
+	uint32_t by_origin[_GR_NH_ORIGIN_COUNT];
+};
+
+// Get route stats for IPv6
+const struct rib6_stats *rib6_get_stats(uint16_t vrf_id);

--- a/modules/ip6/control/nexthop.c
+++ b/modules/ip6/control/nexthop.c
@@ -101,6 +101,7 @@ void nh6_unreachable_cb(struct rte_mbuf *m) {
 		nh->held_pkts++;
 		if (nh->state != GR_NH_S_PENDING) {
 			nh6_solicit(nh);
+			nh_stats_update(nh, GR_NH_S_PENDING);
 			nh->state = GR_NH_S_PENDING;
 		}
 		return;
@@ -190,6 +191,7 @@ void ndp_probe_input_cb(struct rte_mbuf *m) {
 	if (nh && !(nh->flags & GR_NH_F_STATIC) && lladdr_found == ICMP6_OPT_FOUND) {
 		// Refresh all fields.
 		nh->last_reply = gr_clock_us();
+		nh_stats_update(nh, GR_NH_S_REACHABLE);
 		nh->state = GR_NH_S_REACHABLE;
 		nh->ucast_probes = 0;
 		nh->bcast_probes = 0;
@@ -237,6 +239,7 @@ static int nh6_add(struct nexthop *nh) {
 static void nh6_del(struct nexthop *nh) {
 	rib6_cleanup(nh);
 	if (nh->ref_count > 0) {
+		nh_stats_update(nh, GR_NH_S_NEW);
 		nh->state = GR_NH_S_NEW;
 		memset(&nh->mac, 0, sizeof(nh->mac));
 	}

--- a/modules/ip6/control/route.c
+++ b/modules/ip6/control/route.c
@@ -18,6 +18,7 @@
 #include <rte_ethdev.h>
 #include <rte_malloc.h>
 #include <rte_rib6.h>
+#include <rte_telemetry.h>
 
 #include <errno.h>
 #include <stdint.h>
@@ -26,6 +27,7 @@
 #include <sys/queue.h>
 
 static struct rte_rib6 **vrf_ribs;
+static struct rib6_stats stats[MAX_VRFS];
 
 static struct rte_rib6_conf rib6_conf = {
 	.ext_sz = sizeof(gr_nh_origin_t),
@@ -177,6 +179,9 @@ static int rib6_insert_or_replace(
 
 	rte_rib6_set_nh(rn, nh_ptr_to_id(nh));
 	o = rte_rib6_get_ext(rn);
+	gr_nh_origin_t old_origin = origin;
+	if (existing)
+		old_origin = *o;
 	*o = origin;
 	fib6_insert(vrf_id, iface_id, scoped_ip, prefixlen, nh);
 	if (origin != GR_NH_ORIGIN_INTERNAL) {
@@ -189,6 +194,22 @@ static int rib6_insert_or_replace(
 				origin,
 			}
 		);
+	}
+
+	// Update statistics
+	if (vrf_id < MAX_VRFS) {
+		if (existing) {
+			// Replace case: total unchanged; adjust origin bucket if changed
+			if (origin != old_origin) {
+				if (stats[vrf_id].by_origin[old_origin] > 0)
+					stats[vrf_id].by_origin[old_origin]--;
+				stats[vrf_id].by_origin[origin]++;
+			}
+		} else {
+			// New insert
+			stats[vrf_id].total_routes++;
+			stats[vrf_id].by_origin[origin]++;
+		}
 	}
 
 	if (existing)
@@ -255,6 +276,14 @@ int rib6_delete(
 			}
 		);
 	}
+	// Update statistics
+	if (vrf_id < MAX_VRFS) {
+		if (stats[vrf_id].total_routes > 0)
+			stats[vrf_id].total_routes--;
+		if (stats[vrf_id].by_origin[origin] > 0)
+			stats[vrf_id].by_origin[origin]--;
+	}
+
 	nexthop_decref(nh);
 
 	return 0;
@@ -459,6 +488,9 @@ static struct api_out route6_list(const void *request, void **response) {
 }
 
 static void route6_init(struct event_base *) {
+	// Initialize statistics arrays to zero
+	memset(stats, 0, sizeof(stats));
+
 	vrf_ribs = rte_calloc(__func__, MAX_VRFS, sizeof(struct rte_rib6 *), RTE_CACHE_LINE_SIZE);
 	if (vrf_ribs == NULL)
 		ABORT("rte_calloc(vrf_rib6s): %s", rte_strerror(rte_errno));
@@ -506,6 +538,51 @@ void rib6_cleanup(struct nexthop *nh) {
 	}
 }
 
+const struct rib6_stats *rib6_get_stats(uint16_t vrf_id) {
+	if (vrf_id >= MAX_VRFS)
+		return NULL;
+	return &stats[vrf_id];
+}
+
+static int
+telemetry_rib6_stats_get(const char * /*cmd*/, const char * /*params*/, struct rte_tel_data *d) {
+	rte_tel_data_start_dict(d);
+
+	for (uint16_t vrf_id = 0; vrf_id < MAX_VRFS; vrf_id++) {
+		const struct rib6_stats *vrf_stats = rib6_get_stats(vrf_id);
+
+		if (vrf_id != 0 && (vrf_stats == NULL || vrf_stats->total_routes == 0))
+			continue;
+
+		char vrf_key[32];
+		snprintf(vrf_key, sizeof(vrf_key), "%u", vrf_id);
+
+		struct rte_tel_data *vrf_data = rte_tel_data_alloc();
+		if (vrf_data == NULL)
+			continue;
+
+		rte_tel_data_start_dict(vrf_data);
+		rte_tel_data_add_dict_uint(vrf_data, "vrf_id", vrf_id);
+
+		struct rte_tel_data *ipv6_data = rte_tel_data_alloc();
+		if (ipv6_data != NULL) {
+			rte_tel_data_start_dict(ipv6_data);
+			rte_tel_data_add_dict_uint(ipv6_data, "total", vrf_stats->total_routes);
+			rte_tel_data_add_dict_uint(
+				ipv6_data, "link", vrf_stats->by_origin[GR_NH_ORIGIN_LINK]
+			);
+			rte_tel_data_add_dict_container(vrf_data, "ipv6", ipv6_data, 1);
+		}
+
+		if (rte_tel_data_add_dict_container(d, vrf_key, vrf_data, 0) != 0) {
+			rte_tel_data_free(vrf_data);
+			continue;
+		}
+	}
+
+	return 0;
+}
+
 static struct gr_api_handler route6_add_handler = {
 	.name = "ipv6 route add",
 	.request_type = GR_IP6_ROUTE_ADD,
@@ -547,4 +624,7 @@ RTE_INIT(control_ip_init) {
 	gr_register_api_handler(&route6_list_handler);
 	gr_event_register_serializer(&route6_serializer);
 	gr_register_module(&route6_module);
+	rte_telemetry_register_cmd(
+		"/grout/rib6/stats", telemetry_rib6_stats_get, "Get IPv6 RIB statistics"
+	);
 }


### PR DESCRIPTION
- Implement collection of statistics of RIB and nexthops for ipv4 and ipv6
- Expose the collected statistics via DPDK telemetry socket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Per‑VRF telemetry for routing and nexthop statistics with endpoints /grout/nexthop/stats, /grout/rib4/stats and /grout/rib6/stats.
  - Live stats updates on nexthop and route creation, deletion, and state transitions.
  - Public read-only accessors to retrieve per‑VRF stats.

- **Refactor**
  - Internal counters and state buckets added to support real‑time telemetry without changing behavior.

- **Chores**
  - Initialization and bounds checks for stable per‑VRF counters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->