### PR TITLE
build: disable FRR compilation in rpm, deb package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,7 @@ include /usr/share/dpkg/buildflags.mk
 meson_opts := --wrap-mode=default
 meson_opts += --auto-features=enabled
 meson_opts += -Ddpdk:platform=generic
+meson_opts += -Dfrr=disabled
 
 %:
 	dh $@ --buildsystem=meson --with=bash-completion -B$(CURDIR)/debian/_build

--- a/rpm/grout.spec
+++ b/rpm/grout.spec
@@ -65,7 +65,7 @@ Suggests: %{name}
 This package contains the development headers to build %{grout} API clients.
 
 %build
-%meson -Ddpdk:platform=generic
+%meson -Ddpdk:platform=generic -Dfrr=disabled
 %meson_build
 
 %install


### PR DESCRIPTION
With --auto-features=enabled, Meson would compile FRR when its option defaulted to true. Grout package should not compile their own FRR but use system headers. Pass -Dfrr=disabled in deb and rpm builds to prevent bundled FRR compilation.

## Summary by Sourcery

Disable bundled FRR compilation in Debian and RPM packages by passing -Dfrr=disabled to Meson builds

Build:
- Add -Dfrr=disabled to Meson invocation in rpm/grout.spec
- Include -Dfrr=disabled flag in Debian rules Meson build steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to disable the "frr" feature during package builds for both Debian and RPM distributions. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->