### PR TITLE
subprojects/frr: bump to 10.4.1

### DIFF
--- a/frr/meson.build
+++ b/frr/meson.build
@@ -5,7 +5,7 @@ if not get_option('frr').enabled()
   subdir_done()
 endif
 
-frr_dep = dependency('frr', version: '>= 10.3', fallback: ['frr', 'frr_dep'])
+frr_dep = dependency('frr', version: '>= 10.4', fallback: ['frr', 'frr_dep'])
 
 frr_plugin = shared_module(
   'frr_dplane_grout',

--- a/subprojects/frr.wrap
+++ b/subprojects/frr.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/FRRouting/frr
-revision = frr-10.4.0-rc1
+revision = frr-10.4.1
 depth = 1
 diff_files =
 	frr/meson-add-dependency-definition.patch

--- a/subprojects/packagefiles/frr/meson-add-dependency-definition.patch
+++ b/subprojects/packagefiles/frr/meson-add-dependency-definition.patch
@@ -1,6 +1,6 @@
-From 5745031d387c18ed2da7d3cbcce5e2525f9d73b7 Mon Sep 17 00:00:00 2001
+From 5f3d3c0eb05b8c1457b4b77546c6de487b8756c2 Mon Sep 17 00:00:00 2001
 From: Maxime Leroy <maxime@leroys.fr>
-Date: Fri, 23 May 2025 17:44:02 +0200
+Date: Mon, 4 Aug 2025 14:21:26 +0200
 Subject: [PATCH] meson add dependency definition
 
 Signed-off-by: Maxime Leroy <maxime@leroys.fr>
@@ -54,14 +54,14 @@ index 0000000..1e40167
 +}" "$conf_file"
 diff --git a/meson.build b/meson.build
 new file mode 100644
-index 0000000..3153050
+index 0000000..70664dc
 --- /dev/null
 +++ b/meson.build
 @@ -0,0 +1,85 @@
 +# SPDX-License-Identifier: BSD-3-Clause
 +# Copyright (c) 2025 Maxime Leroy, Free Mobile
 +
-+project('frr', 'c', version: '10.3', license: 'GPL-2.0-or-later', meson_version: '>= 0.63.0')
++project('frr', 'c', version: '10.4.1', license: 'GPL-2.0-or-later', meson_version: '>= 0.63.0')
 +
 +srcdir = meson.current_source_dir()
 +builddir = meson.current_build_dir()


### PR DESCRIPTION
Bump to the lastest stable version of FRR, instead of using a RC version.

## Summary by Sourcery

Bump FRR subproject from a release candidate to the latest stable version 10.4.1

Enhancements:
- Update subprojects/frr.wrap to fetch the stable FRR 10.4.1 release
- Bump Meson build FRR dependency requirement to >=10.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required version of the FRRouting (frr) dependency to 10.4.
  * Updated the FRRouting subproject to use the stable release version 10.4.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->