### PR TITLE
subprojects/frr: bump to 10.4-rc1

### DIFF
--- a/subprojects/frr.wrap
+++ b/subprojects/frr.wrap
@@ -1,9 +1,8 @@
 [wrap-git]
 url = https://github.com/FRRouting/frr
-revision = frr-10.3
+revision = frr-10.4.0-rc1
 depth = 1
 diff_files =
-	frr/lib-clippy-pointer-offsets-are-signed.patch,
 	frr/meson-add-dependency-definition.patch
 
 [provide]


### PR DESCRIPTION
It's required for SRv6 encap in staticd IPv4 routes. When 10.4 will be released, we should upgrade it again. (end of week maybe)