### PR TITLE
Srv6 local fix ext parsing

### DIFF
--- a/modules/srv6/datapath/meson.build
+++ b/modules/srv6/datapath/meson.build
@@ -6,3 +6,10 @@ src += files(
   'srv6_output.c',
 )
 inc += include_directories('.')
+
+tests += [
+  {
+    'sources': files('srv6_local.c'),
+    'link_args': [],
+  },
+]

--- a/modules/srv6/datapath/srv6_local.c
+++ b/modules/srv6/datapath/srv6_local.c
@@ -335,6 +335,7 @@ srv6_local_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 			t = gr_mbuf_trace_add(m, node, sizeof(*t));
 			t->behavior = sr_d->behavior;
 			t->out_vrf_id = sr_d->out_vrf_id;
+			t->segleft = 0;
 		} else {
 			t = NULL;
 		}

--- a/modules/srv6/datapath/srv6_local.c
+++ b/modules/srv6/datapath/srv6_local.c
@@ -180,10 +180,6 @@ static int process_upper_layer(struct rte_mbuf *m, struct ip6_info *ip6_info) {
 			return INVALID_PACKET;
 	}
 
-	// avoid ip6_input_local <-> sr6_local loop
-	if (ip6_info->proto == IPPROTO_IPIP || ip6_info->proto == IPPROTO_IPV6)
-		return UNEXPECTED_UPPER;
-
 	// prepend ipv6 header without any ext, before entering ip6_input_local again.
 	if (!ip6_info->ip6_hdr) {
 		ip6 = (struct rte_ipv6_hdr *)rte_pktmbuf_prepend(m, sizeof(*ip6));

--- a/modules/srv6/datapath/srv6_local.c
+++ b/modules/srv6/datapath/srv6_local.c
@@ -348,8 +348,13 @@ srv6_local_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 				goto next;
 			}
 
+			// hdr_len is in 8B units (excl. first 8B)
+			// -> ext_len = 8 * (hdr_len + 1)
+			// each segment is 16B = 2×8B
+			// -> nsegs = hdr_len/2
+			// -> last_entry < hdr_len/2
 			if ((size_t)((sr->hdr_len + 1) << 3) != ext_len
-			    || sr->last_entry > ext_len / 2 - 1
+			    || sr->last_entry > sr->hdr_len / 2 - 1
 			    || sr->segments_left > sr->last_entry + 1
 			    || sr->type != RTE_IPV6_SRCRT_TYPE_4) {
 				// XXX send icmp parameter problem

--- a/modules/srv6/datapath/srv6_local.c
+++ b/modules/srv6/datapath/srv6_local.c
@@ -323,11 +323,6 @@ srv6_local_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 			goto next;
 		}
 
-		if (!proto_supported[ip6_info.proto]) {
-			edge = UNEXPECTED_UPPER;
-			goto next;
-		}
-
 		sr_d = srv6_localsid_nh_priv(ip6_output_mbuf_data(m)->nh);
 		assert(sr_d != NULL);
 

--- a/modules/srv6/datapath/srv6_local.c
+++ b/modules/srv6/datapath/srv6_local.c
@@ -74,7 +74,7 @@ static int ip6_fill_infos(struct rte_mbuf *m, struct ip6_info *ip6_info) {
 
 	// advance through IPv6 extension headers until we find a proto supported by SRv6
 	while (!proto_supported[ip6_info->proto]) {
-		size_t ext_size = 0;
+		size_t ext_len = 0;
 		int next_proto;
 		uint8_t *ext;
 
@@ -83,11 +83,11 @@ static int ip6_fill_infos(struct rte_mbuf *m, struct ip6_info *ip6_info) {
 			return -1;
 
 		ext = rte_pktmbuf_mtod_offset(m, uint8_t *, ip6_info->ext_offset);
-		next_proto = rte_ipv6_get_next_ext(ext, ip6_info->proto, &ext_size);
+		next_proto = rte_ipv6_get_next_ext(ext, ip6_info->proto, &ext_len);
 		if (next_proto < 0)
 			break; // end of extension headers
-		ip6_info->ext_offset += ext_size;
-		ip6_info->len -= ext_size;
+		ip6_info->ext_offset += ext_len;
+		ip6_info->len -= ext_len;
 		ip6_info->proto = next_proto;
 		// next header is always the first field of any extension
 		ip6_info->p_proto = ext;

--- a/modules/srv6/datapath/srv6_local.c
+++ b/modules/srv6/datapath/srv6_local.c
@@ -173,7 +173,7 @@ static inline void decap_srv6(struct rte_mbuf *m, struct ip6_info *ip6_info) {
 
 	// 4.16.1 PSP
 	// remove this SRH
-	adj_len = (sr->hdr_len + 1) << 3;
+	adj_len = ip6_info->sr_len;
 	*ip6_info->p_proto = sr->next_hdr;
 	memmove((void *)ip6 + adj_len, ip6, (void *)sr - (void *)ip6);
 	rte_pktmbuf_adj(m, adj_len);

--- a/smoke/srv6_frr_test.sh
+++ b/smoke/srv6_frr_test.sh
@@ -67,3 +67,5 @@ set_srv6_localsid locator_grout fd00:202 fd00:202::100
 
 # test
 ip netns exec n-$p0 ping -c 3 192.168.60.1
+# check that sid is reachable
+ip netns exec n-$p1 ping6 -c 3 fd00:202::100

--- a/smoke/srv6_test.sh
+++ b/smoke/srv6_test.sh
@@ -66,3 +66,5 @@ grcli add sr localsid fd00:202::100 behavior end.dt4
 
 # test
 ip netns exec $p0 ping -c 3 192.168.60.1
+# check that sid is reachable
+ip netns exec $p1 ping6 -c 3 fd00:202::100


### PR DESCRIPTION
Needs some extra tests.

Any idea to craft packets with ipv6 extension in a bash script ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - SRv6 Segment Routing Header (SRH) detection preserved during decapsulation; Next Header rewiring and tunnel decapsulation flow improved.

- Bug Fixes
  - Safer traversal and stricter SRH validation to prevent malformed headers and overruns.
  - Upper-layer acceptance tightened when SRH is present; unsupported upper-layer types now rejected.

- Tests
  - Unit tests added for SRH parsing and upper-layer handling; smoke tests extended to verify IPv6 reachability to the SRv6 SID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->