### PR TITLE
infra: enable deletion of iface nexthops by dropping GR_NH_F_LINK check

### DIFF
--- a/modules/infra/api/nexthop.c
+++ b/modules/infra/api/nexthop.c
@@ -152,7 +152,7 @@ static struct api_out nh_del(const void *request, void ** /*response*/) {
 		return api_out(ENOENT, 0);
 	}
 
-	if ((nh->flags & (GR_NH_F_LOCAL | GR_NH_F_LINK | GR_NH_F_GATEWAY)) || nh->ref_count > 1)
+	if ((nh->flags & (GR_NH_F_LOCAL | GR_NH_F_GATEWAY)) || nh->ref_count > 1)
 		return api_out(EBUSY, 0);
 
 	ops = nexthop_af_ops_get(nh->af);


### PR DESCRIPTION
Example:
  grout# add nexthop id 123 iface gr-loop1
  grout# del nexthop 123
  error: command failed: Device or resource busy

Because GR_NH_F_LOCAL is already set interface‐address nexthops, the GR_NH_F_LINK test in nh_del() is not useful. By removing this one, iface nexthop can be deleted.

## Summary by Sourcery

Bug Fixes:
- Allow iface nexthop deletion by dropping the GR_NH_F_LINK check that previously caused EBUSY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the conditions for deleting nexthops, allowing deletion in more cases by no longer restricting based on certain internal flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->