### PR TITLE
infra: fix compilation

### DIFF
--- a/modules/infra/datapath/loop_xvrf.c
+++ b/modules/infra/datapath/loop_xvrf.c
@@ -54,9 +54,9 @@ loop_xvrf_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 		eth_data->domain = ETH_DOMAIN_LOCAL;
 
 		// XXX: increment tx stats of gr-loopX on initial vrf
-		stats = iface_get_stats(loop_iface->id);
-		stats->rx_packets[rte_lcore_id()] += 1;
-		stats->rx_bytes[rte_lcore_id()] += rte_pktmbuf_pkt_len(m);
+		stats = iface_get_stats(rte_lcore_id(), loop_iface->id);
+		stats->rx_packets += 1;
+		stats->rx_bytes += rte_pktmbuf_pkt_len(m);
 next:
 		if (gr_mbuf_is_traced(m)
 		    || (loop_iface && loop_iface->flags & GR_IFACE_F_PACKET_TRACE)) {


### PR DESCRIPTION
Use the updated iface_stats model to avoid false sharing.

## Summary by Sourcery

Adapt loop_xvrf module to the updated iface_stats API by passing the logical core ID to iface_get_stats and updating packet/byte counter increments

Enhancements:
- Update iface_get_stats call to include rte_lcore_id as the first argument
- Remove per-core array indexing and increment scalar rx_packets and rx_bytes counters