### PR TITLE
Rpm frr

### DIFF
--- a/.github/actions/frr-install/action.yml
+++ b/.github/actions/frr-install/action.yml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Robin Jarry
+---
+name: Install FRR
+
+inputs:
+  sysconfdir:
+    required: true
+  libdir:
+    required: true
+  libexecdir:
+    required: true
+  sbindir:
+    required: true
+  localstatedir:
+    required: true
+  yangmodelsdir:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install FRR
+      shell: bash
+      run: ./.github/actions/frr-install/run.sh
+      env:
+        SYSCONFDIR: ${{inputs.sysconfdir}}
+        LIBDIR: ${{inputs.libdir}}
+        LIBEXECDIR: ${{inputs.libexecdir}}
+        SBINDIR: ${{inputs.sbindir}}
+        LOCALSTATEDIR: ${{inputs.localstatedir}}
+        YANGMODELSDIR: ${{inputs.yangmodelsdir}}

--- a/.github/actions/frr-install/run.sh
+++ b/.github/actions/frr-install/run.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Robin Jarry
+
+set -xe -o pipefail
+
+: ${PREFIX:=/usr}
+: ${SYSCONFDIR:=/etc/frr}
+: ${LIBDIR:=/usr/lib64}
+: ${SBINDIR:=/usr/lib/frr}
+: ${LIBEXECDIR:=/usr/libexec}
+: ${LOCALSTATEDIR:=/run/frr}
+: ${YANGMODELSDIR:=/usr/share/frr-yang}
+
+frr_url=$(sed -n 's/url = //p' subprojects/frr.wrap)
+frr_tag=$(sed -n 's/revision = //p' subprojects/frr.wrap)
+
+git clone --depth=1 --branch="$frr_tag" "$frr_url" frr_build
+cd frr_build
+curl -L https://github.com/FRRouting/frr/pull/19351.diff | patch -p1
+autoreconf -ivf
+./configure \
+	--prefix=/usr \
+	--sysconfdir="$SYSCONFDIR" \
+	--libdir="$LIBDIR/frr" \
+	--libexecdir="$LIBEXECDIR/frr" \
+	--localstatedir="$LOCALSTATEDIR" \
+	--sbindir="$SBINDIR" \
+	--with-moduledir="$LIBDIR/frr/modules" \
+	--with-yangmodelsdir="$YANGMODELSDIR" \
+	--disable-doc --enable-multipath=1 \
+	--disable-ripd --disable-ripngd --disable-ospfd --disable-ospf6d \
+	--disable-ldpd --disable-nhrpd --disable-eigrpd --disable-babeld \
+	--disable-isisd --disable-pimd --disable-pim6d --disable-pbrd \
+	--disable-fabricd --disable-vrrpd --disable-pathd --disable-ospfapi \
+	--disable-ospfclient --disable-bfdd --disable-python-runtime
+make -j install
+install -Dm 0644 pkgconfig/frr.pc "$LIBDIR/pkgconfig/frr.pc"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,11 +8,6 @@ permissions:
 
 on:
   workflow_call:
-    inputs:
-      upload:
-        type: boolean
-        required: false
-        default: false
   pull_request:
     branches:
       - main
@@ -42,11 +37,8 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: deb-packages
-          path: |
-            grout*.deb
-            grout*.ddeb
+          path: grout*.*deb
           retention-days: 5
-        if: ${{ inputs.upload }}
 
   rpm:
     permissions:
@@ -75,4 +67,3 @@ jobs:
           name: rpm-packages
           path: grout*.rpm
           retention-days: 5
-        if: ${{ inputs.upload }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,27 +17,39 @@ jobs:
     permissions:
       actions: write
     runs-on: ubuntu-24.04
+    container: "debian:stable"
     steps:
       - name: install system dependencies
         run: |
           set -xe
-          sudo apt-get update -qy
-          sudo apt-get install -qy --no-install-recommends \
-            git build-essential meson ninja-build pkgconf go-md2man \
-            python3-pyelftools bash-completion devscripts debhelper \
-            libcmocka-dev libedit-dev libevent-dev libnuma-dev \
-            libsmartcols-dev libarchive-dev libibverbs-dev
+          apt-get update -qy
+          apt-get install -qy --no-install-recommends \
+            autoconf automake bash-completion bison build-essential debhelper \
+            curl devscripts flex git go-md2man libarchive-dev libcap-dev \
+            libcmocka-dev libedit-dev libelf-dev libevent-dev libibverbs-dev \
+            libjson-c-dev libnuma-dev libprotobuf-c-dev libreadline-dev \
+            librtr-dev libsmartcols-dev libtool libyang-dev meson ninja-build \
+            patch pkg-config protobuf-c-compiler python3-dev python3-pyelftools \
+            texinfo
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # force fetch all history
           persist-credentials: false
       - run: git config --global --add safe.directory $PWD
       - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
+      - uses: ./.github/actions/frr-install
+        with:
+          sysconfdir: /etc/frr
+          libdir: /usr/lib/x86_64-linux-gnu
+          libexecdir: /usr/libexec
+          sbindir: /usr/lib/frr
+          localstatedir: /run/frr
+          yangmodelsdir: /usr/share/frr-yang
       - run: make deb
       - uses: actions/upload-artifact@v4
         with:
           name: deb-packages
-          path: grout*.*deb
+          path: grout*.deb
           retention-days: 5
 
   rpm:
@@ -49,18 +61,29 @@ jobs:
       - name: install system dependencies
         run: |
           set -xe
+          dnf install -y https://rpm.frrouting.org/repo/frr-10-repo.el9.noarch.rpm
           dnf --enablerepo=crb install -y --nodocs --setopt=install_weak_deps=0 \
-            git make meson ninja-build pkgconf python3-pyelftools \
-            gcc-toolset-13 scl-utils golang-github-cpuguy83-md2man \
-            libcmocka-devel libedit-devel libevent-devel numactl-devel \
-            libsmartcols-devel libarchive-devel rdma-core-devel \
-            rpm-build systemd
+            autoconf automake bison elfutils-libelf-devel flex gcc-toolset-13 \
+            git golang-github-cpuguy83-md2man json-c-devel libarchive-devel \
+            libcap-devel libcmocka-devel libedit-devel libevent-devel \
+            libsmartcols-devel libyang-devel libtool make meson ninja-build \
+            numactl-devel pkgconf protobuf-c-compiler protobuf-c-devel \
+            python3-pyelftools python3-devel rdma-core-devel readline-devel \
+            rpm-build scl-utils systemd
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # force fetch all history
           persist-credentials: false
       - run: git config --global --add safe.directory $PWD
       - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
+      - uses: ./.github/actions/frr-install
+        with:
+          sysconfdir: /etc
+          libdir: /usr/lib64
+          libexecdir: /usr/libexec
+          sbindir: /usr/lib64/frr
+          localstatedir: /var
+          yangmodelsdir: /usr/share/frr-yang
       - run: make rpm RPMBUILD_OPTS="-D 'toolset gcc-toolset-13'"
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,26 +42,46 @@ jobs:
         with:
           pattern: "*-packages"
           merge-multiple: true
+      - uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
       - uses: docker/metadata-action@v5
         name: Extract metadata for the Docker image
-        id: meta
+        id: meta-grout
         with:
           images: "quay.io/grout/grout"
           tags: |
               type=edge,branch=main
               type=semver,pattern={{version}}
               type=semver,pattern={{major}}.{{minor}}
-      - uses: docker/login-action@v3
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USER }}
-          password: ${{ secrets.QUAY_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: .
-          file: Containerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          file: Containerfile.grout
+          tags: ${{ steps.meta-grout.outputs.tags }}
+          labels: ${{ steps.meta-grout.outputs.labels }}
+          push: true
+      - run: sed -n 's/^revision = /version=/p' subprojects/frr.wrap >> $GITHUB_OUTPUT
+        id: frr-version
+      - uses: docker/metadata-action@v5
+        name: Extract metadata for the Docker image
+        id: meta-frr
+        with:
+          images: "quay.io/grout/frr"
+          tags: |
+            type=edge,branch=main
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          labels: |
+            frr_version=${{steps.frr-version.outputs.version}}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Containerfile.frr
+          tags: ${{ steps.meta-frr.outputs.tags }}
+          labels: ${{ steps.meta-frr.outputs.labels }}
           push: true
       - uses: pyTooling/Actions/releaser@r0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,6 @@ jobs:
       contents: read
       actions: write
     uses: ./.github/workflows/package.yml
-    with:
-      upload: true
 
   upload:
     permissions:
@@ -70,10 +68,5 @@ jobs:
           token: ${{ github.token }}
           tag: "edge"
           files: |
-            grout.x86_64.rpm
-            grout-devel.noarch.rpm
-            grout-debuginfo.x86_64.rpm
-            grout-debugsource.x86_64.rpm
-            grout_amd64.deb
-            grout-dev_all.deb
-            grout-dbgsym_amd64.ddeb
+            grout*.rpm
+            grout*.*deb

--- a/Containerfile
+++ b/Containerfile
@@ -2,9 +2,9 @@
 # Copyright (c) 2025 Christophe Fontaine
 
 FROM registry.access.redhat.com/ubi9 as ubi-builder
-COPY grout.*.rpm /tmp
+COPY grout.*.rpm grout-prometheus.*.rpm /tmp
 RUN mkdir -p /tmp/null
-RUN dnf -y install --nodocs --setopt=install_weak_deps=0 --releasever 9 --installroot /tmp/null /tmp/grout.$(arch).rpm
+RUN dnf -y install --nodocs --setopt=install_weak_deps=0 --releasever 9 --installroot /tmp/null /tmp/grout*.rpm
 RUN dnf -y --installroot /tmp/null clean all
 RUN rm -rf /tmp/null/var/cache/* /tmp/null/var/log/dnf* /tmp/null/var/log/yum.*
 

--- a/Containerfile.frr
+++ b/Containerfile.frr
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Robin Jarry
+
+FROM quay.io/centos/centos:stream9 AS builder
+COPY grout-frr.*.rpm /tmp
+RUN mkdir -p /tmp/null
+RUN dnf -y install https://rpm.frrouting.org/repo/frr-10-repo.el9.noarch.rpm
+RUN dnf -y install --nodocs --setopt=install_weak_deps=0 --releasever 9 --installroot /tmp/null /tmp/grout-frr.*.rpm
+RUN dnf -y --installroot /tmp/null clean all
+RUN rm -rf /tmp/null/var/cache/* /tmp/null/var/log/dnf* /tmp/null/var/log/yum.*
+RUN sed -i 's#^zebra_options=.*#zebra_options="-A 127.0.0.1 --log stdout -M frr_dplane_grout"#' /tmp/null/etc/frr/daemons
+RUN mkdir -p /tmp/null/var/run/frr
+RUN chroot /tmp/null chown -R frr:frr /etc/frr /var/run/frr
+# not packaged in centos, download from upstream
+ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tmp/null/sbin/tini
+ADD https://raw.githubusercontent.com/FRRouting/frr/refs/tags/frr-10.4.1/docker/ubi8-minimal/docker-start /tmp/null/sbin/frr-start
+RUN chmod +x /tmp/null/sbin/tini /tmp/null/sbin/frr-start
+
+FROM scratch
+COPY --from=builder /tmp/null/ /
+STOPSIGNAL SIGRTMIN+3
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/sbin/frr-start"]

--- a/Containerfile.grout
+++ b/Containerfile.grout
@@ -8,6 +8,6 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=0 --releasever 9 --instal
 RUN dnf -y --installroot /tmp/null clean all
 RUN rm -rf /tmp/null/var/cache/* /tmp/null/var/log/dnf* /tmp/null/var/log/yum.*
 
-FROM registry.access.redhat.com/ubi9-micro
+FROM scratch
 COPY --from=ubi-builder /tmp/null/ /
 CMD ["/usr/bin/grout"]

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -76,7 +76,9 @@ deb:
 	mv -vf ../grout-dev_$(debversion)_all.deb grout-dev_all.deb && \
 	mv -vf ../grout-prometheus_$(debversion)_all.deb grout-prometheus_all.deb && \
 	mv -vf ../grout_$(debversion)_$$arch.deb grout_$$arch.deb && \
-	mv -vf ../grout-dbgsym_$(debversion)_$$arch.ddeb grout-dbgsym_$$arch.ddeb
+	mv -vf ../grout-dbgsym_$(debversion)_$$arch.deb grout-dbgsym_$$arch.deb && \
+	mv -vf ../grout-frr_$(debversion)_$$arch.deb grout-frr_$$arch.deb && \
+	mv -vf ../grout-frr-dbgsym_$(debversion)_$$arch.deb grout-frr-dbgsym_$$arch.deb
 
 rpmversion = $(firstword $(version))
 rpmrelease = $(subst -,.,$(lastword $(version))).$(shell sed -nE 's/PLATFORM_ID="platform:(.*)"/\1/p' /etc/os-release)
@@ -89,7 +91,9 @@ rpm:
 	mv -vf ~/rpmbuild/RPMS/noarch/grout-devel-$$version.noarch.rpm grout-devel.noarch.rpm && \
 	mv -vf ~/rpmbuild/RPMS/noarch/grout-prometheus-$$version.noarch.rpm grout-prometheus.noarch.rpm && \
 	mv -vf ~/rpmbuild/RPMS/$$arch/grout-$$version.$$arch.rpm grout.$$arch.rpm && \
-	mv -vf ~/rpmbuild/RPMS/$$arch/grout-debuginfo-$$version.$$arch.rpm grout-debuginfo.$$arch.rpm
+	mv -vf ~/rpmbuild/RPMS/$$arch/grout-debuginfo-$$version.$$arch.rpm grout-debuginfo.$$arch.rpm && \
+	mv -vf ~/rpmbuild/RPMS/$$arch/grout-frr-$$version.$$arch.rpm grout-frr.$$arch.rpm && \
+	mv -vf ~/rpmbuild/RPMS/$$arch/grout-frr-debuginfo-$$version.$$arch.rpm grout-frr-debuginfo.$$arch.rpm
 
 CLANG_FORMAT ?= clang-format
 c_src = git ls-files '*.[ch]' ':!:subprojects'

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -74,6 +74,7 @@ deb:
 	dpkg-buildpackage -b
 	$Q arch=`dpkg-architecture -qDEB_HOST_ARCH` && \
 	mv -vf ../grout-dev_$(debversion)_all.deb grout-dev_all.deb && \
+	mv -vf ../grout-prometheus_$(debversion)_all.deb grout-prometheus_all.deb && \
 	mv -vf ../grout_$(debversion)_$$arch.deb grout_$$arch.deb && \
 	mv -vf ../grout-dbgsym_$(debversion)_$$arch.ddeb grout-dbgsym_$$arch.ddeb
 
@@ -86,10 +87,9 @@ rpm:
 	$Q arch=`rpm --eval '%{_arch}'` && \
 	version="$(rpmversion)-$(rpmrelease)" && \
 	mv -vf ~/rpmbuild/RPMS/noarch/grout-devel-$$version.noarch.rpm grout-devel.noarch.rpm && \
-	for name in grout grout-debuginfo; do \
-		mv -vf ~/rpmbuild/RPMS/$$arch/$$name-$$version.$$arch.rpm \
-			$$name.$$arch.rpm || exit; \
-	done
+	mv -vf ~/rpmbuild/RPMS/noarch/grout-prometheus-$$version.noarch.rpm grout-prometheus.noarch.rpm && \
+	mv -vf ~/rpmbuild/RPMS/$$arch/grout-$$version.$$arch.rpm grout.$$arch.rpm && \
+	mv -vf ~/rpmbuild/RPMS/$$arch/grout-debuginfo-$$version.$$arch.rpm grout-debuginfo.$$arch.rpm
 
 CLANG_FORMAT ?= clang-format
 c_src = git ls-files '*.[ch]' ':!:subprojects'

--- a/debian/control
+++ b/debian/control
@@ -88,3 +88,24 @@ Description: Prometheus exporter for grout
  It comes with a client library to configure it over a standard UNIX socket and
  a CLI that uses that library. The CLI can be used as an interactive shell, but
  also in scripts one command at a time, or by batches.
+
+Package: grout-frr
+Architecture: linux-any
+Depends:
+ ${misc:Depends},
+ ${shlibs:Depends},
+ frr (= 10.4.1),
+Description: FRR dplane plugin for grout
+ grout stands for Graph Router. In English, "grout" refers to thin mortar that
+ hardens to fill gaps between tiles.
+ .
+ grout is a DPDK based network processing application. It uses the rte_graph
+ library for data path processing.
+ .
+ Its main purpose is to simulate a network function or a physical router for
+ testing/replicating real (usually closed source) VNF/CNF behavior with an
+ opensource tool.
+ .
+ It comes with a client library to configure it over a standard UNIX socket and
+ a CLI that uses that library. The CLI can be used as an interactive shell, but
+ also in scripts one command at a time, or by batches.

--- a/debian/control
+++ b/debian/control
@@ -68,3 +68,23 @@ Description: API headers for grout clients
  It comes with a client library to configure it over a standard UNIX socket and
  a CLI that uses that library. The CLI can be used as an interactive shell, but
  also in scripts one command at a time, or by batches.
+
+Package: grout-prometheus
+Architecture: all
+Depends:
+ ${misc:Depends},
+ python3,
+Description: Prometheus exporter for grout
+ grout stands for Graph Router. In English, "grout" refers to thin mortar that
+ hardens to fill gaps between tiles.
+ .
+ grout is a DPDK based network processing application. It uses the rte_graph
+ library for data path processing.
+ .
+ Its main purpose is to simulate a network function or a physical router for
+ testing/replicating real (usually closed source) VNF/CNF behavior with an
+ opensource tool.
+ .
+ It comes with a client library to configure it over a standard UNIX socket and
+ a CLI that uses that library. The CLI can be used as an interactive shell, but
+ also in scripts one command at a time, or by batches.

--- a/debian/grout-frr.install
+++ b/debian/grout-frr.install
@@ -1,0 +1,2 @@
+/usr/share/man/man7/grout-frr.7
+/usr/lib/*/frr/modules/frr_dplane_grout.so

--- a/debian/grout-prometheus.install
+++ b/debian/grout-prometheus.install
@@ -1,0 +1,2 @@
+/usr/bin/grout-telemetry-exporter
+/usr/share/dpdk/telemetry-endpoints/*

--- a/debian/grout.install
+++ b/debian/grout.install
@@ -3,5 +3,4 @@
 /usr/bin/grcli
 /usr/bin/grout
 /usr/share/man/man1/grcli.1
-/usr/share/man/man7/grout-frr.7
 /usr/share/man/man8/grout.8

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,7 @@ include /usr/share/dpkg/default.mk
 meson_opts := --wrap-mode=default
 meson_opts += --auto-features=enabled
 meson_opts += -Ddpdk:platform=generic
-meson_opts += -Dfrr=disabled
+meson_opts += -Dfrr=enabled
 
 build = $(CURDIR)/debian/_build
 dest = $(CURDIR)/debian/tmp

--- a/debian/rules
+++ b/debian/rules
@@ -3,23 +3,30 @@
 # Hardening
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all reproducible=+all optimize=-lto
 DPKG_EXPORT_BUILDFLAGS = 1
-include /usr/share/dpkg/buildflags.mk
+include /usr/share/dpkg/default.mk
 
 meson_opts := --wrap-mode=default
 meson_opts += --auto-features=enabled
 meson_opts += -Ddpdk:platform=generic
 meson_opts += -Dfrr=disabled
 
+build = $(CURDIR)/debian/_build
+dest = $(CURDIR)/debian/tmp
+
 %:
-	dh $@ --buildsystem=meson --with=bash-completion -B$(CURDIR)/debian/_build
+	dh $@ --buildsystem=meson --with=bash-completion -B$(build)
 
 override_dh_auto_configure:
 	dh_auto_configure -- $(meson_opts)
 
 override_dh_auto_install:
-	meson install -C debian/_build --skip-subprojects --destdir=$(CURDIR)/debian/tmp
-	install -D -m 644 main/grout.default debian/tmp/etc/default/grout
-	install -D -m 644 main/grout.init debian/tmp/etc/grout.init
+	meson install -C $(build) --skip-subprojects --destdir=$(dest)
+	install -D -m 644 main/grout.default $(dest)/etc/default/grout
+	install -D -m 644 main/grout.init $(dest)/etc/grout.init
+	install -D -m 0755 subprojects/dpdk/usertools/dpdk-telemetry-exporter.py \
+		$(dest)/usr/bin/grout-telemetry-exporter
+	install -D -m 0644 -t $(dest)/usr/share/dpdk/telemetry-endpoints \
+		subprojects/dpdk/usertools/telemetry-endpoints/*
 
 override_dh_installsystemd:
 	dh_installsystemd --no-start --no-stop-on-upgrade

--- a/rpm/grout.spec
+++ b/rpm/grout.spec
@@ -67,6 +67,14 @@ Suggests: %{name}
 %description devel
 This package contains the development headers to build %{grout} API clients.
 
+%package prometheus
+Summary: Prometheus exporter for DPDK/grout
+BuildArch: noarch
+Requires: python3
+
+%description prometheus
+Prometheus exporter for grout.
+
 %build
 %meson -Ddpdk:platform=generic -Dfrr=disabled
 %meson_build
@@ -79,6 +87,8 @@ install -D -m 0644 main/grout.init %{buildroot}%{_sysconfdir}/grout.init
 install -D -m 0644 main/grout.service %{buildroot}%{_unitdir}/grout.service
 install -D -m 0644 main/grout.bash-completion %{buildroot}%{_datadir}/bash-completion/completions/grout
 install -D -m 0644 cli/grcli.bash-completion %{buildroot}%{_datadir}/bash-completion/completions/grcli
+install -D -m 0755 subprojects/dpdk/usertools/dpdk-telemetry-exporter.py %{buildroot}%{_bindir}/grout-telemetry-exporter
+install -D -m 0644 -t %{buildroot}%{_datadir}/dpdk/telemetry-endpoints subprojects/dpdk/usertools/telemetry-endpoints/*
 
 %post
 %systemd_post %{name}.service
@@ -104,6 +114,12 @@ install -D -m 0644 cli/grcli.bash-completion %{buildroot}%{_datadir}/bash-comple
 %doc README.md
 %license licenses/BSD-3-clause.txt
 %{_includedir}/gr_*.h
+
+%files prometheus
+%doc README.md
+%license licenses/BSD-3-clause.txt
+%attr(755, root, root) %{_bindir}/grout-telemetry-exporter
+%attr(644, root, root) %{_datadir}/dpdk/telemetry-endpoints/*
 
 %changelog
 * Mon Sep 02 2024 Robin Jarry <rjarry@redhat.com>

--- a/rpm/grout.spec
+++ b/rpm/grout.spec
@@ -13,7 +13,7 @@ Name: grout
 Summary: Graph router based on DPDK
 Group: System Environment/Daemons
 URL: https://github.com/DPDK/grout
-License: BSD-3-Clause
+License: BSD-3-Clause AND GPL-2.0-or-later
 Version: %{version}
 Release: %{release}
 Source0: https://github.com/DPDK/grout/archive/%{branch}.tar.gz#/%{name}-%{version}-%{release}.tar.gz
@@ -25,6 +25,7 @@ BuildRequires: %toolset
 BuildRequires: scl-utils
 %endif
 BuildRequires: git
+BuildRequires: golang-github-cpuguy83-md2man
 BuildRequires: libarchive-devel
 BuildRequires: libcmocka-devel
 BuildRequires: libedit-devel
@@ -37,7 +38,6 @@ BuildRequires: numactl-devel
 BuildRequires: pkgconf
 BuildRequires: python3-pyelftools
 BuildRequires: rdma-core-devel
-BuildRequires: golang-github-cpuguy83-md2man
 BuildRequires: systemd
 
 %description
@@ -75,8 +75,15 @@ Requires: python3
 %description prometheus
 Prometheus exporter for grout.
 
+%package frr
+Summary: FRR dplane plugin for grout
+Requires: frr = %(sed -n "s/revision = frr-//p" subprojects/frr.wrap)
+
+%description frr
+FRR dplane plugin for grout
+
 %build
-%meson -Ddpdk:platform=generic -Dfrr=disabled
+%meson -Ddpdk:platform=generic -Dfrr=enabled
 %meson_build
 
 %install
@@ -107,7 +114,6 @@ install -D -m 0644 -t %{buildroot}%{_datadir}/dpdk/telemetry-endpoints subprojec
 %attr(755, root, root) %{_bindir}/grcli
 %attr(755, root, root) %{_bindir}/grout
 %attr(644, root, root) %{_mandir}/man1/grcli.1*
-%attr(644, root, root) %{_mandir}/man7/grout-frr.7*
 %attr(644, root, root) %{_mandir}/man8/grout.8*
 
 %files devel
@@ -120,6 +126,12 @@ install -D -m 0644 -t %{buildroot}%{_datadir}/dpdk/telemetry-endpoints subprojec
 %license licenses/BSD-3-clause.txt
 %attr(755, root, root) %{_bindir}/grout-telemetry-exporter
 %attr(644, root, root) %{_datadir}/dpdk/telemetry-endpoints/*
+
+%files frr
+%doc README.md
+%license licenses/GPL-2.0-or-later.txt
+%attr(755, root, root) %{_libdir}/frr/modules/frr_dplane_grout.so
+%attr(644, root, root) %{_mandir}/man7/grout-frr.7*
 
 %changelog
 * Mon Sep 02 2024 Robin Jarry <rjarry@redhat.com>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Prometheus exporter and FRR plugin packages; FRR support enabled and telemetry exporter included.

- Packaging
  - Debian and RPM outputs expanded to include Prometheus and FRR variants; debug/artifact naming simplified; uploads for .deb/.rpm are now unconditional.

- Containers
  - Separate images for grout and FRR with per-image metadata; runtime images rebuilt from minimal bases and pushed to Quay.

- Chores
  - CI now builds inside distro containers and automates FRR installation and Quay authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->