### PR TITLE
nexthop: allow deleting regardless of flags

### DIFF
--- a/modules/infra/api/nexthop.c
+++ b/modules/infra/api/nexthop.c
@@ -139,6 +139,7 @@ static struct gr_api_handler nh_add_handler = {
 };
 
 static struct api_out nh_del(const void *request, void ** /*response*/) {
+	static const gr_nh_flags_t addr_flags = GR_NH_F_LOCAL | GR_NH_F_STATIC;
 	const struct gr_nh_del_req *req = request;
 	const struct nexthop_af_ops *ops;
 	struct nexthop *nh;
@@ -150,7 +151,7 @@ static struct api_out nh_del(const void *request, void ** /*response*/) {
 		return api_out(ENOENT, 0);
 	}
 
-	if ((nh->flags & (GR_NH_F_LOCAL | GR_NH_F_GATEWAY)) || nh->ref_count > 1)
+	if (nh->type != GR_NH_T_L3 || (nh->flags & addr_flags) == addr_flags || nh->ref_count > 1)
 		return api_out(EBUSY, 0);
 
 	ops = nexthop_af_ops_get(nh->af);

--- a/modules/ip6/control/route.c
+++ b/modules/ip6/control/route.c
@@ -261,7 +261,6 @@ static struct api_out route6_add(const void *request, void ** /*response*/) {
 			nh = nexthop_new(&(struct gr_nexthop) {
 				.type = GR_NH_T_L3,
 				.af = GR_AF_IP6,
-				.flags = 0,
 				.vrf_id = nh->vrf_id,
 				.iface_id = nh->iface_id,
 				.ipv6 = req->nh,


### PR DESCRIPTION
Remove the check for GR_NH_F_LOCAL and GR_NH_F_GATEWAY. Only make sure that local addresses (GR_NH_F_LOCAL | GR_NH_F_STATIC) and non L3 nexthops cannot be deleted.