### PR TITLE
treewide: refactor gr_nexthop

### DIFF
--- a/frr/if_grout.c
+++ b/frr/if_grout.c
@@ -153,19 +153,19 @@ void grout_interface_addr_dplane(struct gr_nexthop *gr_nh, bool new) {
 	else
 		dplane_ctx_set_op(ctx, DPLANE_OP_INTF_ADDR_DEL);
 
-	dplane_ctx_set_ifindex(ctx, gr_nh->iface_id);
+	dplane_ctx_set_ifindex(ctx, gr_nh->l3.iface_id);
 	dplane_ctx_set_ns_id(ctx, GROUT_NS);
 
 	// Convert addr to prefix
-	p.prefixlen = gr_nh->prefixlen;
-	switch (gr_nh->af) {
+	p.prefixlen = gr_nh->l3.prefixlen;
+	switch (gr_nh->l3.af) {
 	case GR_AF_IP4:
 		p.family = AF_INET;
-		p.u.prefix4.s_addr = gr_nh->ipv4;
+		p.u.prefix4.s_addr = gr_nh->l3.ipv4;
 		break;
 	case GR_AF_IP6:
 		p.family = AF_INET6;
-		memcpy(&p.u.prefix6, &gr_nh->ipv6, sizeof(p.u.prefix6));
+		memcpy(&p.u.prefix6, &gr_nh->l3.ipv6, sizeof(p.u.prefix6));
 		break;
 	case GR_AF_UNSPEC:
 		gr_log_err("interface with addr family UNSPEC are not supported");

--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -298,12 +298,12 @@ static void dplane_read_notifications(struct event *event) {
 	case GR_EVENT_IP6_ADDR_DEL:
 		gr_nh = PAYLOAD(gr_e);
 
-		switch (gr_nh->af) {
+		switch (gr_nh->l3.af) {
 		case GR_AF_IP4:
 			gr_log_debug(
 				"%s addr %pI4 notification (%s)",
 				new ? "add" : "del",
-				&gr_nh->ipv4,
+				&gr_nh->l3.ipv4,
 				gr_evt_to_str(gr_e->ev_type)
 			);
 			break;
@@ -311,7 +311,7 @@ static void dplane_read_notifications(struct event *event) {
 			gr_log_debug(
 				"%s addr %pI6 notification (%s)",
 				new ? "add" : "del",
-				&gr_nh->ipv6,
+				&gr_nh->l3.ipv6,
 				gr_evt_to_str(gr_e->ev_type)
 			);
 			break;

--- a/modules/infra/api/gr_nexthop.h
+++ b/modules/infra/api/gr_nexthop.h
@@ -75,20 +75,26 @@ typedef enum : uint8_t {
 //! Nexthop structure exposed to the API.
 struct gr_nexthop {
 	gr_nh_type_t type;
-	addr_family_t af;
 	gr_nh_state_t state;
 	gr_nh_flags_t flags; //!< bit mask of GR_NH_F_*
+	gr_nh_origin_t origin;
 	uint32_t nh_id; //!< Arbitrary ID set by user. Zero means "unset".
 	uint16_t vrf_id; //!< L3 VRF domain
-	uint16_t iface_id; //!< interface associated with this nexthop
-	struct rte_ether_addr mac; //!< link-layer address
-	uint8_t prefixlen; //!< only has meaning with GR_NH_F_LOCAL
-	gr_nh_origin_t origin;
 	union {
-		struct {
-		} addr;
-		ip4_addr_t ipv4;
-		struct rte_ipv6_addr ipv6;
+		struct { // GR_NH_T_L3
+			addr_family_t af;
+			uint16_t iface_id; //!< interface associated with this nexthop
+			struct rte_ether_addr mac; //!< link-layer address
+			uint8_t prefixlen; //!< only has meaning with GR_NH_F_LOCAL
+			union {
+				struct {
+				} addr;
+				ip4_addr_t ipv4;
+				struct rte_ipv6_addr ipv6;
+			};
+		} l3;
+		struct { // GR_NH_T_BLACKHOLE
+		} bh;
 	};
 };
 

--- a/modules/infra/cli/events.c
+++ b/modules/infra/cli/events.c
@@ -53,18 +53,18 @@ static cmd_status_t events_show(const struct gr_api_client *c, const struct ec_p
 			assert(e->payload_len == sizeof(*nh));
 			nh = PAYLOAD(e);
 			printf("> addr add: iface[%d] " ADDR_F "\n",
-			       nh->iface_id,
-			       ADDR_W(nh->af),
-			       &nh->addr);
+			       nh->l3.iface_id,
+			       ADDR_W(nh->l3.af),
+			       &nh->l3.addr);
 			break;
 		case GR_EVENT_IP_ADDR_DEL:
 		case GR_EVENT_IP6_ADDR_DEL:
 			assert(e->payload_len == sizeof(*nh));
 			nh = PAYLOAD(e);
 			printf("> addr del: iface[%d] " ADDR_F "\n",
-			       nh->iface_id,
-			       ADDR_W(nh->af),
-			       &nh->addr);
+			       nh->l3.iface_id,
+			       ADDR_W(nh->l3.af),
+			       &nh->l3.addr);
 			break;
 		case GR_EVENT_IP_ROUTE_ADD:
 			assert(e->payload_len == sizeof(*r4));
@@ -72,7 +72,7 @@ static cmd_status_t events_show(const struct gr_api_client *c, const struct ec_p
 			printf("> route add: %4p/%d via %4p origin %s\n",
 			       &r4->dest.ip,
 			       r4->dest.prefixlen,
-			       &r4->nh.ipv4,
+			       &r4->nh.l3.ipv4,
 			       gr_nh_origin_name(r4->origin));
 			break;
 		case GR_EVENT_IP_ROUTE_DEL:
@@ -81,7 +81,7 @@ static cmd_status_t events_show(const struct gr_api_client *c, const struct ec_p
 			printf("> route del: %4p/%d via %4p origin %s\n",
 			       &r4->dest.ip,
 			       r4->dest.prefixlen,
-			       &r4->nh.ipv4,
+			       &r4->nh.l3.ipv4,
 			       gr_nh_origin_name(r4->origin));
 			break;
 		case GR_EVENT_IP6_ROUTE_ADD:
@@ -90,7 +90,7 @@ static cmd_status_t events_show(const struct gr_api_client *c, const struct ec_p
 			printf("> route add: %6p/%d via %6p origin %s\n",
 			       &r6->dest.ip,
 			       r6->dest.prefixlen,
-			       &r6->nh.ipv6,
+			       &r6->nh.l3.ipv6,
 			       gr_nh_origin_name(r6->origin));
 			break;
 		case GR_EVENT_IP6_ROUTE_DEL:
@@ -99,40 +99,40 @@ static cmd_status_t events_show(const struct gr_api_client *c, const struct ec_p
 			printf("> route del: %6p/%d via %6p origin %s\n",
 			       &r6->dest.ip,
 			       r6->dest.prefixlen,
-			       &r6->nh.ipv6,
+			       &r6->nh.l3.ipv6,
 			       gr_nh_origin_name(r6->origin));
 			break;
 		case GR_EVENT_NEXTHOP_NEW:
 			assert(e->payload_len == sizeof(*nh));
 			nh = PAYLOAD(e);
 			printf("> nh new: iface %d vrf %d " ADDR_F " " ETH_F " origin %s\n",
-			       nh->iface_id,
+			       nh->l3.iface_id,
 			       nh->vrf_id,
-			       ADDR_W(nh->af),
-			       &nh->addr,
-			       &nh->mac,
+			       ADDR_W(nh->l3.af),
+			       &nh->l3.addr,
+			       &nh->l3.mac,
 			       gr_nh_origin_name(nh->origin));
 			break;
 		case GR_EVENT_NEXTHOP_DELETE:
 			assert(e->payload_len == sizeof(*nh));
 			nh = PAYLOAD(e);
 			printf("> nh del: iface %d vrf %d " ADDR_F " " ETH_F "  origin %s\n",
-			       nh->iface_id,
+			       nh->l3.iface_id,
 			       nh->vrf_id,
-			       ADDR_W(nh->af),
-			       &nh->addr,
-			       &nh->mac,
+			       ADDR_W(nh->l3.af),
+			       &nh->l3.addr,
+			       &nh->l3.mac,
 			       gr_nh_origin_name(nh->origin));
 			break;
 		case GR_EVENT_NEXTHOP_UPDATE:
 			assert(e->payload_len == sizeof(*nh));
 			nh = PAYLOAD(e);
 			printf("> nh update: iface %d vrf %d " ADDR_F " " ETH_F " origin %s\n",
-			       nh->iface_id,
+			       nh->l3.iface_id,
 			       nh->vrf_id,
-			       ADDR_W(nh->af),
-			       &nh->addr,
-			       &nh->mac,
+			       ADDR_W(nh->l3.af),
+			       &nh->l3.addr,
+			       &nh->l3.mac,
 			       gr_nh_origin_name(nh->origin));
 			break;
 		default:

--- a/modules/infra/cli/nexthop.c
+++ b/modules/infra/cli/nexthop.c
@@ -65,25 +65,25 @@ static cmd_status_t nh_add(const struct gr_api_client *c, const struct ec_pnode 
 	if (arg_u32(p, "ID", &req.nh.nh_id) < 0 && errno != ENOENT)
 		return CMD_ERROR;
 
-	switch (arg_ip4(p, "IP", &req.nh.ipv4)) {
+	switch (arg_ip4(p, "IP", &req.nh.l3.ipv4)) {
 	case 0:
-		req.nh.af = GR_AF_IP4;
+		req.nh.l3.af = GR_AF_IP4;
 		break;
 	case -EINVAL:
-		if (arg_ip6(p, "IP", &req.nh.ipv6) < 0)
+		if (arg_ip6(p, "IP", &req.nh.l3.ipv6) < 0)
 			return CMD_ERROR;
-		req.nh.af = GR_AF_IP6;
+		req.nh.l3.af = GR_AF_IP6;
 		break;
 	default:
-		req.nh.af = GR_AF_UNSPEC;
+		req.nh.l3.af = GR_AF_UNSPEC;
 		break;
 	}
 
 	if (iface_from_name(c, arg_str(p, "IFACE"), &iface) < 0)
 		return CMD_ERROR;
-	req.nh.iface_id = iface.id;
+	req.nh.l3.iface_id = iface.id;
 
-	if (arg_eth_addr(p, "MAC", &req.nh.mac) < 0 && errno != ENOENT)
+	if (arg_eth_addr(p, "MAC", &req.nh.l3.mac) < 0 && errno != ENOENT)
 		return CMD_ERROR;
 
 	if (gr_api_client_send_recv(c, GR_NH_ADD, sizeof(req), &req, NULL) < 0)
@@ -154,18 +154,18 @@ static cmd_status_t nh_list(const struct gr_api_client *c, const struct ec_pnode
 		else
 			scols_line_set_data(line, 1, "");
 		scols_line_sprintf(line, 2, "%s", gr_nh_type_name(nh));
-		scols_line_sprintf(line, 3, "%s", gr_af_name(nh->af));
-		if (nh->af == GR_AF_UNSPEC)
+		scols_line_sprintf(line, 3, "%s", gr_af_name(nh->l3.af));
+		if (nh->l3.af == GR_AF_UNSPEC)
 			scols_line_set_data(line, 4, "");
 		else
-			scols_line_sprintf(line, 4, ADDR_F, ADDR_W(nh->af), &nh->addr);
+			scols_line_sprintf(line, 4, ADDR_F, ADDR_W(nh->l3.af), &nh->l3.addr);
 
 		if (nh->state == GR_NH_S_REACHABLE)
-			scols_line_sprintf(line, 5, ETH_F, &nh->mac);
+			scols_line_sprintf(line, 5, ETH_F, &nh->l3.mac);
 		else
 			scols_line_set_data(line, 5, "?");
 
-		if (iface_from_id(c, nh->iface_id, &iface) == 0)
+		if (iface_from_id(c, nh->l3.iface_id, &iface) == 0)
 			scols_line_sprintf(line, 6, "%s", iface.name);
 		else
 			scols_line_set_data(line, 6, "?");

--- a/modules/infra/datapath/loop_xvrf.c
+++ b/modules/infra/datapath/loop_xvrf.c
@@ -39,10 +39,10 @@ loop_xvrf_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 
 		if (m->packet_type & RTE_PTYPE_L3_IPV4) {
 			edge = IP_INPUT;
-			loop_iface = iface_from_id(ip_output_mbuf_data(m)->nh->iface_id);
+			loop_iface = iface_from_id(ip_output_mbuf_data(m)->nh->l3.iface_id);
 		} else {
 			edge = IP6_INPUT;
-			loop_iface = iface_from_id(ip6_output_mbuf_data(m)->nh->iface_id);
+			loop_iface = iface_from_id(ip6_output_mbuf_data(m)->nh->l3.iface_id);
 		}
 		if (loop_iface == NULL || loop_iface->type != GR_IFACE_TYPE_LOOPBACK) {
 			edge = INVALID_IFACE; // should not happens

--- a/modules/ip/api/dnat44.c
+++ b/modules/ip/api/dnat44.c
@@ -38,11 +38,11 @@ static void dnat44_data_priv_del(struct nexthop *nh) {
 
 	nh->type = GR_NH_T_L3;
 
-	iface = iface_from_id(nh->iface_id);
+	iface = iface_from_id(nh->l3.iface_id);
 	if (iface == NULL)
 		return;
 
-	snat44_static_rule_del(iface, nh->ipv4);
+	snat44_static_rule_del(iface, nh->l3.ipv4);
 }
 
 static struct api_out dnat44_add(const void *request, void ** /*response*/) {
@@ -57,12 +57,12 @@ static struct api_out dnat44_add(const void *request, void ** /*response*/) {
 
 	nh = nexthop_new(&(struct gr_nexthop) {
 		.type = GR_NH_T_DNAT,
-		.af = GR_AF_IP4,
 		.flags = GR_NH_F_LOCAL | GR_NH_F_STATIC,
 		.state = GR_NH_S_REACHABLE,
 		.vrf_id = iface->vrf_id,
-		.iface_id = iface->id,
-		.ipv4 = req->rule.match,
+		.l3.af = GR_AF_IP4,
+		.l3.iface_id = iface->id,
+		.l3.ipv4 = req->rule.match,
 		.origin = GR_NH_ORIGIN_INTERNAL,
 	});
 	if (nh == NULL)
@@ -118,8 +118,8 @@ static void dnat44_list_iter(struct nexthop *nh, void *priv) {
 	data = dnat44_nh_data(nh);
 
 	struct gr_dnat44_rule rule = {
-		.iface_id = nh->iface_id,
-		.match = nh->ipv4,
+		.iface_id = nh->l3.iface_id,
+		.match = nh->l3.ipv4,
 		.replace = data->replace,
 	};
 	gr_vec_add(iter->rules, rule);

--- a/modules/ip/cli/route.c
+++ b/modules/ip/cli/route.c
@@ -79,18 +79,18 @@ static cmd_status_t route4_list(const struct gr_api_client *c, const struct ec_p
 		struct gr_iface iface;
 		scols_line_sprintf(line, 0, "%u", route->vrf_id);
 		scols_line_sprintf(line, 1, IP4_F "/%hhu", &route->dest.ip, route->dest.prefixlen);
-		switch (route->nh.af) {
+		switch (route->nh.l3.af) {
 		case GR_AF_UNSPEC:
-			if (iface_from_id(c, route->nh.iface_id, &iface) < 0)
-				scols_line_sprintf(line, 2, "%u", route->nh.iface_id);
+			if (iface_from_id(c, route->nh.l3.iface_id, &iface) < 0)
+				scols_line_sprintf(line, 2, "%u", route->nh.l3.iface_id);
 			else
 				scols_line_sprintf(line, 2, "%s", iface.name);
 			break;
 		case GR_AF_IP4:
-			scols_line_sprintf(line, 2, IP4_F, &route->nh.ipv4);
+			scols_line_sprintf(line, 2, IP4_F, &route->nh.l3.ipv4);
 			break;
 		case GR_AF_IP6:
-			scols_line_sprintf(line, 2, IP6_F, &route->nh.ipv6);
+			scols_line_sprintf(line, 2, IP6_F, &route->nh.l3.ipv6);
 			break;
 		}
 		scols_line_sprintf(line, 3, "%s", gr_nh_origin_name(route->origin));
@@ -126,13 +126,14 @@ static cmd_status_t route4_get(const struct gr_api_client *c, const struct ec_pn
 		return CMD_ERROR;
 
 	resp = resp_ptr;
-	printf(IP4_F " via " IP4_F " lladdr " ETH_F, &req.dest, &resp->nh.ipv4, &resp->nh.mac);
+	printf(IP4_F " via " IP4_F " lladdr " ETH_F, &req.dest, &resp->nh.l3.ipv4, &resp->nh.l3.mac
+	);
 	if (resp->nh.nh_id != GR_NH_ID_UNSET)
 		printf(" id %u", resp->nh.nh_id);
-	if (iface_from_id(c, resp->nh.iface_id, &iface) == 0)
+	if (iface_from_id(c, resp->nh.l3.iface_id, &iface) == 0)
 		printf(" iface %s", iface.name);
 	else
-		printf(" iface %u", resp->nh.iface_id);
+		printf(" iface %u", resp->nh.l3.iface_id);
 	printf("\n");
 	free(resp_ptr);
 

--- a/modules/ip/control/route.c
+++ b/modules/ip/control/route.c
@@ -236,14 +236,14 @@ static struct api_out route4_add(const void *request, void ** /*response*/) {
 
 		// if the route gateway is reachable via a prefix route,
 		// create a new unresolved nexthop
-		if (nh->ipv4 != req->nh) {
+		if (nh->l3.ipv4 != req->nh) {
 			nh = nexthop_new(&(struct gr_nexthop) {
 				.type = GR_NH_T_L3,
-				.af = GR_AF_IP4,
 				.flags = GR_NH_F_GATEWAY,
 				.vrf_id = req->vrf_id,
-				.iface_id = nh->iface_id,
-				.ipv4 = req->nh,
+				.l3.af = GR_AF_IP4,
+				.l3.iface_id = nh->l3.iface_id,
+				.l3.ipv4 = req->nh,
 				.origin = req->origin,
 			});
 			if (nh == NULL)
@@ -429,7 +429,8 @@ void rib4_cleanup(struct nexthop *nh) {
 			rte_rib_get_ip(rn, &ip);
 			rte_rib_get_depth(rn, &prefixlen);
 			ip = rte_cpu_to_be_32(ip);
-			LOG(DEBUG, "delete " IP4_F "/%hhu via " IP4_F, &ip, prefixlen, &nh->ipv4);
+			LOG(DEBUG, "delete " IP4_F "/%hhu via " IP4_F, &ip, prefixlen, &nh->l3.ipv4
+			);
 			rib4_delete(nh->vrf_id, ip, prefixlen, nh->type);
 		}
 	}
@@ -441,7 +442,8 @@ void rib4_cleanup(struct nexthop *nh) {
 			rte_rib_get_ip(rn, &ip);
 			rte_rib_get_depth(rn, &prefixlen);
 			ip = rte_cpu_to_be_32(ip);
-			LOG(DEBUG, "delete " IP4_F "/%hhu via " IP4_F, &ip, prefixlen, &nh->ipv4);
+			LOG(DEBUG, "delete " IP4_F "/%hhu via " IP4_F, &ip, prefixlen, &nh->l3.ipv4
+			);
 			rib4_delete(nh->vrf_id, ip, prefixlen, nh->type);
 		}
 	}

--- a/modules/ip/datapath/arp_output_reply.c
+++ b/modules/ip/datapath/arp_output_reply.c
@@ -55,7 +55,7 @@ static uint16_t arp_output_reply_process(
 		arp->arp_data.arp_tha = arp->arp_data.arp_sha;
 		iface_get_eth_addr(iface->id, &arp->arp_data.arp_sha);
 		arp->arp_data.arp_tip = arp->arp_data.arp_sip;
-		arp->arp_data.arp_sip = local->ipv4;
+		arp->arp_data.arp_sip = local->l3.ipv4;
 
 		// Prepare ethernet layer info.
 		eth_data = eth_output_mbuf_data(mbuf);

--- a/modules/ip/datapath/arp_output_request.c
+++ b/modules/ip/datapath/arp_output_request.c
@@ -61,7 +61,7 @@ static uint16_t arp_output_request_process(
 	for (unsigned i = 0; i < n_objs; i++) {
 		mbuf = objs[i];
 		nh = control_input_mbuf_data(mbuf)->data;
-		local = addr4_get_preferred(nh->iface_id, nh->ipv4);
+		local = addr4_get_preferred(nh->l3.iface_id, nh->l3.ipv4);
 
 		if (local == NULL) {
 			edge = ERROR;
@@ -79,16 +79,16 @@ static uint16_t arp_output_request_process(
 		arp->arp_opcode = RTE_BE16(RTE_ARP_OP_REQUEST);
 		arp->arp_hlen = sizeof(struct rte_ether_addr);
 		arp->arp_plen = sizeof(ip4_addr_t);
-		if (iface_get_eth_addr(local->iface_id, &arp->arp_data.arp_sha) < 0) {
+		if (iface_get_eth_addr(local->l3.iface_id, &arp->arp_data.arp_sha) < 0) {
 			edge = ERROR;
 			goto next;
 		}
-		arp->arp_data.arp_sip = local->ipv4;
+		arp->arp_data.arp_sip = local->l3.ipv4;
 		if (nh->last_reply != 0)
-			arp->arp_data.arp_tha = nh->mac;
+			arp->arp_data.arp_tha = nh->l3.mac;
 		else
 			memset(&arp->arp_data.arp_tha, 0xff, sizeof(arp->arp_data.arp_tha));
-		arp->arp_data.arp_tip = nh->ipv4;
+		arp->arp_data.arp_tip = nh->l3.ipv4;
 		if (gr_mbuf_is_traced(mbuf)) {
 			struct rte_arp_hdr *t = gr_mbuf_trace_add(mbuf, node, sizeof(*t));
 			*t = *arp;
@@ -101,7 +101,7 @@ static uint16_t arp_output_request_process(
 		else
 			memset(&eth_data->dst, 0xff, sizeof(eth_data->dst));
 		eth_data->ether_type = RTE_BE16(RTE_ETHER_TYPE_ARP);
-		eth_data->iface = iface_from_id(nh->iface_id);
+		eth_data->iface = iface_from_id(nh->l3.iface_id);
 
 		edge = OUTPUT;
 		sent++;

--- a/modules/ip/datapath/dnat44.c
+++ b/modules/ip/datapath/dnat44.c
@@ -35,7 +35,7 @@ dnat44_process(struct rte_graph *graph, struct rte_node *node, void **objs, uint
 
 		if (d->nh == NULL)
 			edge = NO_ROUTE;
-		else if (d->nh->flags & GR_NH_F_LOCAL && ip->dst_addr == d->nh->ipv4)
+		else if (d->nh->flags & GR_NH_F_LOCAL && ip->dst_addr == d->nh->l3.ipv4)
 			edge = LOCAL;
 		else
 			edge = FORWARD;

--- a/modules/ip/datapath/fib4.c
+++ b/modules/ip/datapath/fib4.c
@@ -109,8 +109,8 @@ int fib4_insert(uint16_t vrf_id, ip4_addr_t ip, uint8_t prefixlen, const struct 
 	if (nh->ref_count == 0)
 		ABORT("nexthop has ref_count==0: vrf=%u iface=%u " IP4_F,
 		      nh->vrf_id,
-		      nh->iface_id,
-		      &nh->ipv4);
+		      nh->l3.iface_id,
+		      &nh->l3.ipv4);
 
 	if (rte_lcore_has_role(rte_lcore_id(), ROLE_NON_EAL))
 		ABORT("fib4 modified from datapath thread");

--- a/modules/ip/datapath/icmp_local_send.c
+++ b/modules/ip/datapath/icmp_local_send.c
@@ -54,12 +54,12 @@ int icmp_local_send(
 	msg->ttl = ttl;
 	msg->dst = dst;
 
-	if ((local = addr4_get_preferred(gw->iface_id, gw->ipv4)) == NULL) {
+	if ((local = addr4_get_preferred(gw->l3.iface_id, gw->l3.ipv4)) == NULL) {
 		free(msg);
 		return -errno;
 	}
 
-	msg->src = local->ipv4;
+	msg->src = local->l3.ipv4;
 
 	if ((ret = post_to_stack(ip4_icmp_request, msg)) < 0) {
 		free(msg);

--- a/modules/ip/datapath/ip_error.c
+++ b/modules/ip/datapath/ip_error.c
@@ -52,14 +52,14 @@ ip_error_process(struct rte_graph *graph, struct rte_node *node, void **objs, ui
 			goto next;
 		}
 		// Select preferred source IP address to reply with
-		if ((local = addr4_get_preferred(nh->iface_id, nh->ipv4)) == NULL) {
+		if ((local = addr4_get_preferred(nh->l3.iface_id, nh->l3.ipv4)) == NULL) {
 			edge = NO_IP;
 			goto next;
 		}
 
 		ip_data = ip_local_mbuf_data(mbuf);
 		ip_data->vrf_id = iface->vrf_id;
-		ip_data->src = local->ipv4;
+		ip_data->src = local->l3.ipv4;
 		ip_data->dst = ip->src_addr;
 
 		// RFC792 payload size: ip header + 64 bits of original datagram

--- a/modules/ip/datapath/ip_input.c
+++ b/modules/ip/datapath/ip_input.c
@@ -138,7 +138,7 @@ ip_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, ui
 
 		// If the resolved next hop is local and the destination IP is ourselves,
 		// send to ip_local.
-		if (nh->flags & GR_NH_F_LOCAL && ip->dst_addr == nh->ipv4)
+		if (nh->flags & GR_NH_F_LOCAL && ip->dst_addr == nh->l3.ipv4)
 			edge = LOCAL;
 		else if (e->domain == ETH_DOMAIN_LOOPBACK)
 			edge = OUTPUT;

--- a/modules/ip/datapath/ip_output.c
+++ b/modules/ip/datapath/ip_output.c
@@ -79,7 +79,7 @@ ip_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 		if (edge != ETH_OUTPUT)
 			goto next;
 
-		iface = iface_from_id(nh->iface_id);
+		iface = iface_from_id(nh->l3.iface_id);
 		if (iface == NULL) {
 			edge = ERROR;
 			goto next;
@@ -102,7 +102,7 @@ ip_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 			goto next;
 
 		if (nh->state != GR_NH_S_REACHABLE
-		    || (nh->flags & GR_NH_F_LINK && ip->dst_addr != nh->ipv4)) {
+		    || (nh->flags & GR_NH_F_LINK && ip->dst_addr != nh->l3.ipv4)) {
 			// The nexthop needs ARP resolution or it is associated with
 			// a "connected" route (i.e. matching an address/prefix on
 			// a local interface).
@@ -117,7 +117,7 @@ ip_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 
 		// Prepare ethernet layer info.
 		eth_data = eth_output_mbuf_data(mbuf);
-		eth_data->dst = nh->mac;
+		eth_data->dst = nh->l3.mac;
 		eth_data->ether_type = RTE_BE16(RTE_ETHER_TYPE_IPV4);
 		sent++;
 next:

--- a/modules/ip6/cli/route.c
+++ b/modules/ip6/cli/route.c
@@ -79,18 +79,18 @@ static cmd_status_t route6_list(const struct gr_api_client *c, const struct ec_p
 		struct gr_iface iface;
 		scols_line_sprintf(line, 0, "%u", route->vrf_id);
 		scols_line_sprintf(line, 1, IP6_F "/%hhu", &route->dest, route->dest.prefixlen);
-		switch (route->nh.af) {
+		switch (route->nh.l3.af) {
 		case GR_AF_UNSPEC:
-			if (iface_from_id(c, route->nh.iface_id, &iface) < 0)
-				scols_line_sprintf(line, 2, "%u", route->nh.iface_id);
+			if (iface_from_id(c, route->nh.l3.iface_id, &iface) < 0)
+				scols_line_sprintf(line, 2, "%u", route->nh.l3.iface_id);
 			else
 				scols_line_sprintf(line, 2, "%s", iface.name);
 			break;
 		case GR_AF_IP4:
-			scols_line_sprintf(line, 2, IP4_F, &route->nh.ipv4);
+			scols_line_sprintf(line, 2, IP4_F, &route->nh.l3.ipv4);
 			break;
 		case GR_AF_IP6:
-			scols_line_sprintf(line, 2, IP6_F, &route->nh.ipv6);
+			scols_line_sprintf(line, 2, IP6_F, &route->nh.l3.ipv6);
 			break;
 		}
 		scols_line_sprintf(line, 3, "%s", gr_nh_origin_name(route->origin));
@@ -127,13 +127,14 @@ static cmd_status_t route6_get(const struct gr_api_client *c, const struct ec_pn
 		return CMD_ERROR;
 
 	resp = resp_ptr;
-	printf(IP6_F " via " IP6_F " lladdr " ETH_F, &req.dest, &resp->nh.ipv6, &resp->nh.mac);
+	printf(IP6_F " via " IP6_F " lladdr " ETH_F, &req.dest, &resp->nh.l3.ipv6, &resp->nh.l3.mac
+	);
 	if (resp->nh.nh_id != GR_NH_ID_UNSET)
 		printf(" id %u", resp->nh.nh_id);
-	if (iface_from_id(c, resp->nh.iface_id, &iface) == 0)
+	if (iface_from_id(c, resp->nh.l3.iface_id, &iface) == 0)
 		printf(" iface %s", iface.name);
 	else
-		printf(" iface %u", resp->nh.iface_id);
+		printf(" iface %u", resp->nh.l3.iface_id);
 	printf("\n");
 	free(resp_ptr);
 

--- a/modules/ip6/control/route.c
+++ b/modules/ip6/control/route.c
@@ -257,13 +257,13 @@ static struct api_out route6_add(const void *request, void ** /*response*/) {
 
 		// if the route gateway is reachable via a prefix route,
 		// create a new unresolved nexthop
-		if (!rte_ipv6_addr_eq(&nh->ipv6, &req->nh)) {
+		if (!rte_ipv6_addr_eq(&nh->l3.ipv6, &req->nh)) {
 			nh = nexthop_new(&(struct gr_nexthop) {
 				.type = GR_NH_T_L3,
-				.af = GR_AF_IP6,
 				.vrf_id = nh->vrf_id,
-				.iface_id = nh->iface_id,
-				.ipv6 = req->nh,
+				.l3.af = GR_AF_IP6,
+				.l3.iface_id = nh->l3.iface_id,
+				.l3.ipv6 = req->nh,
 				.origin = req->origin,
 			});
 			if (nh == NULL)
@@ -273,7 +273,7 @@ static struct api_out route6_add(const void *request, void ** /*response*/) {
 
 	// if route insert fails, the created nexthop will be freed
 	ret = rib6_insert(
-		req->vrf_id, nh->iface_id, &req->dest.ip, req->dest.prefixlen, req->origin, nh
+		req->vrf_id, nh->l3.iface_id, &req->dest.ip, req->dest.prefixlen, req->origin, nh
 	);
 	if (ret == -EEXIST && req->exist_ok)
 		ret = 0;
@@ -313,9 +313,9 @@ static struct api_out route6_get(const void *request, void **response) {
 	if ((resp = calloc(1, sizeof(*resp))) == NULL)
 		return api_out(ENOMEM, 0);
 
-	resp->nh.ipv6 = nh->ipv6;
-	resp->nh.iface_id = nh->iface_id;
-	resp->nh.mac = nh->mac;
+	resp->nh.l3.ipv6 = nh->l3.ipv6;
+	resp->nh.l3.iface_id = nh->l3.iface_id;
+	resp->nh.l3.mac = nh->l3.mac;
 	resp->nh.flags = nh->flags;
 
 	*response = resp;
@@ -460,8 +460,8 @@ void rib6_cleanup(struct nexthop *nh) {
 		if (hop == nh) {
 			rte_rib6_get_ip(rn, &ip);
 			rte_rib6_get_depth(rn, &depth);
-			LOG(DEBUG, "delete " IP6_F "/%hhu via " IP6_F, &ip, depth, &nh->ipv6);
-			rib6_delete(hop->vrf_id, hop->iface_id, &ip, depth, nh->type);
+			LOG(DEBUG, "delete " IP6_F "/%hhu via " IP6_F, &ip, depth, &nh->l3.ipv6);
+			rib6_delete(hop->vrf_id, hop->l3.iface_id, &ip, depth, nh->type);
 		}
 	}
 
@@ -471,8 +471,8 @@ void rib6_cleanup(struct nexthop *nh) {
 		if (hop == nh) {
 			rte_rib6_get_ip(rn, &ip);
 			rte_rib6_get_depth(rn, &depth);
-			LOG(DEBUG, "delete " IP6_F "/%hhu via " IP6_F, &ip, depth, &nh->ipv6);
-			rib6_delete(hop->vrf_id, hop->iface_id, &ip, depth, nh->type);
+			LOG(DEBUG, "delete " IP6_F "/%hhu via " IP6_F, &ip, depth, &nh->l3.ipv6);
+			rib6_delete(hop->vrf_id, hop->l3.iface_id, &ip, depth, nh->type);
 		}
 	}
 }

--- a/modules/ip6/control/router_advert.c
+++ b/modules/ip6/control/router_advert.c
@@ -180,8 +180,8 @@ static void send_ra_cb(evutil_socket_t, short /*what*/, void *priv) {
 		return;
 
 	gr_vec_foreach (nh, hl->nh) {
-		struct rte_ipv6_addr ip = nh->ipv6;
-		if (nh->af != GR_AF_IP6)
+		struct rte_ipv6_addr ip = nh->l3.ipv6;
+		if (nh->l3.af != GR_AF_IP6)
 			continue;
 		if (!rte_ipv6_addr_is_linklocal(&ip))
 			continue;

--- a/modules/ip6/datapath/fib6.c
+++ b/modules/ip6/datapath/fib6.c
@@ -114,8 +114,8 @@ int fib6_insert(
 	if (nh->ref_count == 0)
 		ABORT("nexthop has ref_count==0: vrf=%u iface=%u " IP6_F,
 		      nh->vrf_id,
-		      nh->iface_id,
-		      &nh->ipv6);
+		      nh->l3.iface_id,
+		      &nh->l3.ipv6);
 
 	if (rte_lcore_has_role(rte_lcore_id(), ROLE_NON_EAL))
 		ABORT("fib6 modified from datapath thread");

--- a/modules/ip6/datapath/icmp6_input.c
+++ b/modules/ip6/datapath/icmp6_input.c
@@ -65,7 +65,7 @@ icmp6_input_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 					next = NO_LOCAL_ADDR;
 					goto next;
 				}
-				tmp_ip = local->ipv6;
+				tmp_ip = local->l3.ipv6;
 			} else {
 				// swap source/destination addresses
 				tmp_ip = d->dst;

--- a/modules/ip6/datapath/icmp6_local_send.c
+++ b/modules/ip6/datapath/icmp6_local_send.c
@@ -46,17 +46,17 @@ int icmp6_local_send(
 	const struct nexthop *local;
 	int ret;
 
-	if ((local = addr6_get_preferred(gw->iface_id, &gw->ipv6)) == NULL)
+	if ((local = addr6_get_preferred(gw->l3.iface_id, &gw->l3.ipv6)) == NULL)
 		return -errno;
 
 	if ((msg = calloc(1, sizeof(struct ctl_to_stack))) == NULL)
 		return errno_set(ENOMEM);
-	msg->iface_id = gw->iface_id;
+	msg->iface_id = gw->l3.iface_id;
 	msg->seq_num = seq_num;
 	msg->ident = ident;
 	msg->hop_limit = hop_limit;
 	msg->dst = *dst;
-	msg->src = local->ipv6;
+	msg->src = local->l3.ipv6;
 
 	if ((ret = post_to_stack(ctl_icmp6_request, msg)) < 0) {
 		free(msg);

--- a/modules/ip6/datapath/ip6_error.c
+++ b/modules/ip6/datapath/ip6_error.c
@@ -97,7 +97,7 @@ ip6_error_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 			goto next;
 		}
 		d = ip6_local_mbuf_data(mbuf);
-		d->src = nh->ipv6;
+		d->src = nh->l3.ipv6;
 		d->dst = ip->src_addr;
 		d->len = rte_pktmbuf_pkt_len(mbuf);
 		d->iface = iface;

--- a/modules/ip6/datapath/ip6_input.c
+++ b/modules/ip6/datapath/ip6_input.c
@@ -130,7 +130,7 @@ ip6_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 
 		// If the resolved next hop is local and the destination IP is ourselves,
 		// send to ip6_local.
-		if (nh->flags & GR_NH_F_LOCAL && rte_ipv6_addr_eq(&ip->dst_addr, &nh->ipv6))
+		if (nh->flags & GR_NH_F_LOCAL && rte_ipv6_addr_eq(&ip->dst_addr, &nh->l3.ipv6))
 			edge = LOCAL;
 		else if (e->domain == ETH_DOMAIN_LOOPBACK)
 			edge = OUTPUT;

--- a/modules/ip6/datapath/ip6_output.c
+++ b/modules/ip6/datapath/ip6_output.c
@@ -75,11 +75,11 @@ ip6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 		if (edge != ETH_OUTPUT)
 			goto next;
 
-		// For multicast destination, nh->iface will be NULL
+		// For multicast destination, nh->l3.iface will be NULL
 		if (rte_ipv6_addr_is_mcast(&ip->dst_addr))
 			iface = mbuf_data(mbuf)->iface;
 		else
-			iface = iface_from_id(nh->iface_id);
+			iface = iface_from_id(nh->l3.iface_id);
 		if (iface == NULL) {
 			edge = ERROR;
 			goto next;
@@ -101,7 +101,7 @@ ip6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 		if (!rte_ipv6_addr_is_mcast(&ip->dst_addr)
 		    && (nh->state != GR_NH_S_REACHABLE
 			|| (nh->flags & GR_NH_F_LINK
-			    && !rte_ipv6_addr_eq(&ip->dst_addr, &nh->ipv6)))) {
+			    && !rte_ipv6_addr_eq(&ip->dst_addr, &nh->l3.ipv6)))) {
 			edge = HOLD;
 			goto next;
 		}
@@ -112,7 +112,7 @@ ip6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 		if (rte_ipv6_addr_is_mcast(&ip->dst_addr))
 			rte_ether_mcast_from_ipv6(&eth_data->dst, &ip->dst_addr);
 		else
-			eth_data->dst = nh->mac;
+			eth_data->dst = nh->l3.mac;
 		eth_data->ether_type = RTE_BE16(RTE_ETHER_TYPE_IPV6);
 		sent++;
 next:

--- a/modules/ip6/datapath/ndp_na_output.c
+++ b/modules/ip6/datapath/ndp_na_output.c
@@ -51,24 +51,24 @@ static uint16_t ndp_na_output_process(
 		na->override = 1;
 		na->router = 1;
 		na->solicited = remote != NULL;
-		na->target = local->ipv6;
+		na->target = local->l3.ipv6;
 		opt = PAYLOAD(na);
 		opt->type = ICMP6_OPT_TARGET_LLADDR;
 		opt->len = ICMP6_OPT_LEN(sizeof(*opt) + sizeof(*ll));
 		ll = PAYLOAD(opt);
-		ll->mac = local->mac;
+		ll->mac = local->l3.mac;
 
 		// Fill in IP local data
 		d = ip6_local_mbuf_data(mbuf);
-		d->iface = iface_from_id(local->iface_id);
-		d->src = local->ipv6;
+		d->iface = iface_from_id(local->l3.iface_id);
+		d->src = local->l3.ipv6;
 		if (remote == NULL) {
 			// If the source of the solicitation is the unspecified address, the
 			// node MUST set the Solicited flag to zero and multicast the
 			// advertisement to the all-nodes address.
 			d->dst = (struct rte_ipv6_addr)RTE_IPV6_ADDR_ALLNODES_LINK_LOCAL;
 		} else {
-			d->dst = remote->ipv6;
+			d->dst = remote->l3.ipv6;
 		}
 		d->len = payload_len;
 		d->hop_limit = IP6_DEFAULT_HOP_LIMIT;

--- a/modules/ip6/datapath/ndp_ns_output.c
+++ b/modules/ip6/datapath/ndp_ns_output.c
@@ -69,7 +69,7 @@ static uint16_t ndp_ns_output_process(
 			next = ERROR;
 			goto next;
 		}
-		local = addr6_get_preferred(nh->iface_id, &nh->ipv6);
+		local = addr6_get_preferred(nh->l3.iface_id, &nh->l3.ipv6);
 		if (local == NULL) {
 			next = ERROR;
 			goto next;
@@ -82,21 +82,21 @@ static uint16_t ndp_ns_output_process(
 		icmp6->code = 0;
 		ns = PAYLOAD(icmp6);
 		ns->__reserved = 0;
-		ns->target = nh->ipv6;
+		ns->target = nh->l3.ipv6;
 		opt = PAYLOAD(ns);
 		opt->type = ICMP6_OPT_SRC_LLADDR;
 		opt->len = ICMP6_OPT_LEN(sizeof(*opt) + sizeof(*lladdr));
 		lladdr = PAYLOAD(opt);
-		lladdr->mac = local->mac;
+		lladdr->mac = local->l3.mac;
 
 		// Fill in IP local data
 		d = ip6_local_mbuf_data(mbuf);
-		d->iface = iface_from_id(local->iface_id);
-		d->src = local->ipv6;
+		d->iface = iface_from_id(local->l3.iface_id);
+		d->src = local->l3.ipv6;
 		if (nh->last_reply != 0 && nh->bcast_probes == 0)
-			d->dst = nh->ipv6;
+			d->dst = nh->l3.ipv6;
 		else
-			rte_ipv6_solnode_from_addr(&d->dst, &nh->ipv6);
+			rte_ipv6_solnode_from_addr(&d->dst, &nh->l3.ipv6);
 		d->len = payload_len;
 		d->hop_limit = IP6_DEFAULT_HOP_LIMIT;
 		d->proto = IPPROTO_ICMPV6;

--- a/modules/ipip/datapath_out.c
+++ b/modules/ipip/datapath_out.c
@@ -42,7 +42,7 @@ ipip_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 
 		// Resolve the IPIP interface from the nexthop provided by ip_output.
 		ip_data = ip_output_mbuf_data(mbuf);
-		iface = iface_from_id(ip_data->nh->iface_id);
+		iface = iface_from_id(ip_data->nh->l3.iface_id);
 		if (iface == NULL || iface->type != GR_IFACE_TYPE_IPIP) {
 			edge = NO_TUNNEL;
 			goto next;

--- a/modules/srv6/control/localsid.c
+++ b/modules/srv6/control/localsid.c
@@ -29,12 +29,12 @@ static struct api_out srv6_localsid_add(const void *request, void ** /*response*
 	struct srv6_localsid_nh_priv *data;
 	struct gr_nexthop base = {
 		.type = GR_NH_T_SR6_LOCAL,
-		.af = GR_AF_IP6,
 		.flags = GR_NH_F_LOCAL | GR_NH_F_STATIC,
 		.state = GR_NH_S_REACHABLE,
+		.l3.af = GR_AF_IP6,
 		.vrf_id = req->l.vrf_id,
-		.iface_id = GR_IFACE_ID_UNDEF,
-		.ipv6 = req->l.lsid,
+		.l3.iface_id = GR_IFACE_ID_UNDEF,
+		.l3.ipv6 = req->l.lsid,
 		.origin = req->origin,
 	};
 	struct nexthop *nh;
@@ -83,7 +83,7 @@ static void nh_srv6_list_cb(struct nexthop *nh, void *priv) {
 	data = srv6_localsid_nh_priv(nh);
 	memset(&ldata, 0x00, sizeof(ldata));
 
-	ldata.lsid = nh->ipv6;
+	ldata.lsid = nh->l3.ipv6;
 	ldata.vrf_id = nh->vrf_id;
 	ldata.behavior = data->behavior;
 	ldata.flags = data->flags;

--- a/modules/srv6/control/route.c
+++ b/modules/srv6/control/route.c
@@ -80,7 +80,7 @@ static struct api_out srv6_route_add(const void *request, void ** /*response*/) 
 		.state = GR_NH_S_REACHABLE,
 		.flags = GR_NH_F_GATEWAY | GR_NH_F_STATIC,
 		.vrf_id = req->r.key.vrf_id,
-		.iface_id = GR_IFACE_ID_UNDEF,
+		.l3.iface_id = GR_IFACE_ID_UNDEF,
 		.origin = req->origin,
 	};
 	struct nexthop *nh;
@@ -88,13 +88,13 @@ static struct api_out srv6_route_add(const void *request, void ** /*response*/) 
 
 	// retrieve or create nexthop into rib4/rib6
 	if (req->r.key.is_dest6) {
-		base.ipv6 = req->r.key.dest6.ip;
-		base.prefixlen = req->r.key.dest6.prefixlen;
-		base.af = GR_AF_IP6;
+		base.l3.ipv6 = req->r.key.dest6.ip;
+		base.l3.prefixlen = req->r.key.dest6.prefixlen;
+		base.l3.af = GR_AF_IP6;
 	} else {
-		base.ipv4 = req->r.key.dest4.ip;
-		base.prefixlen = req->r.key.dest4.prefixlen;
-		base.af = GR_AF_IP4;
+		base.l3.ipv4 = req->r.key.dest4.ip;
+		base.l3.prefixlen = req->r.key.dest4.prefixlen;
+		base.l3.af = GR_AF_IP4;
 	}
 
 	nh = nexthop_new(&base);
@@ -202,16 +202,16 @@ static struct api_out srv6_route_list(const void *request, void **response) {
 		d = srv6_encap_nh_priv(nh)->d;
 
 		r->key.vrf_id = nh->vrf_id;
-		switch (nh->af) {
+		switch (nh->l3.af) {
 		case GR_AF_IP6:
 			r->key.is_dest6 = true;
-			r->key.dest6.ip = nh->ipv6;
-			r->key.dest6.prefixlen = nh->prefixlen;
+			r->key.dest6.ip = nh->l3.ipv6;
+			r->key.dest6.prefixlen = nh->l3.prefixlen;
 			break;
 		case GR_AF_IP4:
 			r->key.is_dest6 = false;
-			r->key.dest4.ip = nh->ipv4;
-			r->key.dest4.prefixlen = nh->prefixlen;
+			r->key.dest4.ip = nh->l3.ipv4;
+			r->key.dest4.prefixlen = nh->l3.prefixlen;
 			break;
 		default:
 			// should never happen
@@ -252,13 +252,13 @@ static struct api_out srv6_tunsrc_set(const void *request, void ** /*response*/)
 
 	struct gr_nexthop base = {
 		.type = GR_NH_T_L3,
-		.af = GR_AF_IP6,
 		.flags = GR_NH_F_LOCAL | GR_NH_F_LINK | GR_NH_F_STATIC,
 		.state = GR_NH_S_REACHABLE,
 		.vrf_id = GR_VRF_ID_ALL,
-		.iface_id = GR_IFACE_ID_UNDEF,
-		.ipv6 = req->addr,
-		.prefixlen = 128,
+		.l3.af = GR_AF_IP6,
+		.l3.iface_id = GR_IFACE_ID_UNDEF,
+		.l3.ipv6 = req->addr,
+		.l3.prefixlen = 128,
 		.origin = GR_NH_ORIGIN_LINK,
 	};
 
@@ -282,7 +282,7 @@ static struct api_out srv6_tunsrc_show(const void * /*request*/, void **response
 		return api_out(-ENOMEM, 0);
 
 	if (tunsrc_nh)
-		resp->addr = tunsrc_nh->ipv6;
+		resp->addr = tunsrc_nh->l3.ipv6;
 	else
 		resp->addr = unspec;
 

--- a/modules/srv6/datapath/srv6_output.c
+++ b/modules/srv6/datapath/srv6_output.c
@@ -62,8 +62,8 @@ srv6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 
 			nh = ip_output_mbuf_data(m)->nh;
 			if (t != NULL) {
-				t->dest4.ip = nh->ipv4;
-				t->dest4.prefixlen = nh->prefixlen;
+				t->dest4.ip = nh->l3.ipv4;
+				t->dest4.prefixlen = nh->l3.prefixlen;
 				t->is_dest6 = false;
 			}
 			inner_ip4 = rte_pktmbuf_mtod(m, struct rte_ipv4_hdr *);
@@ -75,8 +75,8 @@ srv6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 
 			nh = ip6_output_mbuf_data(m)->nh;
 			if (t != NULL) {
-				t->dest6.ip = nh->ipv6;
-				t->dest6.prefixlen = nh->prefixlen;
+				t->dest6.ip = nh->l3.ipv6;
+				t->dest6.prefixlen = nh->l3.prefixlen;
 				t->is_dest6 = true;
 			}
 			inner_ip6 = rte_pktmbuf_mtod(m, struct rte_ipv6_hdr *);
@@ -134,14 +134,14 @@ srv6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 		}
 		ip6_output_mbuf_data(m)->nh = nh;
 
-		nh = sr_tunsrc_get(nh->iface_id, &nh->ipv6);
+		nh = sr_tunsrc_get(nh->l3.iface_id, &nh->l3.ipv6);
 		if (nh == NULL) {
 			// cannot output packet on interface that does not have ip6 addr
 			edge = NO_ROUTE;
 			goto next;
 		}
 
-		ip6_set_fields(outer_ip6, plen, proto, &nh->ipv6, &d->seglist[0]);
+		ip6_set_fields(outer_ip6, plen, proto, &nh->l3.ipv6, &d->seglist[0]);
 		edge = IP6_OUTPUT;
 
 next:


### PR DESCRIPTION
Huge refactor of gr_nexthop structure to split
the different fields according to the nexthop type.

Only did it for the exercise of doing it, to understand if this is relevant.