### PR TITLE
tools: add gdb pretty-print

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,2 @@
+handle SIG35 ignore noprint nostop
+source devtools/gdb_pprint.py

--- a/README.md
+++ b/README.md
@@ -293,6 +293,39 @@ Use ? for help and <tab> for command completion.
 grout#
 ```
 
+### Debugging tools
+
+Pretty printers for Grout are available in `devtools/gdb_pprint.py`.
+
+To automatically load them, a `.gdbinit` file is provided, that you can enable
+by adding the following to your `$HOME/.gdbinit` file:
+
+```
+set auto-load local-gdbinit on
+set auto-load safe-path /
+```
+
+You can also load the python script manually:
+
+```
+(gdb) source devtools/gdb_pprint.py
+```
+
+Multiple pretty printers are available, you can verify they are loaded with
+`info pretty-printer`:
+
+```
+(gdb) info pretty-printer
+global pretty-printers:
+  builtin
+    mpx_bound128
+  grout
+    ip4_addr_t
+    struct iface
+    struct rte_ether_addr
+    struct rte_ipv6_addr
+```
+
 ## Contact
 
 * Mailing list: grout@dpdk.org ([archives](http://mails.dpdk.org/archives/grout/))

--- a/devtools/gdb_pprint.py
+++ b/devtools/gdb_pprint.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Christophe Fontaine
+
+import socket
+
+import gdb
+import gdb.printing
+
+
+class IP4Address:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        buf = self.val.address.cast(gdb.lookup_type("unsigned char").pointer())
+        return socket.inet_ntop(socket.AF_INET, bytes(buf[i] for i in range(4)))
+
+
+class IP6Address:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        buf = bytes(self.val["a"][i] for i in range(16))
+        return socket.inet_ntop(socket.AF_INET6, buf)
+
+
+class EtherAddress:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        buf = bytes(self.val["addr_bytes"][i] for i in range(6))
+        return ":".join(f"{b:02x}" for b in buf)
+
+
+class Iface:
+    TYPE_STRUCTS = {
+        "GR_IFACE_TYPE_PORT": "struct __gr_iface_info_port_base",
+        "GR_IFACE_TYPE_VLAN": "struct gr_iface_info_vlan",
+        "GR_IFACE_TYPE_IPIP": "struct gr_iface_info_ipip",
+    }
+
+    def __init__(self, val):
+        self.val = val
+        self.sub_types = {}
+        for type_id, struct in self.TYPE_STRUCTS.items():
+            type_id = int(gdb.lookup_static_symbol(type_id).value())
+            struct = gdb.lookup_type(struct)
+            self.sub_types[type_id] = struct
+
+    def children(self):
+        base_type = gdb.lookup_type("struct __gr_iface_base")
+        ptr = self.val.address.cast(base_type.pointer())
+        base = ptr.dereference()
+        yield (("base", base))
+
+        for field in self.val.type.strip_typedefs().fields():
+            if field.name is None:
+                continue
+
+            if field.name == "info" and int(self.val["type"]) in self.sub_types:
+                port_type = self.sub_types[int(self.val["type"])]
+                ptr = self.val["info"].address.cast(port_type.pointer())
+                info = ptr.dereference()
+                yield (("info", info))
+            else:
+                # yield normally → GDB prints colored "field = value"
+                yield (field.name, self.val[field])
+
+
+def load_grout_pprint():
+    pp = gdb.printing.RegexpCollectionPrettyPrinter("grout")
+    pp.add_printer("ip4_addr_t", r"^ip4_addr_t$", IP4Address)
+    pp.add_printer("struct rte_ipv6_addr", r"^rte_ipv6_addr$", IP6Address)
+    pp.add_printer("struct rte_ether_addr", r"^rte_ether_addr$", EtherAddress)
+    pp.add_printer("struct iface", r"^iface$", Iface)
+    return pp
+
+
+gdb.printing.register_pretty_printer(
+    gdb.current_objfile(), load_grout_pprint(), replace=True
+)


### PR DESCRIPTION
Ease our lives with some pretty print in gdb.
"p iface" now prints the content of "info" according to the port type.

Mac address, IPv4 and IPv6 are printed in a human readable form as well.
```
(gdb) p *ifaces[257]
$177 = {base = {id = 257, type = GR_IFACE_TYPE_PORT, mode = GR_IFACE_MODE_L3, flags = GR_IFACE_F_UP, state = GR_IFACE_S_RUNNING, mtu = 1500, {vrf_id = 0, domain_id = 0}}, subinterfaces = 0x0, name = 0x1489950 "cv0", info = {n_rxq = 1, n_txq = 1, rxq_size = 4096,
    txq_size = 4096, link_speed = 25000, mac = b4:83:51:05:43:ca}}

(gdb) p *base
$178 = {type = GR_NH_T_L3, af = GR_AF_IP6, state = GR_NH_S_NEW, flags = 0, nh_id = 0, vrf_id = 0, iface_id = 257, mac = 00:00:00:00:00:00, prefixlen = 0 '\000', origin = GR_NH_ORIGIN_USER, {addr = {<No data fields>}, ipv4 = 32.1.0.1, ipv6 = 2001:1::42}}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GDB pretty-printers for IPv4, IPv6, Ethernet addresses, and interface structures for clearer, human-readable debugging output.
  - Automatic loading/registration so printers are available during debug sessions.

- **Documentation**
  - New "Debugging tools" section with setup, auto-load guidance, and verification steps for the printers.

- **Chores**
  - Updated GDB configuration to ignore signal 35 and auto-load the pretty-printer module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->