### PR TITLE
ip,ip6: allow route replace from api

### DIFF
--- a/smoke/config_test.sh
+++ b/smoke/config_test.sh
@@ -17,11 +17,13 @@ grcli add nexthop address 4.3.2.1 iface p1 mac ba:d0:ca:ca:00:01
 grcli add ip address 10.0.0.1/24 iface p0
 grcli add ip address 10.1.0.1/24 iface p1
 grcli add ip route 0.0.0.0/0 via 10.0.0.2
+grcli add ip route 0.0.0.0/0 via 10.0.0.1 || fail "route replace should succeed"
 grcli add ip route 4.5.21.2/27 via id 47
 grcli add ip route 172.16.47.0/24 via id 1047
 grcli add ip6 address 2345::1/24 iface p0
 grcli add ip6 address 2346::1/24 iface p1
 grcli add ip6 route ::/0 via 2345::2
+grcli add ip6 route ::/0 via 2345::1 || fail "route6 replace should succeed"
 grcli add ip6 route 2521:111::4/37 via id 1047
 grcli add ip6 route 2521:112::/64 via id 45
 grcli add ip6 route 2521:113::/64 via id 47


### PR DESCRIPTION
On a route update, FRR doesn't remove and add a route, but calls a route add.
This call is rejected as the route already exists. Allow route modification from the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - IPv4/IPv6 route insertion now supports conditional replacement of existing routes, preserves public APIs, and marks gateway routes while emitting route-add events for non-internal origins.

- **Tests**
  - Smoke test extended to insert multiple default routes for IPv4 and IPv6 and verify that route replacements succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->