### PR TITLE
route: do not duplicate NH

### DIFF
--- a/modules/ip/control/route.c
+++ b/modules/ip/control/route.c
@@ -224,7 +224,8 @@ static struct api_out route4_add(const void *request, void ** /*response*/) {
 		nh = nexthop_lookup_by_id(req->nh_id);
 		if (nh == NULL)
 			return api_out(ENOENT, 0);
-	} else {
+	} else if ((nh = nexthop_lookup(GR_AF_IP4, req->vrf_id, GR_IFACE_ID_UNDEF, &req->nh))
+		   == NULL) {
 		// ensure route gateway is reachable
 		if ((nh = rib4_lookup(req->vrf_id, req->nh)) == NULL)
 			return api_out(EHOSTUNREACH, 0);

--- a/modules/ip6/control/route.c
+++ b/modules/ip6/control/route.c
@@ -246,7 +246,8 @@ static struct api_out route6_add(const void *request, void ** /*response*/) {
 		nh = nexthop_lookup_by_id(req->nh_id);
 		if (nh == NULL)
 			return api_out(ENOENT, 0);
-	} else {
+	} else if ((nh = nexthop_lookup(GR_AF_IP6, req->vrf_id, GR_IFACE_ID_UNDEF, &req->nh))
+		   == NULL) {
 		// ensure route gateway is reachable
 		if ((nh = rib6_lookup(req->vrf_id, GR_IFACE_ID_UNDEF, &req->nh)) == NULL)
 			return api_out(EHOSTUNREACH, 0);


### PR DESCRIPTION
A duplicate gateway NH is created when we add 2 routes with the same gateway IP, such as the following config:
```
add ip route 16.0.0.0/24 via 192.168.210.2
add ip route 48.0.0.0/24 via 192.168.211.2
add ip route 16.0.1.0/24 via 192.168.210.2
add ip route 48.0.1.0/24 via 192.168.211.2
```

```
grout# show nexthop
VRF  ID  TYPE  FAMILY  IP                         MAC                IFACE       STATE      FLAGS              ORIGIN
0        L3    IPv6    fe80::48df:37ff:fe68:d710  48:df:37:68:d7:10  cv0	 reachable  static local link  link
0        L3    IPv6    fe80::48df:37ff:fe68:d718  48:df:37:68:d7:18  cv1	 reachable  static local link  link
0        L3    IPv4    192.168.210.1              48:df:37:68:d7:10  cv0	 reachable  static local link  link
0        L3    IPv4    192.168.211.1              48:df:37:68:d7:18  cv1	 reachable  static local link  link
0        L3    IPv4    192.168.210.2              ?                  cv0	 new        gateway            user
0        L3    IPv4    192.168.211.2              ?                  cv1	 new        gateway            user
0        L3    IPv4    192.168.210.2              90:e2:ba:14:2f:8c  cv0	 reachable  gateway            user
0        L3    IPv4    192.168.211.2              90:e2:ba:14:2f:8d  cv1	 reachable  gateway            user
```
Lookup for that nexthop, and if it doesn't exist, create it.

## Summary by Sourcery

Bug Fixes:
- Check for existing nexthop by address before falling back to RIB lookup in IPv4 and IPv6 route addition to prevent duplicate gateway next hops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the logic for adding IPv4 and IPv6 routes to handle nexthop lookups more robustly, providing clearer error handling when a nexthop cannot be found or a gateway is unreachable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->