### PR TITLE
ip/ip6: fix display nexthop

### DIFF
--- a/modules/ip/cli/route.c
+++ b/modules/ip/cli/route.c
@@ -79,13 +79,20 @@ static cmd_status_t route4_list(const struct gr_api_client *c, const struct ec_p
 		struct gr_iface iface;
 		scols_line_sprintf(line, 0, "%u", route->vrf_id);
 		scols_line_sprintf(line, 1, IP4_F "/%hhu", &route->dest.ip, route->dest.prefixlen);
-		if (route->nh.af == GR_AF_UNSPEC) {
+		switch (route->nh.af) {
+		case GR_AF_UNSPEC:
 			if (iface_from_id(c, route->nh.iface_id, &iface) < 0)
 				scols_line_sprintf(line, 2, "%u", route->nh.iface_id);
 			else
 				scols_line_sprintf(line, 2, "%s", iface.name);
-		} else
+			break;
+		case GR_AF_IP4:
 			scols_line_sprintf(line, 2, IP4_F, &route->nh.ipv4);
+			break;
+		case GR_AF_IP6:
+			scols_line_sprintf(line, 2, IP6_F, &route->nh.ipv6);
+			break;
+		}
 		scols_line_sprintf(line, 3, "%s", gr_nh_origin_name(route->origin));
 		if (route->nh.nh_id != GR_NH_ID_UNSET)
 			scols_line_sprintf(line, 4, "%u", route->nh.nh_id);

--- a/modules/ip6/cli/route.c
+++ b/modules/ip6/cli/route.c
@@ -79,13 +79,20 @@ static cmd_status_t route6_list(const struct gr_api_client *c, const struct ec_p
 		struct gr_iface iface;
 		scols_line_sprintf(line, 0, "%u", route->vrf_id);
 		scols_line_sprintf(line, 1, IP6_F "/%hhu", &route->dest, route->dest.prefixlen);
-		if (route->nh.af == GR_AF_UNSPEC) {
+		switch (route->nh.af) {
+		case GR_AF_UNSPEC:
 			if (iface_from_id(c, route->nh.iface_id, &iface) < 0)
 				scols_line_sprintf(line, 2, "%u", route->nh.iface_id);
 			else
 				scols_line_sprintf(line, 2, "%s", iface.name);
-		} else
+			break;
+		case GR_AF_IP4:
+			scols_line_sprintf(line, 2, IP4_F, &route->nh.ipv4);
+			break;
+		case GR_AF_IP6:
 			scols_line_sprintf(line, 2, IP6_F, &route->nh.ipv6);
+			break;
+		}
 		scols_line_sprintf(line, 3, "%s", gr_nh_origin_name(route->origin));
 		if (route->nh.nh_id != GR_NH_ID_UNSET)
 			scols_line_sprintf(line, 4, "%u", route->nh.nh_id);


### PR DESCRIPTION
With the ability to set a nexthop with an ID, we now support a IPv4 gateway for a IPv6 network, and the other way around.

Fix the command 'show ip(6) route' to print the address with the proper format.

```
grout# show ip route
VRF  DESTINATION       NEXT_HOP       ORIGIN  ID  NEXT_HOP_VRF
0    16.0.1.0/24       fc00:210::2    user    11  0

```
Fixes: a1e4087b ("all: add support for gateway-less nexthops")