### PR TITLE
Blackhole

### DIFF
--- a/modules/infra/api/gr_nexthop.h
+++ b/modules/infra/api/gr_nexthop.h
@@ -30,6 +30,8 @@ typedef enum : uint8_t {
 	GR_NH_T_SR6_OUTPUT,
 	GR_NH_T_SR6_LOCAL,
 	GR_NH_T_DNAT,
+	GR_NH_T_BLACKHOLE,
+	GR_NH_T_REJECT,
 } gr_nh_type_t;
 
 // Route install origin values shared by IPv4 and IPv6.
@@ -149,6 +151,10 @@ static inline const char *gr_nh_type_name(const struct gr_nexthop *nh) {
 		return "SRv6-local";
 	case GR_NH_T_DNAT:
 		return "DNAT";
+	case GR_NH_T_BLACKHOLE:
+		return "blackhole";
+	case GR_NH_T_REJECT:
+		return "reject";
 	}
 	return "?";
 }

--- a/modules/infra/control/nexthop.c
+++ b/modules/infra/control/nexthop.c
@@ -312,6 +312,8 @@ void nexthop_type_ops_register(gr_nh_type_t type, const struct nexthop_type_ops 
 	case GR_NH_T_SR6_OUTPUT:
 	case GR_NH_T_SR6_LOCAL:
 	case GR_NH_T_DNAT:
+	case GR_NH_T_BLACKHOLE:
+	case GR_NH_T_REJECT:
 		if (ops == NULL || (ops->free == NULL && ops->equal == NULL))
 			ABORT("invalid type ops");
 		if (type_ops[type] != NULL)
@@ -336,6 +338,8 @@ struct nexthop *nexthop_new(const struct gr_nexthop *base) {
 	case GR_NH_T_SR6_OUTPUT:
 	case GR_NH_T_SR6_LOCAL:
 	case GR_NH_T_DNAT:
+	case GR_NH_T_BLACKHOLE:
+	case GR_NH_T_REJECT:
 		break;
 	default:
 		ABORT("invalid nexthop type %hhu", base->type);

--- a/modules/ip/cli/route.c
+++ b/modules/ip/cli/route.c
@@ -79,20 +79,25 @@ static cmd_status_t route4_list(const struct gr_api_client *c, const struct ec_p
 		struct gr_iface iface;
 		scols_line_sprintf(line, 0, "%u", route->vrf_id);
 		scols_line_sprintf(line, 1, IP4_F "/%hhu", &route->dest.ip, route->dest.prefixlen);
-		switch (route->nh.af) {
-		case GR_AF_UNSPEC:
-			if (iface_from_id(c, route->nh.iface_id, &iface) < 0)
-				scols_line_sprintf(line, 2, "%u", route->nh.iface_id);
-			else
-				scols_line_sprintf(line, 2, "%s", iface.name);
-			break;
-		case GR_AF_IP4:
-			scols_line_sprintf(line, 2, IP4_F, &route->nh.ipv4);
-			break;
-		case GR_AF_IP6:
-			scols_line_sprintf(line, 2, IP6_F, &route->nh.ipv6);
-			break;
-		}
+		if (route->nh.type == GR_NH_T_BLACKHOLE)
+			scols_line_sprintf(line, 2, "blackhole");
+		else if (route->nh.type == GR_NH_T_REJECT)
+			scols_line_sprintf(line, 2, "reject");
+		else
+			switch (route->nh.af) {
+			case GR_AF_UNSPEC:
+				if (iface_from_id(c, route->nh.iface_id, &iface) < 0)
+					scols_line_sprintf(line, 2, "%u", route->nh.iface_id);
+				else
+					scols_line_sprintf(line, 2, "%s", iface.name);
+				break;
+			case GR_AF_IP4:
+				scols_line_sprintf(line, 2, IP4_F, &route->nh.ipv4);
+				break;
+			case GR_AF_IP6:
+				scols_line_sprintf(line, 2, IP6_F, &route->nh.ipv6);
+				break;
+			}
 		scols_line_sprintf(line, 3, "%s", gr_nh_origin_name(route->origin));
 		if (route->nh.nh_id != GR_NH_ID_UNSET)
 			scols_line_sprintf(line, 4, "%u", route->nh.nh_id);

--- a/modules/ip/control/route.c
+++ b/modules/ip/control/route.c
@@ -265,7 +265,9 @@ static struct api_out route4_del(const void *request, void ** /*response*/) {
 	int ret;
 
 	nh = rib4_lookup(req->vrf_id, req->dest.ip);
-	ret = rib4_delete(req->vrf_id, req->dest.ip, req->dest.prefixlen, GR_NH_T_L3);
+	ret = rib4_delete(
+		req->vrf_id, req->dest.ip, req->dest.prefixlen, nh ? nh->type : GR_NH_T_L3
+	);
 	if (ret == -ENOENT && req->missing_ok)
 		ret = 0;
 

--- a/modules/ip/datapath/ip_input.c
+++ b/modules/ip/datapath/ip_input.c
@@ -158,6 +158,8 @@ next:
 
 static void ip_input_register(void) {
 	gr_eth_input_add_type(RTE_BE16(RTE_ETHER_TYPE_IPV4), "ip_input");
+	ip_input_register_nexthop_type(GR_NH_T_BLACKHOLE, "ip_blackhole");
+	ip_input_register_nexthop_type(GR_NH_T_REJECT, "ip_error_dest_unreach");
 }
 
 static struct rte_node_register input_node = {
@@ -190,6 +192,7 @@ GR_DROP_REGISTER(ip_input_bad_checksum);
 GR_DROP_REGISTER(ip_input_bad_length);
 GR_DROP_REGISTER(ip_input_bad_version);
 GR_DROP_REGISTER(ip_input_other_host);
+GR_DROP_REGISTER(ip_blackhole);
 
 #ifdef __GROUT_UNIT_TEST__
 #include <gr_cmocka.h>

--- a/modules/ip6/cli/route.c
+++ b/modules/ip6/cli/route.c
@@ -79,20 +79,25 @@ static cmd_status_t route6_list(const struct gr_api_client *c, const struct ec_p
 		struct gr_iface iface;
 		scols_line_sprintf(line, 0, "%u", route->vrf_id);
 		scols_line_sprintf(line, 1, IP6_F "/%hhu", &route->dest, route->dest.prefixlen);
-		switch (route->nh.af) {
-		case GR_AF_UNSPEC:
-			if (iface_from_id(c, route->nh.iface_id, &iface) < 0)
-				scols_line_sprintf(line, 2, "%u", route->nh.iface_id);
-			else
-				scols_line_sprintf(line, 2, "%s", iface.name);
-			break;
-		case GR_AF_IP4:
-			scols_line_sprintf(line, 2, IP4_F, &route->nh.ipv4);
-			break;
-		case GR_AF_IP6:
-			scols_line_sprintf(line, 2, IP6_F, &route->nh.ipv6);
-			break;
-		}
+		if (route->nh.type == GR_NH_T_BLACKHOLE)
+			scols_line_sprintf(line, 2, "blackhole");
+		else if (route->nh.type == GR_NH_T_REJECT)
+			scols_line_sprintf(line, 2, "reject");
+		else
+			switch (route->nh.af) {
+			case GR_AF_UNSPEC:
+				if (iface_from_id(c, route->nh.iface_id, &iface) < 0)
+					scols_line_sprintf(line, 2, "%u", route->nh.iface_id);
+				else
+					scols_line_sprintf(line, 2, "%s", iface.name);
+				break;
+			case GR_AF_IP4:
+				scols_line_sprintf(line, 2, IP4_F, &route->nh.ipv4);
+				break;
+			case GR_AF_IP6:
+				scols_line_sprintf(line, 2, IP6_F, &route->nh.ipv6);
+				break;
+			}
 		scols_line_sprintf(line, 3, "%s", gr_nh_origin_name(route->origin));
 		if (route->nh.nh_id != GR_NH_ID_UNSET)
 			scols_line_sprintf(line, 4, "%u", route->nh.nh_id);

--- a/modules/ip6/control/route.c
+++ b/modules/ip6/control/route.c
@@ -290,7 +290,11 @@ static struct api_out route6_del(const void *request, void ** /*response*/) {
 
 	nh = rib6_lookup(req->vrf_id, GR_IFACE_ID_UNDEF, &req->dest.ip);
 	ret = rib6_delete(
-		req->vrf_id, GR_IFACE_ID_UNDEF, &req->dest.ip, req->dest.prefixlen, GR_NH_T_L3
+		req->vrf_id,
+		GR_IFACE_ID_UNDEF,
+		&req->dest.ip,
+		req->dest.prefixlen,
+		nh ? nh->type : GR_NH_T_L3
 	);
 	if (ret == -ENOENT && req->missing_ok)
 		ret = 0;

--- a/modules/ip6/datapath/icmp6_output.c
+++ b/modules/ip6/datapath/icmp6_output.c
@@ -16,6 +16,8 @@
 
 enum {
 	OUTPUT = 0,
+	BLACKHOLE,
+	REJECT,
 	NO_HEADROOM,
 	NO_ROUTE,
 	EDGE_COUNT,
@@ -65,6 +67,13 @@ static uint16_t icmp6_output_process(
 			edge = NO_ROUTE;
 			goto next;
 		}
+		if (nh->type == GR_NH_T_BLACKHOLE) {
+			edge = BLACKHOLE;
+			goto next;
+		} else if (nh->type == GR_NH_T_REJECT) {
+			edge = REJECT;
+			goto next;
+		}
 		o = ip6_output_mbuf_data(mbuf);
 		o->nh = nh;
 		o->iface = d->iface;
@@ -84,6 +93,8 @@ static struct rte_node_register icmp6_output_node = {
 	.nb_edges = EDGE_COUNT,
 	.next_nodes = {
 		[OUTPUT] = "ip6_output",
+		[BLACKHOLE] = "ip6_blackhole",
+		[REJECT] = "ip6_admin_prohibited",
 		[NO_HEADROOM] = "error_no_headroom",
 		[NO_ROUTE] = "icmp6_output_no_route",
 	},
@@ -96,4 +107,5 @@ static struct gr_node_info icmp6_output_info = {
 
 GR_NODE_REGISTER(icmp6_output_info);
 
-GR_DROP_REGISTER(icmp6_output_no_route)
+GR_DROP_REGISTER(icmp6_output_no_route);
+GR_DROP_REGISTER(ip6_admin_prohibited);

--- a/modules/ip6/datapath/ip6_input.c
+++ b/modules/ip6/datapath/ip6_input.c
@@ -151,6 +151,8 @@ next:
 
 static void ip6_input_register(void) {
 	gr_eth_input_add_type(RTE_BE16(RTE_ETHER_TYPE_IPV6), "ip6_input");
+	ip6_input_register_nexthop_type(GR_NH_T_BLACKHOLE, "ip6_blackhole");
+	ip6_input_register_nexthop_type(GR_NH_T_REJECT, "ip6_error_dest_unreach");
 }
 
 static struct rte_node_register input_node = {
@@ -185,6 +187,7 @@ GR_DROP_REGISTER(ip6_input_other_host);
 GR_DROP_REGISTER(ip6_input_bad_version);
 GR_DROP_REGISTER(ip6_input_bad_addr);
 GR_DROP_REGISTER(ip6_input_bad_length);
+GR_DROP_REGISTER(ip6_blackhole);
 
 #ifdef __GROUT_UNIT_TEST__
 #include <gr_cmocka.h>


### PR DESCRIPTION
With the following conf:
```
grout# show ip route
VRF  DESTINATION       NEXT_HOP       ORIGIN        ID  NEXT_HOP_VRF
0    192.168.210.6/32  blackhole      zebra_static  2   0
```

On ARP Request, grouts writes an error:

```
--------- 07:28:58.933602645 cpu 0 ---------
port_rx: port=0 queue=0
eth_input: 4c:77:6d:7d:1c:c7 > ff:ff:ff:ff:ff:ff type=ARP(0x0806) iface=cv0
arp_input: request who has 192.168.210.1? tell 192.168.210.6
arp_input_request:
control_output:
```


```
ERR: GROUT: arp_probe_input_cb: ip4_nexthop_insert: Device or resource busy
```

The reason is that the /32 route already exists for that specific host.


With a broader blackhole, the NH is created as expected, but is dropped after.

```
grout# show  ip route
VRF  DESTINATION       NEXT_HOP       ORIGIN        ID  NEXT_HOP_VRF
0    192.168.210.0/25  blackhole      user          2   0
0    192.168.210.0/24  192.168.210.1  link              0
```


```
NOTICE: GROUT: trace_log_packet: [rx cv0] dc:2c:6e:47:35:87 > b4:83:51:05:43:ca / ARP request who has 192.168.210.1? tell 192.168.210.3, (pkt_len=60)
NOTICE: GROUT: trace_log_packet: [tx cv0] b4:83:51:05:43:ca > dc:2c:6e:47:35:87 / ARP reply 192.168.210.1 is at b4:83:51:05:43:ca, (pkt_len=42)
NOTICE: GROUT: trace_log_packet: [rx cv0] 4c:77:6d:7d:1c:c8 > 01:80:c2:00:00:00 type=0x0027, (pkt_len=60)
NOTICE: GROUT: drop_packets: [eth_input_unknown_type] 1 packets
NOTICE: GROUT: trace_log_packet: [rx cv1] 4c:77:6d:7d:1c:c9 > 01:80:c2:00:00:00 type=0x0027, (pkt_len=60)
NOTICE: GROUT: drop_packets: [eth_input_unknown_type] 1 packets
NOTICE: GROUT: trace_log_packet: [rx cv0] dc:2c:6e:47:35:87 > b4:83:51:05:43:ca / IP 192.168.210.3 > 192.168.210.1 ttl=255 proto=TCP(6), (pkt_len=74)
NOTICE: GROUT: drop_packets: [ip_blackhole] 1 packets
```

What would be the expected behavior in that case ?
Should we answer to the ARP request ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end support for blackhole and reject nexthops: CLI add options "blackhole" and "reject"; nexthop creation no longer requires an interface for these types and they synchronize to routing/control/datapath.
  * Datapath: dedicated blackhole/reject drop paths for IPv4/IPv6; ARP/ICMP/NDP/ICMP6/ICMP output divert blackhole/reject packets to those paths.
  * Route listings and CLI now show "blackhole" or "reject" as Next Hop.

* **Bug Fixes**
  * Route deletion (IPv4/IPv6) now respects the actual nexthop type when removing routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->