### PR TITLE
nexthop: avoid nuking routing tables after 6 arp/ndp failures

### DIFF
--- a/modules/infra/control/nexthop.c
+++ b/modules/infra/control/nexthop.c
@@ -531,14 +531,13 @@ void nexthop_incref(struct nexthop *nh) {
 static void nexthop_ageing_cb(struct nexthop *nh, void *) {
 	const struct nexthop_af_ops *ops = af_ops[nh->af];
 	clock_t now = gr_clock_us();
-	time_t reply_age, request_age;
 	unsigned probes, max_probes;
+	time_t reply_age;
 
 	if (nh->flags & GR_NH_F_STATIC)
 		return;
 
 	reply_age = (now - nh->last_reply) / CLOCKS_PER_SEC;
-	request_age = (now - nh->last_request) / CLOCKS_PER_SEC;
 	max_probes = nh_conf.max_ucast_probes + nh_conf.max_bcast_probes;
 	probes = nh->ucast_probes + nh->bcast_probes;
 
@@ -573,16 +572,7 @@ static void nexthop_ageing_cb(struct nexthop *nh, void *) {
 			nh->state = GR_NH_S_STALE;
 		break;
 	case GR_NH_S_FAILED:
-		if (request_age > nh_conf.lifetime_unreachable_sec) {
-			LOG(DEBUG,
-			    ADDR_F " vrf=%u failed_probes=%u held_pkts=%u: failed -> <destroy>",
-			    ADDR_W(nh->af),
-			    &nh->addr,
-			    nh->vrf_id,
-			    probes,
-			    nh->held_pkts);
-			ops->del(nh);
-		}
+		break;
 	}
 }
 


### PR DESCRIPTION
When 3 unicast ARP/NDP and 3 {broad,multi}cast probes have failed to get a response, the nexthop is marked as "failed" and is "deleted" after lifetime_unreachable_sec (60 seconds by default).

This deletion is rather aggressive and completely removes all routes that point to this failed nexthop. This may have unwanted side effects when running for a long time in production.

Keep the nexthop alive and leave all routing tables alone.