### PR TITLE
ip: copy input ttl for local packets

### DIFF
--- a/modules/ip/datapath/ip_local.c
+++ b/modules/ip/datapath/ip_local.c
@@ -47,6 +47,7 @@ static uint16_t ip_input_local_process(
 			data->len = rte_be_to_cpu_16(ip->total_length) - rte_ipv4_hdr_len(ip);
 			data->vrf_id = iface->vrf_id;
 			data->proto = ip->next_proto_id;
+			data->ttl = ip->time_to_live;
 			rte_pktmbuf_adj(mbuf, sizeof(*ip));
 		}
 		rte_node_enqueue_x1(graph, node, edge, mbuf);


### PR DESCRIPTION
Some protocols (such as BFD) check the TTL value of the ingress packets. As the TTL field wasn'y copied in the local mbuf data, the default value (64) was used when the packet was emitted on the kernel interface.

Copy the proper value instead.