### PR TITLE
api: change list requests to a streaming model

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -82,6 +82,7 @@ ForEachMacros:
   - TAILQ_FOREACH
   - TAILQ_FOREACH_SAFE
   - rte_graph_foreach_node
+  - gr_api_client_stream_foreach
   - gr_vec_foreach
   - gr_vec_foreach_ref
   - gr_nh_flags_foreach

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -40,10 +40,11 @@ update-graph: all
 	$(BUILDDIR)/grcli show graph brief | dot -Tsvg > docs/graph.svg
 
 .PHONY: coverage
-coverage: test
+coverage:
 	$Q mkdir -p $(BUILDDIR)/coverage
 	$Q gcovr --html-details $(BUILDDIR)/coverage/index.html --txt \
-		-e '.*_test.c' -ur . $(BUILDDIR)
+		-e '.*_test.c' -e 'subprojects/*' --gcov-ignore-parse-errors \
+		-ur . $(BUILDDIR)
 	@echo Coverage data is present in $(BUILDDIR)/coverage/index.html
 
 .PHONY: all

--- a/api/gr_api.h
+++ b/api/gr_api.h
@@ -33,13 +33,23 @@ struct gr_api_client *gr_api_client_connect(const char *sock_path);
 
 int gr_api_client_disconnect(struct gr_api_client *);
 
-int gr_api_client_send_recv(
-	const struct gr_api_client *,
+long int
+gr_api_client_send(struct gr_api_client *, uint32_t req_type, size_t tx_len, const void *tx_data);
+
+int gr_api_client_recv(struct gr_api_client *, uint32_t for_id, void **rx_data);
+
+static inline int gr_api_client_send_recv(
+	struct gr_api_client *client,
 	uint32_t req_type,
 	size_t tx_len,
 	const void *tx_data,
 	void **rx_data
-);
+) {
+	long int ret = gr_api_client_send(client, req_type, tx_len, tx_data);
+	if (ret < 0)
+		return ret;
+	return gr_api_client_recv(client, ret, rx_data);
+}
 
 #define GR_MAIN_MODULE 0xcafe
 

--- a/api/gr_api.h
+++ b/api/gr_api.h
@@ -51,6 +51,59 @@ static inline int gr_api_client_send_recv(
 	return gr_api_client_recv(client, ret, rx_data);
 }
 
+// Send a request and iterate over the received stream of responses.
+//
+// @p obj (const <any> *)
+//     The iterating variable. It must be a (preferably const) pointer
+//     to the type of objects returned by the requested API endpoint.
+// @p ret (int)
+//     The final return code of the operation.
+// @p client <struct gr_api_client *>
+//     Client object used to perform the requests.
+// @p req_type <uint32_t>
+//     Code for the request operation.
+// @p tx_len <size_t>
+//     Size of the request payload. Must be 0 if tx_data is NULL.
+// @p tx_data <void *>
+//     Request payload. Must be NULL if tx_len is 0.
+//
+// This should be used like a for loop, e.g.:
+//
+//     struct gr_ip4_route_list_req = {.vrf_id = 0};
+//     const struct gr_ip4_route *r;
+//     int ret;
+//
+//     gr_api_client_stream_foreach (r, ret, client, GR_IP4_ROUTE_LIST, sizeof(req), &req) {
+//         do stuff with r;
+//     }
+//     if (ret < 0)
+//         handle error;
+//
+// XXX: Interrupting the loop with break or an early return will cause memory leaks
+// and will leave messages hanging in the socket buffer. Make sure to let the loop
+// terminate gracefully.
+#define gr_api_client_stream_foreach(obj, ret, client, req_type, tx_len, tx_data)                  \
+	for (long int __id = gr_api_client_send(client, req_type, tx_len, tx_data), __first = 1;   \
+	     ({                                                                                    \
+		     if (__first == 1)                                                             \
+			     ret = __id;                                                           \
+		     __id >= 0 && __first; /* statement expression value */                        \
+	     });                                                                                   \
+	     __first = 0)                                                                          \
+		for (void *__ptr = NULL; ({                                                        \
+			     bool more = false;                                                    \
+			     ret = gr_api_client_recv(client, __id, &__ptr);                       \
+			     if (ret < 0) {                                                        \
+				     free(__ptr);                                                  \
+				     __ptr = NULL;                                                 \
+			     } else if (__ptr != NULL) {                                           \
+				     obj = __ptr;                                                  \
+				     more = true;                                                  \
+			     }                                                                     \
+			     more; /* statement expression value */                                \
+		     });                                                                           \
+		     free(__ptr), __ptr = NULL)
+
 #define GR_MAIN_MODULE 0xcafe
 
 #define GR_MAIN_HELLO REQUEST_TYPE(GR_MAIN_MODULE, 0x1981)

--- a/cli/ec_node_dyn.c
+++ b/cli/ec_node_dyn.c
@@ -57,9 +57,9 @@ static struct gr_api_client *connect_client(struct ec_comp *comp) {
 	return client;
 }
 
-static const struct gr_api_client *get_client(struct ec_comp *comp) {
+static struct gr_api_client *get_client(struct ec_comp *comp) {
 	struct ec_pnode *pstate = ec_comp_get_cur_pstate(comp);
-	const struct gr_api_client *client = NULL;
+	struct gr_api_client *client = NULL;
 
 	while (client == NULL && pstate != NULL) {
 		const struct ec_node *node = ec_pnode_get_node(pstate);
@@ -78,7 +78,7 @@ static int ec_node_dyn_complete(
 	const struct ec_strvec *strvec
 ) {
 	const struct ec_node_dyn *priv = ec_node_priv(node);
-	const struct gr_api_client *client;
+	struct gr_api_client *client;
 
 	assert(priv->cb != NULL);
 

--- a/cli/exec.c
+++ b/cli/exec.c
@@ -49,7 +49,7 @@ static cmd_cb_t *find_cmd_callback(struct ec_pnode *parsed) {
 }
 
 static exec_status_t exec_strvec(
-	const struct gr_api_client *client,
+	struct gr_api_client *client,
 	const struct ec_node *cmdlist,
 	const struct ec_strvec *vec
 ) {
@@ -86,7 +86,7 @@ out:
 }
 
 exec_status_t
-exec_line(const struct gr_api_client *client, const struct ec_node *cmdlist, const char *line) {
+exec_line(struct gr_api_client *client, const struct ec_node *cmdlist, const char *line) {
 	exec_status_t status = EXEC_SUCCESS;
 	struct ec_strvec *vec = NULL;
 
@@ -110,7 +110,7 @@ out:
 }
 
 exec_status_t exec_args(
-	const struct gr_api_client *client,
+	struct gr_api_client *client,
 	const struct ec_node *cmdlist,
 	size_t argc,
 	const char *const *argv

--- a/cli/exec.h
+++ b/cli/exec.h
@@ -22,11 +22,7 @@ typedef enum {
 
 #define CALLBACK_ATTR "callback"
 
-exec_status_t exec_line(const struct gr_api_client *, const struct ec_node *, const char *line);
+exec_status_t exec_line(struct gr_api_client *, const struct ec_node *, const char *line);
 
-exec_status_t exec_args(
-	const struct gr_api_client *,
-	const struct ec_node *,
-	size_t argc,
-	const char *const *argv
-);
+exec_status_t
+exec_args(struct gr_api_client *, const struct ec_node *, size_t argc, const char *const *argv);

--- a/cli/gr_cli.h
+++ b/cli/gr_cli.h
@@ -29,7 +29,7 @@ typedef enum {
 	CMD_EXIT,
 } cmd_status_t;
 
-typedef cmd_status_t(cmd_cb_t)(const struct gr_api_client *, const struct ec_pnode *);
+typedef cmd_status_t(cmd_cb_t)(struct gr_api_client *, const struct ec_pnode *);
 
 struct ec_node *with_help(const char *help, struct ec_node *node);
 
@@ -100,7 +100,7 @@ static inline int arg_u32(const struct ec_pnode *p, const char *id, uint32_t *va
 #define CTX_CLEAR CTX_ARG("clear", "Clear counters or temporary entries.")
 
 typedef int (*ec_node_dyn_comp_t)(
-	const struct gr_api_client *,
+	struct gr_api_client *,
 	const struct ec_node *,
 	struct ec_comp *,
 	const char *arg,

--- a/cli/interact.c
+++ b/cli/interact.c
@@ -60,7 +60,7 @@ const char *__lsan_default_options(void) {
 }
 #endif
 
-int interact(const struct gr_api_client *client, struct ec_node *cmdlist) {
+int interact(struct gr_api_client *client, struct ec_node *cmdlist) {
 	int flags = EC_EDITLINE_DEFAULT_SIGHANDLER;
 	struct ec_editline *edit = NULL;
 	struct ec_node *shlex = NULL;

--- a/cli/interact.h
+++ b/cli/interact.h
@@ -7,4 +7,4 @@
 
 #include <ecoli.h>
 
-int interact(const struct gr_api_client *, struct ec_node *);
+int interact(struct gr_api_client *, struct ec_node *);

--- a/cli/quit.c
+++ b/cli/quit.c
@@ -4,7 +4,7 @@
 #include <gr_api.h>
 #include <gr_cli.h>
 
-static cmd_status_t quit(const struct gr_api_client *, const struct ec_pnode *) {
+static cmd_status_t quit(struct gr_api_client *, const struct ec_pnode *) {
 	return CMD_EXIT;
 }
 

--- a/frr/meson.build
+++ b/frr/meson.build
@@ -29,7 +29,7 @@ frr_plugin = shared_module(
   include_directories: api_inc + include_directories('.'),
   install: not install_build_flag,
   install_dir  : frr_dep.get_variable('moduledir'),
-  override_options: ['c_std=gnu11'],
+  override_options: ['b_sanitize=none'],
 )
 
 if install_build_flag

--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -180,7 +180,6 @@ static void grout_sync_nhs(struct event *e) {
 static void grout_sync_ifaces_addresses(struct event *e) {
 	struct gr_ip4_addr_list_req ip_req = {.vrf_id = EVENT_VAL(e)};
 	const struct gr_ip4_ifaddr *ip_addr;
-	void *resp;
 	int ret;
 
 	gr_log_debug("sync ifaces addresses for vrf %u", EVENT_VAL(e));
@@ -205,24 +204,24 @@ static void grout_sync_ifaces_addresses(struct event *e) {
 		gr_log_err("GR_IP4_ADDR_LIST: %s", strerror(errno));
 
 	struct gr_ip6_addr_list_req ip6_req = {.vrf_id = EVENT_VAL(e)};
-	struct gr_ip6_addr_list_resp *ip6_resp;
-	if (grout_client_send_recv(GR_IP6_ADDR_LIST, sizeof(ip6_req), &ip6_req, &resp) < 0) {
-		gr_log_err("GR_IP4_ADDR_LIST: %s", strerror(errno));
-	} else {
-		ip6_resp = resp;
-		for (uint16_t i = 0; i < ip6_resp->n_addrs; i++) {
-			struct gr_nexthop dummy = {
-				.af = GR_AF_IP6,
-				.ipv6 = ip6_resp->addrs[i].addr.ip,
-				.prefixlen = ip6_resp->addrs[i].addr.prefixlen,
-				.iface_id = ip6_resp->addrs[i].iface_id,
-				.vrf_id = EVENT_VAL(e),
-			};
-			gr_log_debug("sync addr %pI6", &dummy.ipv6);
-			grout_interface_addr_dplane(&dummy, true);
-		}
-		free(ip6_resp);
+	const struct gr_ip6_ifaddr *ip6_addr;
+
+	gr_api_client_stream_foreach (
+		ip6_addr, ret, grout_ctx.client, GR_IP6_ADDR_LIST, sizeof(ip6_req), &ip6_req
+	) {
+		struct gr_nexthop dummy = {
+			.af = GR_AF_IP6,
+			.ipv6 = ip6_addr->addr.ip,
+			.prefixlen = ip6_addr->addr.prefixlen,
+			.iface_id = ip6_addr->iface_id,
+			.vrf_id = EVENT_VAL(e),
+		};
+		gr_log_debug("sync addr %pI6", &dummy.ipv6);
+		grout_interface_addr_dplane(&dummy, true);
 	}
+	if (ret < 0)
+		gr_log_err("GR_IP6_ADDR_LIST: %s", strerror(errno));
+
 	event_add_event(zrouter.master, grout_sync_nhs, NULL, EVENT_VAL(e), NULL);
 }
 

--- a/main/api.c
+++ b/main/api.c
@@ -239,6 +239,24 @@ static void disconnect_client(struct api_ctx *ctx) {
 	free(ctx);
 }
 
+void api_send(struct api_ctx *ctx, uint32_t len, const void *payload) {
+	assert(ctx != NULL);
+	assert(len != 0);
+	assert(payload != NULL);
+
+	LOG(DEBUG, "pid=%d for_id=%u len=%u", ctx->pid, ctx->header.id, len);
+
+	struct gr_api_response resp = {
+		.for_id = ctx->header.id,
+		.payload_len = len,
+		.status = 0,
+	};
+	if (bufferevent_write(ctx->bev, &resp, sizeof(resp)) < 0)
+		LOG(ERR, "pid=%d cannot write header", ctx->pid);
+	if (bufferevent_write(ctx->bev, payload, len) < 0)
+		LOG(ERR, "pid=%d cannot write payload", ctx->pid);
+}
+
 static void read_cb(struct bufferevent *bev, void *priv) {
 	struct evbuffer *input = bufferevent_get_input(bev);
 	struct api_ctx *ctx = priv;

--- a/main/gr_module.h
+++ b/main/gr_module.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <gr_api.h>
+
 #include <event2/event.h>
 
 #include <stdint.h>
@@ -17,6 +19,13 @@ static inline struct api_out api_out(uint32_t status, uint32_t len) {
 	struct api_out out = {status, len};
 	return out;
 }
+
+struct api_ctx {
+	struct gr_api_request header;
+	bool header_complete;
+	struct bufferevent *bev;
+	LIST_ENTRY(api_ctx) next;
+};
 
 typedef struct api_out (*gr_api_handler_func)(const void *request, void **response);
 

--- a/main/gr_module.h
+++ b/main/gr_module.h
@@ -30,6 +30,8 @@ struct api_ctx {
 	LIST_ENTRY(api_ctx) next;
 };
 
+void api_send(struct api_ctx *, uint32_t len, const void *payload);
+
 typedef struct api_out (*gr_api_handler_func)(const void *request, struct api_ctx *);
 
 struct gr_api_handler {

--- a/main/gr_module.h
+++ b/main/gr_module.h
@@ -5,6 +5,7 @@
 
 #include <gr_api.h>
 
+#include <event2/bufferevent.h>
 #include <event2/event.h>
 
 #include <stdint.h>
@@ -13,10 +14,11 @@
 struct api_out {
 	uint32_t status;
 	uint32_t len;
+	void *payload;
 };
 
-static inline struct api_out api_out(uint32_t status, uint32_t len) {
-	struct api_out out = {status, len};
+static inline struct api_out api_out(uint32_t status, uint32_t len, void *payload) {
+	struct api_out out = {status, len, payload};
 	return out;
 }
 
@@ -24,10 +26,11 @@ struct api_ctx {
 	struct gr_api_request header;
 	bool header_complete;
 	struct bufferevent *bev;
+	pid_t pid;
 	LIST_ENTRY(api_ctx) next;
 };
 
-typedef struct api_out (*gr_api_handler_func)(const void *request, void **response);
+typedef struct api_out (*gr_api_handler_func)(const void *request, struct api_ctx *);
 
 struct gr_api_handler {
 	const char *name;

--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -182,10 +182,7 @@ struct gr_infra_iface_list_req {
 	gr_iface_type_t type; // use GR_IFACE_TYPE_UNDEF for all
 };
 
-struct gr_infra_iface_list_resp {
-	uint16_t n_ifaces;
-	struct gr_iface ifaces[/* n_ifaces */];
-};
+// STREAM(struct gr_iface);
 
 #define GR_INFRA_IFACE_SET REQUEST_TYPE(GR_INFRA_MODULE, 0x0005)
 

--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -169,6 +169,7 @@ struct gr_infra_iface_del_req {
 
 struct gr_infra_iface_get_req {
 	uint16_t iface_id;
+	char name[GR_IFACE_NAME_SIZE];
 };
 
 struct gr_infra_iface_get_resp {

--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -75,7 +75,7 @@ struct gr_iface {
 
 #define GR_IFACE_NAME_SIZE 64
 	char name[GR_IFACE_NAME_SIZE]; // Interface name (utf-8 encoded, nul terminated).
-	uint8_t info[256]; // Type specific interface info.
+	uint8_t info[]; // Type specific interface info.
 };
 
 // Port reconfig attributes
@@ -103,8 +103,6 @@ struct gr_iface_info_port {
 	char driver_name[GR_PORT_DRIVER_NAME_SIZE];
 };
 
-static_assert(sizeof(struct gr_iface_info_port) <= MEMBER_SIZE(struct gr_iface, info));
-
 // VLAN reconfig attributes
 #define GR_VLAN_SET_PARENT GR_BIT64(32)
 #define GR_VLAN_SET_VLAN GR_BIT64(33)
@@ -116,8 +114,6 @@ struct gr_iface_info_vlan {
 	uint16_t vlan_id;
 	struct rte_ether_addr mac;
 };
-
-static_assert(sizeof(struct gr_iface_info_vlan) <= MEMBER_SIZE(struct gr_iface, info));
 
 struct gr_port_rxq_map {
 	uint16_t iface_id;
@@ -187,8 +183,8 @@ struct gr_infra_iface_list_req {
 #define GR_INFRA_IFACE_SET REQUEST_TYPE(GR_INFRA_MODULE, 0x0005)
 
 struct gr_infra_iface_set_req {
-	struct gr_iface iface;
 	uint64_t set_attrs;
+	struct gr_iface iface;
 };
 
 // struct gr_infra_iface_set_resp { };

--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -220,10 +220,7 @@ struct gr_infra_iface_stats_get_resp {
 
 // struct gr_infra_rxq_list_req { };
 
-struct gr_infra_rxq_list_resp {
-	uint16_t n_rxqs;
-	struct gr_port_rxq_map rxqs[/* n_rxq */];
-};
+// STREAM(struct gr_port_rxq_map);
 
 #define GR_INFRA_RXQ_SET REQUEST_TYPE(GR_INFRA_MODULE, 0x0011)
 

--- a/modules/infra/api/gr_nexthop.h
+++ b/modules/infra/api/gr_nexthop.h
@@ -291,7 +291,4 @@ struct gr_nh_list_req {
 	bool all;
 };
 
-struct gr_nh_list_resp {
-	uint16_t n_nhs;
-	struct gr_nexthop nhs[/* n_nhs */];
-};
+// STREAM(struct gr_nexthop);

--- a/modules/infra/api/iface.c
+++ b/modules/infra/api/iface.c
@@ -61,10 +61,19 @@ static struct api_out iface_del(const void *request, void ** /*response*/) {
 static struct api_out iface_get(const void *request, void **response) {
 	const struct gr_infra_iface_get_req *req = request;
 	struct gr_infra_iface_get_resp *resp = NULL;
-	struct iface *iface;
+	const struct iface *iface = NULL;
 
-	if ((iface = iface_from_id(req->iface_id)) == NULL)
-		return api_out(ENODEV, 0);
+	if (req->iface_id != GR_IFACE_ID_UNDEF) {
+		if ((iface = iface_from_id(req->iface_id)) == NULL)
+			return api_out(ENODEV, 0);
+	} else {
+		while ((iface = iface_next(GR_IFACE_TYPE_UNDEF, iface)) != NULL) {
+			if (strncmp(iface->name, req->name, sizeof(req->name)) == 0)
+				break;
+		}
+		if (iface == NULL)
+			return api_out(ENODEV, 0);
+	}
 
 	if ((resp = malloc(sizeof(*resp))) == NULL)
 		return api_out(ENOMEM, 0);

--- a/modules/infra/api/iface.c
+++ b/modules/infra/api/iface.c
@@ -82,23 +82,17 @@ static struct api_out iface_get(const void *request, struct api_ctx *) {
 	return api_out(0, sizeof(*resp), resp);
 }
 
-static struct api_out iface_list(const void *request, struct api_ctx *) {
+static struct api_out iface_list(const void *request, struct api_ctx *ctx) {
 	const struct gr_infra_iface_list_req *req = request;
-	struct gr_infra_iface_list_resp *resp = NULL;
 	const struct iface *iface = NULL;
-	uint16_t n_ifaces;
-	size_t len;
 
-	n_ifaces = ifaces_count(req->type);
+	while ((iface = iface_next(req->type, iface)) != NULL) {
+		struct gr_iface api_iface;
+		iface_to_api(&api_iface, iface);
+		api_send(ctx, sizeof(api_iface), &api_iface);
+	}
 
-	len = sizeof(*resp) + n_ifaces * sizeof(struct gr_iface);
-	if ((resp = calloc(1, len)) == NULL)
-		return api_out(ENOMEM, 0, NULL);
-
-	while ((iface = iface_next(req->type, iface)) != NULL)
-		iface_to_api(&resp->ifaces[resp->n_ifaces++], iface);
-
-	return api_out(0, len, resp);
+	return api_out(0, 0, NULL);
 }
 
 static struct api_out iface_set(const void *request, struct api_ctx *) {

--- a/modules/infra/api/stats.c
+++ b/modules/infra/api/stats.c
@@ -34,7 +34,7 @@ static struct stat *find_stat(struct stat *stats, const char *name) {
 	return errno_set_null(ENOENT);
 }
 
-static struct api_out stats_get(const void *request, void **response) {
+static struct api_out stats_get(const void *request, struct api_ctx *) {
 	const struct gr_infra_stats_get_req *req = request;
 	struct gr_infra_stats_get_resp *resp = NULL;
 	gr_vec struct stat *stats = NULL;
@@ -184,15 +184,14 @@ free_xstat:
 	}
 
 	gr_vec_free(stats);
-	*response = resp;
-	return api_out(0, len);
+	return api_out(0, len, resp);
 err:
 	gr_vec_free(stats);
 	free(resp);
-	return api_out(-ret, 0);
+	return api_out(-ret, 0, NULL);
 }
 
-static struct api_out stats_reset(const void * /*request*/, void ** /*response*/) {
+static struct api_out stats_reset(const void * /*request*/, struct api_ctx *) {
 	struct worker *worker;
 	struct iface *iface;
 	int ret;
@@ -210,15 +209,15 @@ static struct api_out stats_reset(const void * /*request*/, void ** /*response*/
 	while ((iface = iface_next(GR_IFACE_TYPE_PORT, iface)) != NULL) {
 		struct iface_info_port *port = (struct iface_info_port *)iface->info;
 		if ((ret = rte_eth_stats_reset(port->port_id)) < 0)
-			return api_out(-ret, 0);
+			return api_out(-ret, 0, NULL);
 		if ((ret = rte_eth_xstats_reset(port->port_id)) < 0)
-			return api_out(-ret, 0);
+			return api_out(-ret, 0, NULL);
 	}
 
-	return api_out(0, 0);
+	return api_out(0, 0, NULL);
 }
 
-static struct api_out iface_stats_get(const void * /*request*/, void **response) {
+static struct api_out iface_stats_get(const void * /*request*/, struct api_ctx *) {
 	struct gr_infra_iface_stats_get_resp *resp = NULL;
 	gr_vec struct gr_iface_stats *stats_vec = NULL;
 	struct iface *iface = NULL;
@@ -268,12 +267,11 @@ static struct api_out iface_stats_get(const void * /*request*/, void **response)
 	memcpy(resp->stats, stats_vec, n_stats * sizeof(struct gr_iface_stats));
 
 	gr_vec_free(stats_vec);
-	*response = resp;
-	return api_out(0, len);
+	return api_out(0, len, resp);
 err:
 	gr_vec_free(stats_vec);
 	free(resp);
-	return api_out(-ret, 0);
+	return api_out(-ret, 0, NULL);
 }
 
 static int

--- a/modules/infra/api/trace.c
+++ b/modules/infra/api/trace.c
@@ -23,7 +23,7 @@ static void iface_add_callback(uint32_t /*event*/, const void *obj) {
 		iface_from_id(iface->id)->flags |= GR_IFACE_F_PACKET_TRACE;
 }
 
-static struct api_out set_trace(const void *request, void ** /*response*/) {
+static struct api_out set_trace(const void *request, struct api_ctx *) {
 	const struct gr_infra_packet_trace_set_req *req = request;
 	struct iface *iface = NULL;
 
@@ -38,7 +38,7 @@ static struct api_out set_trace(const void *request, void ** /*response*/) {
 		}
 	} else {
 		if ((iface = iface_from_id(req->iface_id)) == NULL)
-			return api_out(ENODEV, 0);
+			return api_out(ENODEV, 0, NULL);
 
 		if (req->enabled)
 			iface->flags |= GR_IFACE_F_PACKET_TRACE;
@@ -46,16 +46,16 @@ static struct api_out set_trace(const void *request, void ** /*response*/) {
 			iface->flags &= ~GR_IFACE_F_PACKET_TRACE;
 	}
 
-	return api_out(0, 0);
+	return api_out(0, 0, NULL);
 }
 
-static struct api_out dump_trace(const void *request, void **response) {
+static struct api_out dump_trace(const void *request, struct api_ctx *) {
 	const struct gr_infra_packet_trace_dump_req *req = request;
 	struct gr_infra_packet_trace_dump_resp *resp;
 	int ret;
 
 	if ((resp = malloc(GR_API_MAX_MSG_LEN)) == NULL)
-		return api_out(ENOMEM, 0);
+		return api_out(ENOMEM, 0, NULL);
 
 	ret = gr_trace_dump(
 		resp->trace,
@@ -66,27 +66,25 @@ static struct api_out dump_trace(const void *request, void **response) {
 	);
 	if (ret < 0) {
 		free(resp);
-		return api_out(-ret, 0);
+		return api_out(-ret, 0, NULL);
 	}
 
-	*response = resp;
-
-	return api_out(0, sizeof(*resp) + resp->len);
+	return api_out(0, sizeof(*resp) + resp->len, resp);
 }
 
-static struct api_out clear_trace(const void * /*request*/, void ** /*response*/) {
+static struct api_out clear_trace(const void * /*request*/, struct api_ctx *) {
 	gr_trace_clear();
-	return api_out(0, 0);
+	return api_out(0, 0, NULL);
 }
 
-static struct api_out packet_log_enable(const void * /*request */, void ** /*response*/) {
+static struct api_out packet_log_enable(const void * /*request */, struct api_ctx *) {
 	gr_config.log_packets = true;
-	return api_out(0, 0);
+	return api_out(0, 0, NULL);
 }
 
-static struct api_out packet_log_disable(const void * /*request */, void ** /*response*/) {
+static struct api_out packet_log_disable(const void * /*request */, struct api_ctx *) {
 	gr_config.log_packets = false;
-	return api_out(0, 0);
+	return api_out(0, 0, NULL);
 }
 
 static struct gr_api_handler set_trace_handler = {

--- a/modules/infra/cli/affinity.c
+++ b/modules/infra/cli/affinity.c
@@ -11,7 +11,7 @@
 #include <ecoli.h>
 #include <libsmartcols.h>
 
-static cmd_status_t affinity_set(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t affinity_set(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_infra_cpu_affinity_set_req req = {0};
 	const char *arg;
 
@@ -30,7 +30,7 @@ static cmd_status_t affinity_set(const struct gr_api_client *c, const struct ec_
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t affinity_show(const struct gr_api_client *c, const struct ec_pnode *) {
+static cmd_status_t affinity_show(struct gr_api_client *c, const struct ec_pnode *) {
 	struct gr_infra_cpu_affinity_get_resp resp;
 	void *resp_ptr = NULL;
 	char buf[BUFSIZ];
@@ -54,7 +54,7 @@ static cmd_status_t affinity_show(const struct gr_api_client *c, const struct ec
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t rxq_set(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t rxq_set(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_infra_rxq_set_req req;
 	struct gr_iface iface;
 
@@ -86,7 +86,7 @@ static int rxqs_order(const void *a, const void *b) {
 	return rxq_a->rxq_id - rxq_b->rxq_id;
 }
 
-static cmd_status_t rxq_list(const struct gr_api_client *c, const struct ec_pnode *) {
+static cmd_status_t rxq_list(struct gr_api_client *c, const struct ec_pnode *) {
 	struct libscols_table *table = scols_new_table();
 	struct gr_infra_rxq_list_resp *resp;
 	void *resp_ptr = NULL;

--- a/modules/infra/cli/events.c
+++ b/modules/infra/cli/events.c
@@ -25,7 +25,7 @@ static const struct gr_cli_event_printer *get_event_printer(uint32_t ev_type) {
 	return NULL;
 }
 
-static cmd_status_t events_show(const struct gr_api_client *c, const struct ec_pnode *) {
+static cmd_status_t events_show(struct gr_api_client *c, const struct ec_pnode *) {
 	struct gr_event_subscribe_req req = {
 		.suppress_self_events = false, .ev_type = EVENT_TYPE_ALL
 	};

--- a/modules/infra/cli/gr_cli_iface.h
+++ b/modules/infra/cli/gr_cli_iface.h
@@ -22,8 +22,8 @@ void register_iface_type(struct cli_iface_type *);
 
 const struct cli_iface_type *type_from_name(const char *name);
 const struct cli_iface_type *type_from_id(gr_iface_type_t type_id);
-int iface_from_name(struct gr_api_client *c, const char *name, struct gr_iface *iface);
-int iface_from_id(struct gr_api_client *c, uint16_t ifid, struct gr_iface *iface);
+struct gr_iface *iface_from_name(struct gr_api_client *c, const char *name);
+struct gr_iface *iface_from_id(struct gr_api_client *c, uint16_t ifid);
 
 struct ec_node;
 struct ec_comp;
@@ -65,5 +65,6 @@ uint64_t parse_iface_args(
 	struct gr_api_client *c,
 	const struct ec_pnode *p,
 	struct gr_iface *iface,
+	size_t info_size,
 	bool update
 );

--- a/modules/infra/cli/gr_cli_iface.h
+++ b/modules/infra/cli/gr_cli_iface.h
@@ -14,29 +14,29 @@ struct cli_iface_type {
 	STAILQ_ENTRY(cli_iface_type) next;
 	gr_iface_type_t type_id;
 	const char *name;
-	void (*show)(const struct gr_api_client *c, const struct gr_iface *);
-	void (*list_info)(const struct gr_api_client *c, const struct gr_iface *, char *, size_t);
+	void (*show)(struct gr_api_client *c, const struct gr_iface *);
+	void (*list_info)(struct gr_api_client *c, const struct gr_iface *, char *, size_t);
 };
 
 void register_iface_type(struct cli_iface_type *);
 
 const struct cli_iface_type *type_from_name(const char *name);
 const struct cli_iface_type *type_from_id(gr_iface_type_t type_id);
-int iface_from_name(const struct gr_api_client *c, const char *name, struct gr_iface *iface);
-int iface_from_id(const struct gr_api_client *c, uint16_t ifid, struct gr_iface *iface);
+int iface_from_name(struct gr_api_client *c, const char *name, struct gr_iface *iface);
+int iface_from_id(struct gr_api_client *c, uint16_t ifid, struct gr_iface *iface);
 
 struct ec_node;
 struct ec_comp;
 
 int complete_iface_types(
-	const struct gr_api_client *c,
+	struct gr_api_client *c,
 	const struct ec_node *node,
 	struct ec_comp *comp,
 	const char *arg,
 	void *cb_arg
 );
 int complete_iface_names(
-	const struct gr_api_client *c,
+	struct gr_api_client *c,
 	const struct ec_node *node,
 	struct ec_comp *comp,
 	const char *arg,
@@ -62,7 +62,7 @@ int complete_iface_names(
 		)
 
 uint64_t parse_iface_args(
-	const struct gr_api_client *c,
+	struct gr_api_client *c,
 	const struct ec_pnode *p,
 	struct gr_iface *iface,
 	bool update

--- a/modules/infra/cli/graph.c
+++ b/modules/infra/cli/graph.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-static cmd_status_t graph_dump(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t graph_dump(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_infra_graph_dump_req req = {.flags = 0};
 	const struct gr_infra_graph_dump_resp *resp;
 	void *resp_ptr = NULL;

--- a/modules/infra/cli/iface.c
+++ b/modules/infra/cli/iface.c
@@ -40,7 +40,7 @@ const struct cli_iface_type *type_from_name(const char *name) {
 }
 
 int complete_iface_types(
-	const struct gr_api_client *,
+	struct gr_api_client *,
 	const struct ec_node *node,
 	struct ec_comp *comp,
 	const char *arg,
@@ -68,7 +68,7 @@ const struct cli_iface_type *type_from_id(gr_iface_type_t type_id) {
 }
 
 int complete_iface_names(
-	const struct gr_api_client *c,
+	struct gr_api_client *c,
 	const struct ec_node *node,
 	struct ec_comp *comp,
 	const char *arg,
@@ -98,7 +98,7 @@ fail:
 	return ret;
 }
 
-int iface_from_name(const struct gr_api_client *c, const char *name, struct gr_iface *iface) {
+int iface_from_name(struct gr_api_client *c, const char *name, struct gr_iface *iface) {
 	struct gr_infra_iface_get_req req = {.iface_id = GR_IFACE_ID_UNDEF};
 	const struct gr_infra_iface_get_resp *resp;
 	void *resp_ptr = NULL;
@@ -118,7 +118,7 @@ int iface_from_name(const struct gr_api_client *c, const char *name, struct gr_i
 	return 0;
 }
 
-int iface_from_id(const struct gr_api_client *c, uint16_t iface_id, struct gr_iface *iface) {
+int iface_from_id(struct gr_api_client *c, uint16_t iface_id, struct gr_iface *iface) {
 	struct gr_infra_iface_get_req req = {.iface_id = iface_id, .name = ""};
 	const struct gr_infra_iface_get_resp *resp;
 	void *resp_ptr = NULL;
@@ -134,7 +134,7 @@ int iface_from_id(const struct gr_api_client *c, uint16_t iface_id, struct gr_if
 }
 
 uint64_t parse_iface_args(
-	const struct gr_api_client *c,
+	struct gr_api_client *c,
 	const struct ec_pnode *p,
 	struct gr_iface *iface,
 	bool update
@@ -194,7 +194,7 @@ err:
 	return 0;
 }
 
-static cmd_status_t iface_del(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t iface_del(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_infra_iface_del_req req;
 	struct gr_iface iface;
 
@@ -215,7 +215,7 @@ static int iface_order(const void *ia, const void *ib) {
 	return a->id - b->id;
 }
 
-static cmd_status_t iface_list(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t iface_list(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct libscols_table *table = scols_new_table();
 	struct gr_infra_iface_list_resp *resp;
 	struct gr_infra_iface_list_req req;
@@ -321,7 +321,7 @@ err:
 	return CMD_ERROR;
 }
 
-static cmd_status_t iface_stats(const struct gr_api_client *c, const struct ec_pnode * /*p*/) {
+static cmd_status_t iface_stats(struct gr_api_client *c, const struct ec_pnode * /*p*/) {
 	struct gr_infra_iface_stats_get_resp *resp = NULL;
 	struct libscols_table *table = NULL;
 	cmd_status_t status = CMD_ERROR;
@@ -383,7 +383,7 @@ end:
 	return status;
 }
 
-static cmd_status_t iface_rates(const struct gr_api_client *c, const struct ec_pnode * /*p*/) {
+static cmd_status_t iface_rates(struct gr_api_client *c, const struct ec_pnode * /*p*/) {
 	const struct gr_infra_iface_stats_get_resp *resp1, *resp2;
 	void *resp1_ptr = NULL, *resp2_ptr = NULL;
 	struct libscols_table *table = NULL;
@@ -461,7 +461,7 @@ end:
 	return status;
 }
 
-static cmd_status_t iface_show(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t iface_show(struct gr_api_client *c, const struct ec_pnode *p) {
 	const struct cli_iface_type *type;
 	struct gr_iface iface;
 

--- a/modules/infra/cli/loopback.c
+++ b/modules/infra/cli/loopback.c
@@ -6,10 +6,9 @@
 #include <gr_cli_iface.h>
 #include <gr_infra.h>
 
-static void loopback_show(const struct gr_api_client *, const struct gr_iface *) { }
+static void loopback_show(struct gr_api_client *, const struct gr_iface *) { }
 
-static void
-loopback_list_info(const struct gr_api_client *, const struct gr_iface *, char *, size_t) { }
+static void loopback_list_info(struct gr_api_client *, const struct gr_iface *, char *, size_t) { }
 
 static struct cli_iface_type loopback_type = {
 	.type_id = GR_IFACE_TYPE_LOOPBACK,

--- a/modules/infra/cli/nexthop.c
+++ b/modules/infra/cli/nexthop.c
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-static cmd_status_t set_config(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t set_config(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_infra_nh_config_set_req req = {0};
 
 	if (arg_u32(p, "MAX", &req.max_count) < 0 && errno != ENOENT)
@@ -37,7 +37,7 @@ static cmd_status_t set_config(const struct gr_api_client *c, const struct ec_pn
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t show_config(const struct gr_api_client *c, const struct ec_pnode *) {
+static cmd_status_t show_config(struct gr_api_client *c, const struct ec_pnode *) {
 	const struct gr_infra_nh_config_get_resp *resp;
 	void *resp_ptr = NULL;
 
@@ -59,7 +59,7 @@ static cmd_status_t show_config(const struct gr_api_client *c, const struct ec_p
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t nh_add(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t nh_add(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_nh_add_req req = {
 		.exist_ok = true,
 		.nh.origin = GR_NH_ORIGIN_USER,
@@ -107,7 +107,7 @@ send:
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t nh_del(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t nh_del(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_nh_del_req req = {.missing_ok = true};
 
 	if (arg_u32(p, "ID", &req.nh_id) < 0)
@@ -119,7 +119,7 @@ static cmd_status_t nh_del(const struct gr_api_client *c, const struct ec_pnode 
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t nh_list(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t nh_list(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_nh_list_req req = {.vrf_id = UINT16_MAX};
 	struct libscols_table *table = scols_new_table();
 	const struct gr_nh_list_resp *resp;

--- a/modules/infra/cli/port.c
+++ b/modules/infra/cli/port.c
@@ -14,7 +14,7 @@
 #include <errno.h>
 #include <sys/queue.h>
 
-static void port_show(const struct gr_api_client *c, const struct gr_iface *iface) {
+static void port_show(struct gr_api_client *c, const struct gr_iface *iface) {
 	const struct gr_iface_info_port *port = (const struct gr_iface_info_port *)iface->info;
 	struct gr_iface peer;
 
@@ -39,7 +39,7 @@ static void port_show(const struct gr_api_client *c, const struct gr_iface *ifac
 }
 
 static void
-port_list_info(const struct gr_api_client *c, const struct gr_iface *iface, char *buf, size_t len) {
+port_list_info(struct gr_api_client *c, const struct gr_iface *iface, char *buf, size_t len) {
 	const struct gr_iface_info_port *port = (const struct gr_iface_info_port *)iface->info;
 	struct gr_iface peer;
 	size_t n = 0;
@@ -63,7 +63,7 @@ static struct cli_iface_type port_type = {
 };
 
 static uint64_t parse_port_args(
-	const struct gr_api_client *c,
+	struct gr_api_client *c,
 	const struct ec_pnode *p,
 	struct gr_iface *iface,
 	bool update
@@ -117,7 +117,7 @@ err:
 	return 0;
 }
 
-static cmd_status_t port_add(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t port_add(struct gr_api_client *c, const struct ec_pnode *p) {
 	const struct gr_infra_iface_add_resp *resp;
 	struct gr_infra_iface_add_req req = {
 		.iface = {.type = GR_IFACE_TYPE_PORT, .flags = GR_IFACE_F_UP}
@@ -136,7 +136,7 @@ static cmd_status_t port_add(const struct gr_api_client *c, const struct ec_pnod
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t port_set(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t port_set(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_infra_iface_set_req req = {0};
 
 	if ((req.set_attrs = parse_port_args(c, p, &req.iface, true)) == 0)

--- a/modules/infra/cli/stats.c
+++ b/modules/infra/cli/stats.c
@@ -29,7 +29,7 @@ static int stats_order_cycles(const void *sa, const void *sb) {
 	return 1;
 }
 
-static cmd_status_t stats_get(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t stats_get(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_infra_stats_get_req req = {.flags = 0};
 	bool brief = arg_str(p, "brief") != NULL;
 	struct gr_infra_stats_get_resp *resp;
@@ -103,7 +103,7 @@ fail:
 	return CMD_ERROR;
 }
 
-static cmd_status_t stats_reset(const struct gr_api_client *c, const struct ec_pnode *) {
+static cmd_status_t stats_reset(struct gr_api_client *c, const struct ec_pnode *) {
 	if (gr_api_client_send_recv(c, GR_INFRA_STATS_RESET, 0, NULL, NULL) < 0)
 		return CMD_ERROR;
 

--- a/modules/infra/cli/trace.c
+++ b/modules/infra/cli/trace.c
@@ -12,7 +12,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-static cmd_status_t trace_set(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t trace_set(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_infra_packet_trace_set_req req;
 	struct gr_iface iface;
 
@@ -31,7 +31,7 @@ static cmd_status_t trace_set(const struct gr_api_client *c, const struct ec_pno
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t trace_del(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t trace_del(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_infra_packet_trace_set_req req;
 	struct gr_iface iface;
 
@@ -49,7 +49,7 @@ static cmd_status_t trace_del(const struct gr_api_client *c, const struct ec_pno
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t trace_show(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t trace_show(struct gr_api_client *c, const struct ec_pnode *p) {
 	const struct gr_infra_packet_trace_dump_resp *resp = NULL;
 	struct gr_infra_packet_trace_dump_req req;
 	uint16_t max_packets = 10;
@@ -84,21 +84,21 @@ static cmd_status_t trace_show(const struct gr_api_client *c, const struct ec_pn
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t trace_clear(const struct gr_api_client *c, const struct ec_pnode *) {
+static cmd_status_t trace_clear(struct gr_api_client *c, const struct ec_pnode *) {
 	if (gr_api_client_send_recv(c, GR_INFRA_PACKET_TRACE_CLEAR, 0, NULL, NULL) < 0)
 		return CMD_ERROR;
 
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t packet_logging_set(const struct gr_api_client *c, const struct ec_pnode *) {
+static cmd_status_t packet_logging_set(struct gr_api_client *c, const struct ec_pnode *) {
 	if (gr_api_client_send_recv(c, GR_INFRA_PACKET_LOG_SET, 0, NULL, NULL) < 0)
 		return CMD_ERROR;
 
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t packet_logging_clear(const struct gr_api_client *c, const struct ec_pnode *) {
+static cmd_status_t packet_logging_clear(struct gr_api_client *c, const struct ec_pnode *) {
 	if (gr_api_client_send_recv(c, GR_INFRA_PACKET_LOG_CLEAR, 0, NULL, NULL) < 0)
 		return CMD_ERROR;
 

--- a/modules/infra/cli/trace.c
+++ b/modules/infra/cli/trace.c
@@ -14,16 +14,17 @@
 
 static cmd_status_t trace_set(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_infra_packet_trace_set_req req;
-	struct gr_iface iface;
+	struct gr_iface *iface = NULL;
 
 	req.enabled = true;
 
 	if (arg_str(p, "all") != NULL)
 		req.all = true;
-	else if (iface_from_name(c, arg_str(p, "NAME"), &iface) < 0)
+	else if ((iface = iface_from_name(c, arg_str(p, "NAME"))) == NULL)
 		return CMD_ERROR;
 	else
-		req.iface_id = iface.id;
+		req.iface_id = iface->id;
+	free(iface);
 
 	if (gr_api_client_send_recv(c, GR_INFRA_PACKET_TRACE_SET, sizeof(req), &req, NULL) < 0)
 		return CMD_ERROR;
@@ -33,15 +34,16 @@ static cmd_status_t trace_set(struct gr_api_client *c, const struct ec_pnode *p)
 
 static cmd_status_t trace_del(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_infra_packet_trace_set_req req;
-	struct gr_iface iface;
+	struct gr_iface *iface = NULL;
 
 	req.enabled = false;
 	if (arg_str(p, "all") != NULL)
 		req.all = true;
-	else if (iface_from_name(c, arg_str(p, "NAME"), &iface) < 0)
+	else if ((iface = iface_from_name(c, arg_str(p, "NAME"))) == NULL)
 		return CMD_ERROR;
 	else
-		req.iface_id = iface.id;
+		req.iface_id = iface->id;
+	free(iface);
 
 	if (gr_api_client_send_recv(c, GR_INFRA_PACKET_TRACE_SET, sizeof(req), &req, NULL) < 0)
 		return CMD_ERROR;

--- a/modules/infra/cli/vlan.c
+++ b/modules/infra/cli/vlan.c
@@ -15,25 +15,29 @@
 #include <sys/queue.h>
 
 static void vlan_show(struct gr_api_client *c, const struct gr_iface *iface) {
-	const struct gr_iface_info_vlan *vlan = (const struct gr_iface_info_vlan *)iface->info;
-	struct gr_iface parent;
+	const struct gr_iface_info_vlan *vlan = PAYLOAD(iface);
+	struct gr_iface *parent = iface_from_id(c, vlan->parent_id);
 
-	if (iface_from_id(c, vlan->parent_id, &parent) < 0)
+	if (parent == NULL)
 		printf("parent: %u\n", vlan->parent_id);
 	else
-		printf("parent: %s\n", parent.name);
+		printf("parent: %s\n", parent->name);
 	printf("vlan_id: %u\n", vlan->vlan_id);
+
+	free(parent);
 }
 
 static void
 vlan_list_info(struct gr_api_client *c, const struct gr_iface *iface, char *buf, size_t len) {
-	const struct gr_iface_info_vlan *vlan = (const struct gr_iface_info_vlan *)iface->info;
-	struct gr_iface parent;
+	const struct gr_iface_info_vlan *vlan = PAYLOAD(iface);
+	struct gr_iface *parent = iface_from_id(c, vlan->parent_id);
 
-	if (iface_from_id(c, vlan->parent_id, &parent) < 0)
+	if (parent == NULL)
 		snprintf(buf, len, "parent=%u vlan_id=%u", vlan->parent_id, vlan->vlan_id);
 	else
-		snprintf(buf, len, "parent=%s vlan_id=%u", parent.name, vlan->vlan_id);
+		snprintf(buf, len, "parent=%s vlan_id=%u", parent->name, vlan->vlan_id);
+
+	free(parent);
 }
 
 static struct cli_iface_type vlan_type = {
@@ -49,22 +53,25 @@ static uint64_t parse_vlan_args(
 	struct gr_iface *iface,
 	bool update
 ) {
-	uint64_t set_attrs = parse_iface_args(c, p, iface, update);
 	struct gr_iface_info_vlan *vlan;
 	const char *parent_name;
-	struct gr_iface parent;
+	uint64_t set_attrs;
 
+	set_attrs = parse_iface_args(c, p, iface, sizeof(*vlan), update);
 	vlan = (struct gr_iface_info_vlan *)iface->info;
 	parent_name = arg_str(p, "PARENT");
 	if (parent_name != NULL) {
-		if (iface_from_name(c, parent_name, &parent) < 0)
+		struct gr_iface *parent = iface_from_name(c, parent_name);
+		if (parent == NULL)
 			return 0;
-		if (parent.type != GR_IFACE_TYPE_PORT) {
+		if (parent->type != GR_IFACE_TYPE_PORT) {
 			errno = EMEDIUMTYPE;
+			free(parent);
 			return 0;
 		}
-		vlan->parent_id = parent.id;
+		vlan->parent_id = parent->id;
 		set_attrs |= GR_VLAN_SET_PARENT;
+		free(parent);
 	}
 
 	if (arg_u16(p, "VLAN", &vlan->vlan_id) == 0)
@@ -73,16 +80,19 @@ static uint64_t parse_vlan_args(
 	if (arg_eth_addr(p, "MAC", &vlan->mac) == 0) {
 		set_attrs |= GR_VLAN_SET_MAC;
 	} else if (!update) {
+		struct gr_iface *parent = iface_from_id(c, vlan->parent_id);
 		const struct gr_iface_info_port *port;
-		if (parent_name == NULL && iface_from_id(c, vlan->parent_id, &parent) < 0)
+		if (parent == NULL)
 			return 0;
-		if (parent.type != GR_IFACE_TYPE_PORT) {
+		if (parent->type != GR_IFACE_TYPE_PORT) {
 			errno = EMEDIUMTYPE;
+			free(parent);
 			return 0;
 		}
-		port = (const struct gr_iface_info_port *)parent.info;
+		port = (const struct gr_iface_info_port *)parent->info;
 		vlan->mac = port->mac;
 		set_attrs |= GR_VLAN_SET_MAC;
+		free(parent);
 	}
 
 	if (set_attrs == 0)
@@ -92,33 +102,52 @@ static uint64_t parse_vlan_args(
 
 static cmd_status_t vlan_add(struct gr_api_client *c, const struct ec_pnode *p) {
 	const struct gr_infra_iface_add_resp *resp;
-	struct gr_infra_iface_add_req req = {
-		.iface = {.type = GR_IFACE_TYPE_VLAN, .flags = GR_IFACE_F_UP}
-	};
+	struct gr_infra_iface_add_req *req = NULL;
 	void *resp_ptr = NULL;
+	size_t len;
 
-	if (parse_vlan_args(c, p, &req.iface, false) == 0)
-		return CMD_ERROR;
+	len = sizeof(*req) + sizeof(struct gr_iface_info_vlan);
+	if ((req = calloc(1, len)) == NULL)
+		goto err;
 
-	if (gr_api_client_send_recv(c, GR_INFRA_IFACE_ADD, sizeof(req), &req, &resp_ptr) < 0)
-		return CMD_ERROR;
+	req->iface.type = GR_IFACE_TYPE_VLAN;
+	req->iface.flags = GR_IFACE_F_UP;
 
+	if (parse_vlan_args(c, p, &req->iface, false) == 0)
+		goto err;
+
+	if (gr_api_client_send_recv(c, GR_INFRA_IFACE_ADD, len, req, &resp_ptr) < 0)
+		goto err;
+
+	free(req);
 	resp = resp_ptr;
 	printf("Created interface %u\n", resp->iface_id);
 	free(resp_ptr);
 	return CMD_SUCCESS;
+err:
+	free(req);
+	return CMD_ERROR;
 }
 
 static cmd_status_t vlan_set(struct gr_api_client *c, const struct ec_pnode *p) {
-	struct gr_infra_iface_set_req req = {0};
+	struct gr_infra_iface_set_req *req = NULL;
+	cmd_status_t ret = CMD_ERROR;
+	size_t len;
 
-	if ((req.set_attrs = parse_vlan_args(c, p, &req.iface, true)) == 0)
-		return CMD_ERROR;
+	len = sizeof(*req) + sizeof(struct gr_iface_info_vlan);
+	if ((req = calloc(1, len)) == NULL)
+		goto out;
 
-	if (gr_api_client_send_recv(c, GR_INFRA_IFACE_SET, sizeof(req), &req, NULL) < 0)
-		return CMD_ERROR;
+	if ((req->set_attrs = parse_vlan_args(c, p, &req->iface, true)) == 0)
+		goto out;
 
-	return CMD_SUCCESS;
+	if (gr_api_client_send_recv(c, GR_INFRA_IFACE_SET, len, req, NULL) < 0)
+		goto out;
+
+	ret = CMD_SUCCESS;
+out:
+	free(req);
+	return ret;
 }
 
 #define VLAN_ATTRS_CMD IFACE_ATTRS_CMD ",(mac MAC)"

--- a/modules/infra/cli/vlan.c
+++ b/modules/infra/cli/vlan.c
@@ -14,7 +14,7 @@
 #include <errno.h>
 #include <sys/queue.h>
 
-static void vlan_show(const struct gr_api_client *c, const struct gr_iface *iface) {
+static void vlan_show(struct gr_api_client *c, const struct gr_iface *iface) {
 	const struct gr_iface_info_vlan *vlan = (const struct gr_iface_info_vlan *)iface->info;
 	struct gr_iface parent;
 
@@ -26,7 +26,7 @@ static void vlan_show(const struct gr_api_client *c, const struct gr_iface *ifac
 }
 
 static void
-vlan_list_info(const struct gr_api_client *c, const struct gr_iface *iface, char *buf, size_t len) {
+vlan_list_info(struct gr_api_client *c, const struct gr_iface *iface, char *buf, size_t len) {
 	const struct gr_iface_info_vlan *vlan = (const struct gr_iface_info_vlan *)iface->info;
 	struct gr_iface parent;
 
@@ -44,7 +44,7 @@ static struct cli_iface_type vlan_type = {
 };
 
 static uint64_t parse_vlan_args(
-	const struct gr_api_client *c,
+	struct gr_api_client *c,
 	const struct ec_pnode *p,
 	struct gr_iface *iface,
 	bool update
@@ -90,7 +90,7 @@ static uint64_t parse_vlan_args(
 	return set_attrs;
 }
 
-static cmd_status_t vlan_add(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t vlan_add(struct gr_api_client *c, const struct ec_pnode *p) {
 	const struct gr_infra_iface_add_resp *resp;
 	struct gr_infra_iface_add_req req = {
 		.iface = {.type = GR_IFACE_TYPE_VLAN, .flags = GR_IFACE_F_UP}
@@ -109,7 +109,7 @@ static cmd_status_t vlan_add(const struct gr_api_client *c, const struct ec_pnod
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t vlan_set(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t vlan_set(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_infra_iface_set_req req = {0};
 
 	if ((req.set_attrs = parse_vlan_args(c, p, &req.iface, true)) == 0)

--- a/modules/infra/control/gr_iface.h
+++ b/modules/infra/control/gr_iface.h
@@ -37,7 +37,8 @@ typedef void (*iface_to_api_t)(void *api_info, const struct iface *);
 
 struct iface_type {
 	uint16_t id;
-	size_t info_size;
+	size_t pub_size;
+	size_t priv_size;
 	iface_init_t init;
 	iface_reconfig_t reconfig;
 	iface_fini_t fini;

--- a/modules/infra/control/iface.c
+++ b/modules/infra/control/iface.c
@@ -89,7 +89,7 @@ struct iface *iface_create(const struct gr_iface *conf, const void *api_info) {
 		}
 	}
 
-	iface = rte_zmalloc(__func__, sizeof(*iface) + type->info_size, RTE_CACHE_LINE_SIZE);
+	iface = rte_zmalloc(__func__, sizeof(*iface) + type->priv_size, RTE_CACHE_LINE_SIZE);
 	if (iface == NULL) {
 		errno = ENOMEM;
 		goto fail;

--- a/modules/infra/control/loopback.c
+++ b/modules/infra/control/loopback.c
@@ -291,7 +291,8 @@ static void iface_loopback_to_api(void * /* info */, const struct iface * /* ifa
 static struct iface_type iface_type_loopback = {
 	.id = GR_IFACE_TYPE_LOOPBACK,
 	.name = "loopback",
-	.info_size = sizeof(struct iface_info_loopback),
+	.pub_size = 0,
+	.priv_size = sizeof(struct iface_info_loopback),
 	.init = iface_loopback_init,
 	.fini = iface_loopback_fini,
 	.to_api = iface_loopback_to_api,

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -700,7 +700,8 @@ static void port_fini(struct event_base *) {
 static struct iface_type iface_type_port = {
 	.id = GR_IFACE_TYPE_PORT,
 	.name = "port",
-	.info_size = sizeof(struct iface_info_port),
+	.pub_size = sizeof(struct gr_iface_info_port),
+	.priv_size = sizeof(struct iface_info_port),
 	.init = iface_port_init,
 	.reconfig = iface_port_reconfig,
 	.fini = iface_port_fini,

--- a/modules/infra/control/vlan.c
+++ b/modules/infra/control/vlan.c
@@ -224,7 +224,8 @@ static void vlan_to_api(void *info, const struct iface *iface) {
 static struct iface_type iface_type_vlan = {
 	.id = GR_IFACE_TYPE_VLAN,
 	.name = "vlan",
-	.info_size = sizeof(struct iface_info_vlan),
+	.pub_size = sizeof(struct gr_iface_info_vlan),
+	.priv_size = sizeof(struct iface_info_vlan),
 	.init = iface_vlan_init,
 	.reconfig = iface_vlan_reconfig,
 	.fini = iface_vlan_fini,

--- a/modules/ip/api/gr_ip4.h
+++ b/modules/ip/api/gr_ip4.h
@@ -66,10 +66,7 @@ struct gr_ip4_route_list_req {
 	uint16_t vrf_id;
 };
 
-struct gr_ip4_route_list_resp {
-	uint16_t n_routes;
-	struct gr_ip4_route routes[/* n_routes */];
-};
+// STREAM(struct gr_ip4_route);
 
 // addresses ///////////////////////////////////////////////////////////////////
 

--- a/modules/ip/api/gr_ip4.h
+++ b/modules/ip/api/gr_ip4.h
@@ -97,10 +97,7 @@ struct gr_ip4_addr_list_req {
 	uint16_t vrf_id;
 };
 
-struct gr_ip4_addr_list_resp {
-	uint16_t n_addrs;
-	struct gr_ip4_ifaddr addrs[/* n_addrs */];
-};
+// STREAM(struct gr_ip4_ifaddr);
 
 // icmp ////////////////////////////////////////////////////////////////////////
 

--- a/modules/ip/cli/address.c
+++ b/modules/ip/cli/address.c
@@ -16,7 +16,7 @@
 
 #include <stdint.h>
 
-static cmd_status_t addr_add(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t addr_add(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip4_addr_add_req req = {.exist_ok = true};
 	struct gr_iface iface;
 
@@ -32,7 +32,7 @@ static cmd_status_t addr_add(const struct gr_api_client *c, const struct ec_pnod
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t addr_del(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t addr_del(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip4_addr_del_req req = {.missing_ok = true};
 	struct gr_iface iface;
 
@@ -48,7 +48,7 @@ static cmd_status_t addr_del(const struct gr_api_client *c, const struct ec_pnod
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t addr_list(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t addr_list(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct libscols_table *table = scols_new_table();
 	const struct gr_ip4_addr_list_resp *resp;
 	struct gr_ip4_addr_list_req req = {0};

--- a/modules/ip/cli/address.c
+++ b/modules/ip/cli/address.c
@@ -49,34 +49,21 @@ static cmd_status_t addr_del(struct gr_api_client *c, const struct ec_pnode *p) 
 }
 
 static cmd_status_t addr_list(struct gr_api_client *c, const struct ec_pnode *p) {
-	struct libscols_table *table = scols_new_table();
-	const struct gr_ip4_addr_list_resp *resp;
 	struct gr_ip4_addr_list_req req = {0};
+	const struct gr_ip4_ifaddr *addr;
 	struct gr_iface iface;
-	void *resp_ptr = NULL;
+	int ret;
 
-	if (table == NULL)
+	if (arg_u16(p, "VRF", &req.vrf_id) < 0 && errno != ENOENT)
 		return CMD_ERROR;
 
-	if (arg_u16(p, "VRF", &req.vrf_id) < 0 && errno != ENOENT) {
-		scols_unref_table(table);
-		return CMD_ERROR;
-	}
-
-	if (gr_api_client_send_recv(c, GR_IP4_ADDR_LIST, sizeof(req), &req, &resp_ptr) < 0) {
-		scols_unref_table(table);
-		return CMD_ERROR;
-	}
-
-	resp = resp_ptr;
-
+	struct libscols_table *table = scols_new_table();
 	scols_table_new_column(table, "IFACE", 0, 0);
 	scols_table_new_column(table, "ADDRESS", 0, 0);
 	scols_table_set_column_separator(table, "  ");
 
-	for (size_t i = 0; i < resp->n_addrs; i++) {
+	gr_api_client_stream_foreach (addr, ret, c, GR_IP4_ADDR_LIST, sizeof(req), &req) {
 		struct libscols_line *line = scols_table_new_line(table, NULL);
-		const struct gr_ip4_ifaddr *addr = &resp->addrs[i];
 		if (iface_from_id(c, addr->iface_id, &iface) == 0)
 			scols_line_sprintf(line, 0, "%s", iface.name);
 		else
@@ -86,9 +73,8 @@ static cmd_status_t addr_list(struct gr_api_client *c, const struct ec_pnode *p)
 
 	scols_print_table(table);
 	scols_unref_table(table);
-	free(resp_ptr);
 
-	return CMD_SUCCESS;
+	return ret < 0 ? CMD_ERROR : CMD_SUCCESS;
 }
 
 static int ctx_init(struct ec_node *root) {

--- a/modules/ip/cli/address.c
+++ b/modules/ip/cli/address.c
@@ -18,13 +18,15 @@
 
 static cmd_status_t addr_add(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip4_addr_add_req req = {.exist_ok = true};
-	struct gr_iface iface;
+	struct gr_iface *iface = iface_from_name(c, arg_str(p, "IFACE"));
+
+	if (iface == NULL)
+		return CMD_ERROR;
+	req.addr.iface_id = iface->id;
+	free(iface);
 
 	if (arg_ip4_net(p, "IP_NET", &req.addr.addr, false) < 0)
 		return CMD_ERROR;
-	if (iface_from_name(c, arg_str(p, "IFACE"), &iface) < 0)
-		return CMD_ERROR;
-	req.addr.iface_id = iface.id;
 
 	if (gr_api_client_send_recv(c, GR_IP4_ADDR_ADD, sizeof(req), &req, NULL) < 0)
 		return CMD_ERROR;
@@ -34,13 +36,15 @@ static cmd_status_t addr_add(struct gr_api_client *c, const struct ec_pnode *p) 
 
 static cmd_status_t addr_del(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip4_addr_del_req req = {.missing_ok = true};
-	struct gr_iface iface;
+	struct gr_iface *iface = iface_from_name(c, arg_str(p, "IFACE"));
+
+	if (iface == NULL)
+		return CMD_ERROR;
+	req.addr.iface_id = iface->id;
+	free(iface);
 
 	if (arg_ip4_net(p, "IP_NET", &req.addr.addr, false) < 0)
 		return CMD_ERROR;
-	if (iface_from_name(c, arg_str(p, "IFACE"), &iface) < 0)
-		return CMD_ERROR;
-	req.addr.iface_id = iface.id;
 
 	if (gr_api_client_send_recv(c, GR_IP4_ADDR_DEL, sizeof(req), &req, NULL) < 0)
 		return CMD_ERROR;
@@ -51,7 +55,6 @@ static cmd_status_t addr_del(struct gr_api_client *c, const struct ec_pnode *p) 
 static cmd_status_t addr_list(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip4_addr_list_req req = {0};
 	const struct gr_ip4_ifaddr *addr;
-	struct gr_iface iface;
 	int ret;
 
 	if (arg_u16(p, "VRF", &req.vrf_id) < 0 && errno != ENOENT)
@@ -64,10 +67,12 @@ static cmd_status_t addr_list(struct gr_api_client *c, const struct ec_pnode *p)
 
 	gr_api_client_stream_foreach (addr, ret, c, GR_IP4_ADDR_LIST, sizeof(req), &req) {
 		struct libscols_line *line = scols_table_new_line(table, NULL);
-		if (iface_from_id(c, addr->iface_id, &iface) == 0)
-			scols_line_sprintf(line, 0, "%s", iface.name);
+		struct gr_iface *iface = iface_from_id(c, addr->iface_id);
+		if (iface != NULL)
+			scols_line_sprintf(line, 0, "%s", iface->name);
 		else
 			scols_line_sprintf(line, 0, "%u", addr->iface_id);
+		free(iface);
 		scols_line_sprintf(line, 1, IP4_F "/%hhu", &addr->addr.ip, addr->addr.prefixlen);
 	}
 

--- a/modules/ip/cli/icmp.c
+++ b/modules/ip/cli/icmp.c
@@ -29,7 +29,7 @@ static void sighandler(int) {
 }
 
 static cmd_status_t icmp_send(
-	const struct gr_api_client *c,
+	struct gr_api_client *c,
 	struct gr_ip4_icmp_send_req *req,
 	uint16_t msdelay,
 	uint16_t count,
@@ -128,7 +128,7 @@ static cmd_status_t icmp_send(
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t ping(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t ping(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip4_icmp_send_req req = {.seq_num = 0, .vrf = 0};
 	cmd_status_t ret = CMD_ERROR;
 	uint16_t count = UINT16_MAX;
@@ -154,7 +154,7 @@ static cmd_status_t ping(const struct gr_api_client *c, const struct ec_pnode *p
 	return ret;
 }
 
-static cmd_status_t traceroute(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t traceroute(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip4_icmp_send_req req = {.seq_num = 0, .vrf = 0};
 	cmd_status_t ret = CMD_SUCCESS;
 

--- a/modules/ip/cli/route.c
+++ b/modules/ip/cli/route.c
@@ -16,7 +16,7 @@
 
 #include <errno.h>
 
-static cmd_status_t route4_add(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t route4_add(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip4_route_add_req req = {.exist_ok = true, .origin = GR_NH_ORIGIN_USER};
 
 	if (arg_ip4_net(p, "DEST", &req.dest, true) < 0)
@@ -34,7 +34,7 @@ static cmd_status_t route4_add(const struct gr_api_client *c, const struct ec_pn
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t route4_del(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t route4_del(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip4_route_del_req req = {.missing_ok = true};
 
 	if (arg_ip4_net(p, "DEST", &req.dest, true) < 0)
@@ -48,7 +48,7 @@ static cmd_status_t route4_del(const struct gr_api_client *c, const struct ec_pn
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t route4_list(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t route4_list(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip4_route_list_req req = {.vrf_id = UINT16_MAX};
 	struct libscols_table *table = scols_new_table();
 	const struct gr_ip4_route_list_resp *resp;
@@ -114,7 +114,7 @@ static cmd_status_t route4_list(const struct gr_api_client *c, const struct ec_p
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t route4_get(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t route4_get(struct gr_api_client *c, const struct ec_pnode *p) {
 	const struct gr_ip4_route_get_resp *resp;
 	struct gr_ip4_route_get_req req = {0};
 	struct gr_iface iface;

--- a/modules/ip/cli/route.c
+++ b/modules/ip/cli/route.c
@@ -50,22 +50,13 @@ static cmd_status_t route4_del(struct gr_api_client *c, const struct ec_pnode *p
 
 static cmd_status_t route4_list(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip4_route_list_req req = {.vrf_id = UINT16_MAX};
-	struct libscols_table *table = scols_new_table();
-	const struct gr_ip4_route_list_resp *resp;
-	void *resp_ptr = NULL;
-
-	if (table == NULL)
-		return CMD_ERROR;
+	const struct gr_ip4_route *route;
+	int ret;
 
 	if (arg_u16(p, "VRF", &req.vrf_id) < 0 && errno != ENOENT)
 		return CMD_ERROR;
 
-	if (gr_api_client_send_recv(c, GR_IP4_ROUTE_LIST, sizeof(req), &req, &resp_ptr) < 0) {
-		scols_unref_table(table);
-		return CMD_ERROR;
-	}
-
-	resp = resp_ptr;
+	struct libscols_table *table = scols_new_table();
 	scols_table_new_column(table, "VRF", 0, 0);
 	scols_table_new_column(table, "DESTINATION", 0, 0);
 	scols_table_new_column(table, "NEXT_HOP", 0, 0);
@@ -74,9 +65,8 @@ static cmd_status_t route4_list(struct gr_api_client *c, const struct ec_pnode *
 	scols_table_new_column(table, "NEXT_HOP_VRF", 0, 0);
 	scols_table_set_column_separator(table, "  ");
 
-	for (size_t i = 0; i < resp->n_routes; i++) {
+	gr_api_client_stream_foreach (route, ret, c, GR_IP4_ROUTE_LIST, sizeof(req), &req) {
 		struct libscols_line *line = scols_table_new_line(table, NULL);
-		const struct gr_ip4_route *route = &resp->routes[i];
 		struct gr_iface iface;
 		scols_line_sprintf(line, 0, "%u", route->vrf_id);
 		scols_line_sprintf(line, 1, IP4_F "/%hhu", &route->dest.ip, route->dest.prefixlen);
@@ -109,9 +99,8 @@ static cmd_status_t route4_list(struct gr_api_client *c, const struct ec_pnode *
 
 	scols_print_table(table);
 	scols_unref_table(table);
-	free(resp_ptr);
 
-	return CMD_SUCCESS;
+	return ret < 0 ? CMD_ERROR : CMD_SUCCESS;
 }
 
 static cmd_status_t route4_get(struct gr_api_client *c, const struct ec_pnode *p) {

--- a/modules/ip/control/route.c
+++ b/modules/ip/control/route.c
@@ -385,36 +385,23 @@ static void route4_list_cb(
 	void *priv
 ) {
 	if (origin != GR_NH_ORIGIN_INTERNAL) {
-		gr_vec struct gr_ip4_route **routes = priv;
+		struct api_ctx *ctx = priv;
 		struct gr_ip4_route r = {
 			.vrf_id = vrf_id,
 			.dest = {ip, prefixlen},
 			.nh = nh->base,
 			.origin = origin,
 		};
-		gr_vec_add(*routes, r);
+		api_send(ctx, sizeof(r), &r);
 	}
 }
 
-static struct api_out route4_list(const void *request, struct api_ctx *) {
+static struct api_out route4_list(const void *request, struct api_ctx *ctx) {
 	const struct gr_ip4_route_list_req *req = request;
-	struct gr_ip4_route_list_resp *resp = NULL;
-	gr_vec struct gr_ip4_route *routes = NULL;
-	size_t len;
 
-	rib4_iter(req->vrf_id, route4_list_cb, &routes);
+	rib4_iter(req->vrf_id, route4_list_cb, (void *)ctx);
 
-	len = sizeof(*resp) + gr_vec_len(routes) * sizeof(struct gr_ip4_route);
-	if ((resp = calloc(1, len)) == NULL) {
-		gr_vec_free(routes);
-		return api_out(ENOMEM, 0, NULL);
-	}
-
-	resp->n_routes = gr_vec_len(routes);
-	memcpy(resp->routes, routes, gr_vec_len(routes) * sizeof(resp->routes[0]));
-	gr_vec_free(routes);
-
-	return api_out(0, len, resp);
+	return api_out(0, 0, NULL);
 }
 
 static void route4_init(struct event_base *) {

--- a/modules/ip6/api/gr_ip6.h
+++ b/modules/ip6/api/gr_ip6.h
@@ -97,10 +97,7 @@ struct gr_ip6_addr_list_req {
 	uint16_t vrf_id;
 };
 
-struct gr_ip6_addr_list_resp {
-	uint16_t n_addrs;
-	struct gr_ip6_ifaddr addrs[/* n_addrs */];
-};
+// STREAM(struct gr_ip6_ifaddr);
 
 // router advertisement ////////////////////////////////////////////////////////
 

--- a/modules/ip6/api/gr_ip6.h
+++ b/modules/ip6/api/gr_ip6.h
@@ -120,16 +120,13 @@ struct gr_ip6_ra_show_req {
 	uint16_t iface_id;
 };
 
+// STREAM(struct gr_ip6_ra_conf);
+
 struct gr_ip6_ra_conf {
 	bool enabled;
 	uint16_t iface_id;
 	uint16_t interval;
 	uint16_t lifetime;
-};
-
-struct gr_ip6_ra_show_resp {
-	uint16_t n_ras;
-	struct gr_ip6_ra_conf ras[];
 };
 
 // icmpv6 ////////////////////////////////////////////////////////////////////////

--- a/modules/ip6/api/gr_ip6.h
+++ b/modules/ip6/api/gr_ip6.h
@@ -66,10 +66,7 @@ struct gr_ip6_route_list_req {
 	uint16_t vrf_id;
 };
 
-struct gr_ip6_route_list_resp {
-	uint16_t n_routes;
-	struct gr_ip6_route routes[/* n_routes */];
-};
+// STREAM(struct gr_ip6_route);
 
 // addresses ///////////////////////////////////////////////////////////////////
 

--- a/modules/ip6/cli/address.c
+++ b/modules/ip6/cli/address.c
@@ -16,7 +16,7 @@
 
 #include <stdint.h>
 
-static cmd_status_t addr_add(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t addr_add(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip6_addr_add_req req = {.exist_ok = true};
 	struct gr_iface iface;
 
@@ -32,7 +32,7 @@ static cmd_status_t addr_add(const struct gr_api_client *c, const struct ec_pnod
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t addr_del(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t addr_del(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip6_addr_del_req req = {.missing_ok = true};
 	struct gr_iface iface;
 
@@ -48,7 +48,7 @@ static cmd_status_t addr_del(const struct gr_api_client *c, const struct ec_pnod
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t addr_list(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t addr_list(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct libscols_table *table = scols_new_table();
 	const struct gr_ip6_addr_list_resp *resp;
 	struct gr_ip6_addr_list_req req = {0};

--- a/modules/ip6/cli/icmp6.c
+++ b/modules/ip6/cli/icmp6.c
@@ -21,7 +21,7 @@ static void sighandler(int) {
 }
 
 static cmd_status_t icmp_send(
-	const struct gr_api_client *c,
+	struct gr_api_client *c,
 	struct gr_ip6_icmp_send_req *req,
 	uint16_t msdelay,
 	uint16_t count,
@@ -138,7 +138,7 @@ static cmd_status_t icmp_send(
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t ping(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t ping(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip6_icmp_send_req req = {.iface = GR_IFACE_ID_UNDEF, .vrf = 0};
 	cmd_status_t ret = CMD_ERROR;
 	uint16_t count = UINT16_MAX;
@@ -171,7 +171,7 @@ static cmd_status_t ping(const struct gr_api_client *c, const struct ec_pnode *p
 	return ret;
 }
 
-static cmd_status_t traceroute(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t traceroute(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip6_icmp_send_req req = {.iface = GR_IFACE_ID_UNDEF, .vrf = 0};
 	cmd_status_t ret = CMD_SUCCESS;
 	struct gr_iface iface;

--- a/modules/ip6/cli/icmp6.c
+++ b/modules/ip6/cli/icmp6.c
@@ -143,7 +143,6 @@ static cmd_status_t ping(struct gr_api_client *c, const struct ec_pnode *p) {
 	cmd_status_t ret = CMD_ERROR;
 	uint16_t count = UINT16_MAX;
 	uint16_t msdelay = 1000;
-	struct gr_iface iface;
 	const char *str;
 
 	if (arg_ip6(p, "DEST", &req.addr) < 0)
@@ -155,9 +154,11 @@ static cmd_status_t ping(struct gr_api_client *c, const struct ec_pnode *p) {
 	if ((ret = arg_u16(p, "DELAY", &msdelay)) < 0 && ret != ENOENT)
 		return CMD_ERROR;
 	if ((str = arg_str(p, "IFACE")) != NULL) {
-		if (iface_from_name(c, str, &iface) < 0)
+		struct gr_iface *iface = iface_from_name(c, str);
+		if (iface == NULL)
 			return CMD_ERROR;
-		req.iface = iface.id;
+		req.iface = iface->id;
+		free(iface);
 	}
 
 	sighandler_t prev_handler = signal(SIGINT, sighandler);
@@ -174,7 +175,6 @@ static cmd_status_t ping(struct gr_api_client *c, const struct ec_pnode *p) {
 static cmd_status_t traceroute(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip6_icmp_send_req req = {.iface = GR_IFACE_ID_UNDEF, .vrf = 0};
 	cmd_status_t ret = CMD_SUCCESS;
-	struct gr_iface iface;
 	const char *str;
 
 	if (arg_ip6(p, "DEST", &req.addr) < 0)
@@ -182,9 +182,11 @@ static cmd_status_t traceroute(struct gr_api_client *c, const struct ec_pnode *p
 	if ((ret = arg_u16(p, "VRF", &req.vrf)) < 0 && ret != ENOENT)
 		return CMD_ERROR;
 	if ((str = arg_str(p, "IFACE")) != NULL) {
-		if (iface_from_name(c, str, &iface) < 0)
+		struct gr_iface *iface = iface_from_name(c, str);
+		if (iface == NULL)
 			return CMD_ERROR;
-		req.iface = iface.id;
+		req.iface = iface->id;
+		free(iface);
 	}
 
 	sighandler_t prev_handler = signal(SIGINT, sighandler);

--- a/modules/ip6/cli/route.c
+++ b/modules/ip6/cli/route.c
@@ -16,7 +16,7 @@
 
 #include <errno.h>
 
-static cmd_status_t route6_add(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t route6_add(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip6_route_add_req req = {.exist_ok = true, .origin = GR_NH_ORIGIN_USER};
 
 	if (arg_ip6_net(p, "DEST", &req.dest, true) < 0)
@@ -34,7 +34,7 @@ static cmd_status_t route6_add(const struct gr_api_client *c, const struct ec_pn
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t route6_del(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t route6_del(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip6_route_del_req req = {.missing_ok = true};
 
 	if (arg_ip6_net(p, "DEST", &req.dest, true) < 0)
@@ -48,7 +48,7 @@ static cmd_status_t route6_del(const struct gr_api_client *c, const struct ec_pn
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t route6_list(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t route6_list(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip6_route_list_req req = {.vrf_id = UINT16_MAX};
 	struct libscols_table *table = scols_new_table();
 	const struct gr_ip6_route_list_resp *resp;
@@ -114,7 +114,7 @@ static cmd_status_t route6_list(const struct gr_api_client *c, const struct ec_p
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t route6_get(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t route6_get(struct gr_api_client *c, const struct ec_pnode *p) {
 	const struct gr_ip6_route_get_resp *resp;
 	struct gr_ip6_route_get_req req = {0};
 	struct gr_iface iface;

--- a/modules/ip6/cli/route.c
+++ b/modules/ip6/cli/route.c
@@ -67,7 +67,6 @@ static cmd_status_t route6_list(struct gr_api_client *c, const struct ec_pnode *
 
 	gr_api_client_stream_foreach (route, ret, c, GR_IP6_ROUTE_LIST, sizeof(req), &req) {
 		struct libscols_line *line = scols_table_new_line(table, NULL);
-		struct gr_iface iface;
 		scols_line_sprintf(line, 0, "%u", route->vrf_id);
 		scols_line_sprintf(line, 1, IP6_F "/%hhu", &route->dest, route->dest.prefixlen);
 		if (route->nh.type == GR_NH_T_BLACKHOLE)
@@ -77,10 +76,12 @@ static cmd_status_t route6_list(struct gr_api_client *c, const struct ec_pnode *
 		else
 			switch (route->nh.af) {
 			case GR_AF_UNSPEC:
-				if (iface_from_id(c, route->nh.iface_id, &iface) < 0)
+				struct gr_iface *iface = iface_from_id(c, route->nh.iface_id);
+				if (iface == NULL)
 					scols_line_sprintf(line, 2, "%u", route->nh.iface_id);
 				else
-					scols_line_sprintf(line, 2, "%s", iface.name);
+					scols_line_sprintf(line, 2, "%s", iface->name);
+				free(iface);
 				break;
 			case GR_AF_IP4:
 				scols_line_sprintf(line, 2, IP4_F, &route->nh.ipv4);
@@ -106,7 +107,6 @@ static cmd_status_t route6_list(struct gr_api_client *c, const struct ec_pnode *
 static cmd_status_t route6_get(struct gr_api_client *c, const struct ec_pnode *p) {
 	const struct gr_ip6_route_get_resp *resp;
 	struct gr_ip6_route_get_req req = {0};
-	struct gr_iface iface;
 	void *resp_ptr = NULL;
 
 	if (arg_ip6(p, "DEST", &req.dest) < 0) {
@@ -125,10 +125,12 @@ static cmd_status_t route6_get(struct gr_api_client *c, const struct ec_pnode *p
 	printf(IP6_F " via " IP6_F " lladdr " ETH_F, &req.dest, &resp->nh.ipv6, &resp->nh.mac);
 	if (resp->nh.nh_id != GR_NH_ID_UNSET)
 		printf(" id %u", resp->nh.nh_id);
-	if (iface_from_id(c, resp->nh.iface_id, &iface) == 0)
-		printf(" iface %s", iface.name);
+	struct gr_iface *iface = iface_from_id(c, resp->nh.iface_id);
+	if (iface != NULL)
+		printf(" iface %s", iface->name);
 	else
 		printf(" iface %u", resp->nh.iface_id);
+	free(iface);
 	printf("\n");
 	free(resp_ptr);
 

--- a/modules/ip6/cli/router_advert.c
+++ b/modules/ip6/cli/router_advert.c
@@ -14,42 +14,37 @@
 #include <libsmartcols.h>
 
 static cmd_status_t ra_show(struct gr_api_client *c, const struct ec_pnode *p) {
-	struct gr_ip6_ra_show_resp *resp;
+	const struct gr_ip6_ra_conf *ra;
 	struct gr_ip6_ra_show_req req;
 	struct gr_iface iface;
-	void *resp_ptr = NULL;
+	int ret;
 
 	if (!iface_from_name(c, arg_str(p, "IFACE"), &iface))
 		req.iface_id = iface.id;
 	else
-		req.iface_id = 0;
-
-	if (gr_api_client_send_recv(c, GR_IP6_IFACE_RA_SHOW, sizeof(req), &req, &resp_ptr) < 0)
-		return CMD_ERROR;
-	resp = resp_ptr;
+		req.iface_id = GR_IFACE_ID_UNDEF;
 
 	struct libscols_table *table = scols_new_table();
 	scols_table_new_column(table, "IFACE", 0, 0);
 	scols_table_new_column(table, "RA", 0, 0);
-	scols_table_new_column(table, "interval", 0, 0);
-	scols_table_new_column(table, "lifetime", 0, 0);
+	scols_table_new_column(table, "INTERVAL", 0, 0);
+	scols_table_new_column(table, "LIFETIME", 0, 0);
 	scols_table_set_column_separator(table, "  ");
 
-	for (uint16_t i = 0; i < resp->n_ras; i++) {
+	gr_api_client_stream_foreach (ra, ret, c, GR_IP6_IFACE_RA_SHOW, sizeof(req), &req) {
 		struct libscols_line *line = scols_table_new_line(table, NULL);
-		if (iface_from_id(c, resp->ras[i].iface_id, &iface) == 0)
+		if (iface_from_id(c, ra->iface_id, &iface) == 0)
 			scols_line_sprintf(line, 0, "%s", iface.name);
 		else
-			scols_line_sprintf(line, 0, "%u", resp->ras[i].iface_id);
-		scols_line_sprintf(line, 1, "%u", resp->ras[i].enabled);
-		scols_line_sprintf(line, 2, "%u", resp->ras[i].interval);
-		scols_line_sprintf(line, 3, "%u", resp->ras[i].lifetime);
+			scols_line_sprintf(line, 0, "%u", ra->iface_id);
+		scols_line_sprintf(line, 1, "%u", ra->enabled);
+		scols_line_sprintf(line, 2, "%u", ra->interval);
+		scols_line_sprintf(line, 3, "%u", ra->lifetime);
 	}
 
 	scols_print_table(table);
 	scols_unref_table(table);
-	free(resp_ptr);
-	return CMD_SUCCESS;
+	return ret < 0 ? CMD_ERROR : CMD_SUCCESS;
 }
 
 static cmd_status_t ra_set(struct gr_api_client *c, const struct ec_pnode *p) {

--- a/modules/ip6/cli/router_advert.c
+++ b/modules/ip6/cli/router_advert.c
@@ -13,7 +13,7 @@
 #include <ecoli.h>
 #include <libsmartcols.h>
 
-static cmd_status_t ra_show(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t ra_show(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip6_ra_show_resp *resp;
 	struct gr_ip6_ra_show_req req;
 	struct gr_iface iface;
@@ -52,7 +52,7 @@ static cmd_status_t ra_show(const struct gr_api_client *c, const struct ec_pnode
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t ra_set(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t ra_set(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip6_ra_set_req req = {0};
 	struct gr_iface iface;
 
@@ -71,7 +71,7 @@ static cmd_status_t ra_set(const struct gr_api_client *c, const struct ec_pnode 
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t ra_clear(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t ra_clear(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip6_ra_clear_req req;
 	struct gr_iface iface;
 

--- a/modules/ip6/control/route.c
+++ b/modules/ip6/control/route.c
@@ -422,36 +422,23 @@ static void route6_list_cb(
 	void *priv
 ) {
 	if (origin != GR_NH_ORIGIN_INTERNAL) {
-		gr_vec struct gr_ip6_route **routes = priv;
+		struct api_ctx *ctx = priv;
 		struct gr_ip6_route r = {
 			.vrf_id = vrf_id,
 			.dest = {*ip, prefixlen},
 			.nh = nh->base,
 			.origin = origin,
 		};
-		gr_vec_add(*routes, r);
+		api_send(ctx, sizeof(r), &r);
 	}
 }
 
-static struct api_out route6_list(const void *request, struct api_ctx *) {
+static struct api_out route6_list(const void *request, struct api_ctx *ctx) {
 	const struct gr_ip6_route_list_req *req = request;
-	struct gr_ip6_route_list_resp *resp = NULL;
-	gr_vec struct gr_ip6_route *routes = NULL;
-	size_t len;
 
-	rib6_iter(req->vrf_id, route6_list_cb, &routes);
+	rib6_iter(req->vrf_id, route6_list_cb, ctx);
 
-	len = sizeof(*resp) + gr_vec_len(routes) * sizeof(struct gr_ip6_route);
-	if ((resp = calloc(1, len)) == NULL) {
-		gr_vec_free(routes);
-		return api_out(ENOMEM, 0, NULL);
-	}
-
-	resp->n_routes = gr_vec_len(routes);
-	memcpy(resp->routes, routes, gr_vec_len(routes) * sizeof(resp->routes[0]));
-	gr_vec_free(routes);
-
-	return api_out(0, len, resp);
+	return api_out(0, 0, NULL);
 }
 
 static void route6_init(struct event_base *) {

--- a/modules/ipip/cli.c
+++ b/modules/ipip/cli.c
@@ -11,7 +11,7 @@
 
 #include <errno.h>
 
-static void ipip_show(const struct gr_api_client *, const struct gr_iface *iface) {
+static void ipip_show(struct gr_api_client *, const struct gr_iface *iface) {
 	const struct gr_iface_info_ipip *ipip = (const struct gr_iface_info_ipip *)iface->info;
 
 	printf("local: " IP4_F "\n", &ipip->local);
@@ -19,7 +19,7 @@ static void ipip_show(const struct gr_api_client *, const struct gr_iface *iface
 }
 
 static void
-ipip_list_info(const struct gr_api_client *, const struct gr_iface *iface, char *buf, size_t len) {
+ipip_list_info(struct gr_api_client *, const struct gr_iface *iface, char *buf, size_t len) {
 	const struct gr_iface_info_ipip *ipip = (const struct gr_iface_info_ipip *)iface->info;
 
 	snprintf(buf, len, "local=" IP4_F " remote=" IP4_F, &ipip->local, &ipip->remote);
@@ -33,7 +33,7 @@ static struct cli_iface_type ipip_type = {
 };
 
 static uint64_t parse_ipip_args(
-	const struct gr_api_client *c,
+	struct gr_api_client *c,
 	const struct ec_pnode *p,
 	struct gr_iface *iface,
 	bool update
@@ -67,7 +67,7 @@ static uint64_t parse_ipip_args(
 	return set_attrs;
 }
 
-static cmd_status_t ipip_add(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t ipip_add(struct gr_api_client *c, const struct ec_pnode *p) {
 	const struct gr_infra_iface_add_resp *resp;
 	struct gr_infra_iface_add_req req = {
 		.iface = {.type = GR_IFACE_TYPE_IPIP, .flags = GR_IFACE_F_UP}
@@ -86,7 +86,7 @@ static cmd_status_t ipip_add(const struct gr_api_client *c, const struct ec_pnod
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t ipip_set(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t ipip_set(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_infra_iface_set_req req = {0};
 
 	if ((req.set_attrs = parse_ipip_args(c, p, &req.iface, true)) == 0)

--- a/modules/ipip/control.c
+++ b/modules/ipip/control.c
@@ -127,7 +127,8 @@ static void ipip_to_api(void *info, const struct iface *iface) {
 static struct iface_type iface_type_ipip = {
 	.id = GR_IFACE_TYPE_IPIP,
 	.name = "ipip",
-	.info_size = sizeof(struct iface_info_ipip),
+	.pub_size = sizeof(struct gr_iface_info_ipip),
+	.priv_size = sizeof(struct iface_info_ipip),
 	.init = iface_ipip_init,
 	.reconfig = iface_ipip_reconfig,
 	.fini = iface_ipip_fini,

--- a/modules/ipip/gr_ipip.h
+++ b/modules/ipip/gr_ipip.h
@@ -18,5 +18,3 @@ struct gr_iface_info_ipip {
 	ip4_addr_t local;
 	ip4_addr_t remote;
 };
-
-static_assert(sizeof(struct gr_iface_info_ipip) <= MEMBER_SIZE(struct gr_iface, info));

--- a/modules/policy/api/dnat44.c
+++ b/modules/policy/api/dnat44.c
@@ -111,7 +111,7 @@ static struct api_out dnat44_del(const void *request, struct api_ctx *) {
 
 struct dnat44_list_iterator {
 	uint16_t vrf_id;
-	gr_vec struct gr_dnat44_policy *policies;
+	struct api_ctx *ctx;
 };
 
 static void dnat44_list_iter(struct nexthop *nh, void *priv) {
@@ -131,34 +131,19 @@ static void dnat44_list_iter(struct nexthop *nh, void *priv) {
 		.match = nh->ipv4,
 		.replace = data->replace,
 	};
-	gr_vec_add(iter->policies, policy);
+	api_send(iter->ctx, sizeof(policy), &policy);
 }
 
-static struct api_out dnat44_list(const void *request, struct api_ctx *) {
+static struct api_out dnat44_list(const void *request, struct api_ctx *ctx) {
 	const struct gr_dnat44_list_req *req = request;
-	struct gr_dnat44_list_resp *resp;
 	struct dnat44_list_iterator iter = {
 		.vrf_id = req->vrf_id,
-		.policies = NULL,
+		.ctx = ctx,
 	};
-	size_t len;
 
 	nexthop_iter(dnat44_list_iter, &iter);
 
-	len = sizeof(*resp) + gr_vec_len(iter.policies) * sizeof(struct gr_dnat44_policy);
-	resp = malloc(len);
-	if (resp == NULL) {
-		gr_vec_free(iter.policies);
-		return api_out(ENOMEM, 0, NULL);
-	}
-
-	resp->n_policies = gr_vec_len(iter.policies);
-	memcpy(resp->policies,
-	       iter.policies,
-	       gr_vec_len(iter.policies) * sizeof(struct gr_dnat44_policy));
-	gr_vec_free(iter.policies);
-
-	return api_out(0, len, resp);
+	return api_out(0, 0, NULL);
 }
 
 static struct gr_api_handler add_handler = {

--- a/modules/policy/api/gr_conntrack.h
+++ b/modules/policy/api/gr_conntrack.h
@@ -79,10 +79,7 @@ struct gr_conntrack {
 
 // struct gr_conntrack_list_req { };
 
-struct gr_conntrack_list_resp {
-	uint32_t n_conns;
-	struct gr_conntrack conns[/* n_conns */];
-};
+// STREAM(struct gr_conntrack);
 
 #define GR_CONNTRACK_FLUSH REQUEST_TYPE(GR_CONNTRACK_MODULE, 0x0002)
 

--- a/modules/policy/api/gr_nat.h
+++ b/modules/policy/api/gr_nat.h
@@ -75,7 +75,4 @@ struct gr_snat44_del_req {
 
 // struct gr_snat44_list_req { };
 
-struct gr_snat44_list_resp {
-	uint16_t n_policies;
-	struct gr_snat44_policy policies[/* n_policies */];
-};
+// STREAM(struct gr_snat44_policy);

--- a/modules/policy/api/gr_nat.h
+++ b/modules/policy/api/gr_nat.h
@@ -43,10 +43,7 @@ struct gr_dnat44_list_req {
 	uint16_t vrf_id;
 };
 
-struct gr_dnat44_list_resp {
-	uint16_t n_policies;
-	struct gr_dnat44_policy policies[/* n_policies */];
-};
+// STREAM(struct gr_dnat44_policy);
 
 // snat44 //////////////////////////////////////////////////////////////////////
 

--- a/modules/policy/api/snat44.c
+++ b/modules/policy/api/snat44.c
@@ -38,24 +38,17 @@ static struct api_out snat44_del(const void *request, struct api_ctx *) {
 	return api_out(-ret, 0, NULL);
 }
 
-static struct api_out snat44_list(const void * /*request*/, struct api_ctx *) {
+static struct api_out snat44_list(const void * /*request*/, struct api_ctx *ctx) {
 	gr_vec struct gr_snat44_policy *policies;
-	struct gr_snat44_list_resp *resp;
-	size_t len;
+	struct gr_snat44_policy *policy;
 
 	policies = snat44_dynamic_policy_export();
-	len = sizeof(*resp) + gr_vec_len(policies) * sizeof(*policies);
-	resp = malloc(len);
-	if (resp == NULL) {
-		gr_vec_free(policies);
-		return api_out(ENOMEM, 0, NULL);
+	gr_vec_foreach_ref (policy, policies) {
+		api_send(ctx, sizeof(*policy), policy);
 	}
-
-	resp->n_policies = gr_vec_len(policies);
-	memcpy(resp->policies, policies, gr_vec_len(policies) * sizeof(*policies));
 	gr_vec_free(policies);
 
-	return api_out(0, len, resp);
+	return api_out(0, 0, NULL);
 }
 
 static struct gr_api_handler add_handler = {

--- a/modules/policy/cli/conntrack.c
+++ b/modules/policy/cli/conntrack.c
@@ -40,12 +40,14 @@ static cmd_status_t conn_list(struct gr_api_client *c, const struct ec_pnode *) 
 	gr_api_client_stream_foreach (conn, ret, c, GR_CONNTRACK_LIST, 0, NULL) {
 		struct libscols_line *fwd = scols_table_new_line(table, NULL);
 		struct libscols_line *rev = scols_table_new_line(table, NULL);
-		struct gr_iface iface;
+		struct gr_iface *iface = iface_from_id(c, conn->iface_id);
 
-		if (iface_from_id(c, conn->iface_id, &iface) < 0)
+		if (iface == NULL)
 			scols_line_sprintf(fwd, 0, "%u", conn->iface_id);
 		else
-			scols_line_sprintf(fwd, 0, "%s", iface.name);
+			scols_line_sprintf(fwd, 0, "%s", iface->name);
+
+		free(iface);
 
 		scols_line_sprintf(fwd, 1, "0x%08x", conn->id);
 

--- a/modules/policy/cli/conntrack.c
+++ b/modules/policy/cli/conntrack.c
@@ -16,7 +16,7 @@
 
 #include <stdint.h>
 
-static cmd_status_t conn_list(const struct gr_api_client *c, const struct ec_pnode *) {
+static cmd_status_t conn_list(struct gr_api_client *c, const struct ec_pnode *) {
 	const struct gr_conntrack_list_resp *resp;
 	struct libscols_table *table;
 	cmd_status_t ret = CMD_ERROR;
@@ -98,14 +98,14 @@ end:
 	return ret;
 }
 
-static cmd_status_t conn_flush(const struct gr_api_client *c, const struct ec_pnode *) {
+static cmd_status_t conn_flush(struct gr_api_client *c, const struct ec_pnode *) {
 	if (gr_api_client_send_recv(c, GR_CONNTRACK_FLUSH, 0, NULL, NULL) < 0)
 		return CMD_ERROR;
 
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t config_show(const struct gr_api_client *c, const struct ec_pnode *) {
+static cmd_status_t config_show(struct gr_api_client *c, const struct ec_pnode *) {
 	const struct gr_conntrack_conf_get_resp *resp;
 	void *resp_ptr = NULL;
 
@@ -129,7 +129,7 @@ static cmd_status_t config_show(const struct gr_api_client *c, const struct ec_p
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t config_set(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t config_set(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_conntrack_conf_set_req req = {0};
 
 	if (arg_u32(p, "MAX", &req.max_count) < 0 && errno != ENOENT)

--- a/modules/policy/cli/dnat44.c
+++ b/modules/policy/cli/dnat44.c
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 
-static cmd_status_t dnat44_add(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t dnat44_add(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_dnat44_add_req req = {.exist_ok = true};
 	struct gr_iface iface;
 
@@ -33,7 +33,7 @@ static cmd_status_t dnat44_add(const struct gr_api_client *c, const struct ec_pn
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t dnat44_del(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t dnat44_del(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_dnat44_del_req req = {.missing_ok = true};
 	struct gr_iface iface;
 
@@ -49,7 +49,7 @@ static cmd_status_t dnat44_del(const struct gr_api_client *c, const struct ec_pn
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t dnat44_list(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t dnat44_list(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct libscols_table *table = scols_new_table();
 	const struct gr_dnat44_list_resp *resp;
 	struct gr_dnat44_list_req req = {0};

--- a/modules/policy/cli/snat44.c
+++ b/modules/policy/cli/snat44.c
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 
-static cmd_status_t snat44_add(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t snat44_add(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_snat44_add_req req = {.exist_ok = true};
 	struct gr_iface iface;
 
@@ -33,7 +33,7 @@ static cmd_status_t snat44_add(const struct gr_api_client *c, const struct ec_pn
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t snat44_del(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t snat44_del(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_snat44_del_req req = {.missing_ok = true};
 	struct gr_iface iface;
 
@@ -51,7 +51,7 @@ static cmd_status_t snat44_del(const struct gr_api_client *c, const struct ec_pn
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t snat44_list(const struct gr_api_client *c, const struct ec_pnode *) {
+static cmd_status_t snat44_list(struct gr_api_client *c, const struct ec_pnode *) {
 	const struct gr_snat44_list_resp *resp;
 	struct libscols_table *table;
 	cmd_status_t ret = CMD_ERROR;

--- a/modules/policy/cli/snat44.c
+++ b/modules/policy/cli/snat44.c
@@ -16,12 +16,14 @@
 #include <stdint.h>
 
 static cmd_status_t snat44_add(struct gr_api_client *c, const struct ec_pnode *p) {
+	struct gr_iface *iface = iface_from_name(c, arg_str(p, "IFACE"));
 	struct gr_snat44_add_req req = {.exist_ok = true};
-	struct gr_iface iface;
 
-	if (iface_from_name(c, arg_str(p, "IFACE"), &iface) < 0)
+	if (iface == NULL)
 		return CMD_ERROR;
-	req.policy.iface_id = iface.id;
+	req.policy.iface_id = iface->id;
+	free(iface);
+
 	if (arg_ip4_net(p, "NET", &req.policy.net, true) < 0)
 		return CMD_ERROR;
 	if (arg_ip4(p, "REPLACE", &req.policy.replace) < 0)
@@ -34,12 +36,14 @@ static cmd_status_t snat44_add(struct gr_api_client *c, const struct ec_pnode *p
 }
 
 static cmd_status_t snat44_del(struct gr_api_client *c, const struct ec_pnode *p) {
+	struct gr_iface *iface = iface_from_name(c, arg_str(p, "IFACE"));
 	struct gr_snat44_del_req req = {.missing_ok = true};
-	struct gr_iface iface;
 
-	if (iface_from_name(c, arg_str(p, "IFACE"), &iface) < 0)
+	if (iface == NULL)
 		return CMD_ERROR;
-	req.policy.iface_id = iface.id;
+	req.policy.iface_id = iface->id;
+	free(iface);
+
 	if (arg_ip4_net(p, "NET", &req.policy.net, true) < 0)
 		return CMD_ERROR;
 	if (arg_ip4(p, "REPLACE", &req.policy.replace) < 0)
@@ -64,12 +68,13 @@ static cmd_status_t snat44_list(struct gr_api_client *c, const struct ec_pnode *
 
 	gr_api_client_stream_foreach (policy, ret, c, GR_SNAT44_LIST, 0, NULL) {
 		struct libscols_line *line = scols_table_new_line(table, NULL);
-		struct gr_iface iface;
+		struct gr_iface *iface = iface_from_id(c, policy->iface_id);
 
-		if (iface_from_id(c, policy->iface_id, &iface) < 0)
+		if (iface == NULL)
 			scols_line_sprintf(line, 0, "%u", policy->iface_id);
 		else
-			scols_line_sprintf(line, 0, "%s", iface.name);
+			scols_line_sprintf(line, 0, "%s", iface->name);
+		free(iface);
 
 		scols_line_sprintf(line, 1, IP4_F "/%hhu", &policy->net.ip, policy->net.prefixlen);
 		scols_line_sprintf(line, 2, IP4_F, &policy->replace);

--- a/modules/srv6/api/gr_srv6.h
+++ b/modules/srv6/api/gr_srv6.h
@@ -126,7 +126,4 @@ struct gr_srv6_localsid_list_req {
 	uint16_t vrf_id;
 };
 
-struct gr_srv6_localsid_list_resp {
-	uint16_t n_lsid;
-	struct gr_srv6_localsid lsid[/* n_lsid */];
-};
+// STREAM(struct gr_srv6_localsid);

--- a/modules/srv6/api/gr_srv6.h
+++ b/modules/srv6/api/gr_srv6.h
@@ -58,10 +58,7 @@ struct gr_srv6_route_list_req {
 	uint16_t vrf_id;
 };
 
-struct gr_srv6_route_list_resp {
-	uint16_t n_route;
-	uint8_t route[/* n_route */];
-};
+// STREAM(struct gr_srv6_route);
 
 #define GR_SRV6_TUNSRC_SET REQUEST_TYPE(GR_SRV6_MODULE, 0x0005)
 struct gr_srv6_tunsrc_set_req {

--- a/modules/srv6/cli/localsid.c
+++ b/modules/srv6/cli/localsid.c
@@ -36,7 +36,7 @@ static gr_srv6_behavior_t str_to_behavior(const char *str) {
 	return SR_BEHAVIOR_MAX;
 }
 
-static cmd_status_t srv6_localsid_add(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t srv6_localsid_add(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_srv6_localsid_add_req req = {
 		.l.out_vrf_id = UINT16_MAX, .exist_ok = true, .origin = GR_NH_ORIGIN_USER
 	};
@@ -79,7 +79,7 @@ static cmd_status_t srv6_localsid_add(const struct gr_api_client *c, const struc
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t srv6_localsid_del(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t srv6_localsid_del(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_srv6_localsid_del_req req = {.vrf_id = 0, .missing_ok = true};
 
 	if (arg_ip6(p, "SID", &req.lsid) < 0)
@@ -94,7 +94,7 @@ static cmd_status_t srv6_localsid_del(const struct gr_api_client *c, const struc
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t srv6_localsid_show(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t srv6_localsid_show(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_srv6_localsid_list_req req = {.vrf_id = UINT16_MAX};
 	struct libscols_table *table = scols_new_table();
 	struct gr_srv6_localsid_list_resp *resp;

--- a/modules/srv6/cli/route.c
+++ b/modules/srv6/cli/route.c
@@ -12,7 +12,7 @@
 
 #include <errno.h>
 
-static cmd_status_t srv6_route_add(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t srv6_route_add(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_srv6_route_add_req *req;
 	const struct ec_strvec *v;
 	const struct ec_pnode *n;
@@ -63,7 +63,7 @@ static cmd_status_t srv6_route_add(const struct gr_api_client *c, const struct e
 	return ret < 0 ? CMD_ERROR : CMD_SUCCESS;
 }
 
-static cmd_status_t srv6_route_del(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t srv6_route_del(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_srv6_route_del_req req = {.key.vrf_id = 0, .missing_ok = true};
 
 	if (arg_ip6_net(p, "DEST6", &req.key.dest6, true) >= 0)
@@ -82,7 +82,7 @@ static cmd_status_t srv6_route_del(const struct gr_api_client *c, const struct e
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t srv6_route_show(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t srv6_route_show(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct libscols_table *table = scols_new_table();
 	struct gr_srv6_route_list_req req = {};
 	struct gr_srv6_route_list_resp *resp;
@@ -159,7 +159,7 @@ static cmd_status_t srv6_route_show(const struct gr_api_client *c, const struct 
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t srv6_tunsrc_set(const struct gr_api_client *c, const struct ec_pnode *p) {
+static cmd_status_t srv6_tunsrc_set(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_srv6_tunsrc_set_req req;
 
 	if (arg_ip6(p, "SRC", &req.addr) < 0)
@@ -171,14 +171,14 @@ static cmd_status_t srv6_tunsrc_set(const struct gr_api_client *c, const struct 
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t srv6_tunsrc_clear(const struct gr_api_client *c, const struct ec_pnode *) {
+static cmd_status_t srv6_tunsrc_clear(struct gr_api_client *c, const struct ec_pnode *) {
 	if (gr_api_client_send_recv(c, GR_SRV6_TUNSRC_CLEAR, 0, NULL, NULL) < 0)
 		return CMD_ERROR;
 
 	return CMD_SUCCESS;
 }
 
-static cmd_status_t srv6_tunsrc_show(const struct gr_api_client *c, const struct ec_pnode *) {
+static cmd_status_t srv6_tunsrc_show(struct gr_api_client *c, const struct ec_pnode *) {
 	struct gr_srv6_tunsrc_show_resp *resp;
 	void *resp_ptr;
 

--- a/modules/srv6/control/route.c
+++ b/modules/srv6/control/route.c
@@ -73,7 +73,7 @@ static void srv6_encap_data_del(struct nexthop *nh) {
 }
 
 // srv6 route ////////////////////////////////////////////////////////////////
-static struct api_out srv6_route_add(const void *request, void ** /*response*/) {
+static struct api_out srv6_route_add(const void *request, struct api_ctx *) {
 	const struct gr_srv6_route_add_req *req = request;
 	struct gr_nexthop base = {
 		.type = GR_NH_T_SR6_OUTPUT,
@@ -99,12 +99,12 @@ static struct api_out srv6_route_add(const void *request, void ** /*response*/) 
 
 	nh = nexthop_new(&base);
 	if (nh == NULL)
-		return api_out(errno, 0);
+		return api_out(errno, 0, NULL);
 
 	ret = srv6_encap_data_add(nh, req->r.encap_behavior, req->r.n_seglist, req->r.seglist);
 	if (ret < 0) {
 		nexthop_decref(nh);
-		return api_out(-ret, 0);
+		return api_out(-ret, 0, NULL);
 	}
 
 	if (req->r.key.is_dest6)
@@ -128,10 +128,10 @@ static struct api_out srv6_route_add(const void *request, void ** /*response*/) 
 	if (ret == -EEXIST && req->exist_ok)
 		ret = 0;
 
-	return api_out(-ret, 0);
+	return api_out(-ret, 0, NULL);
 }
 
-static struct api_out srv6_route_del(const void *request, void ** /*response*/) {
+static struct api_out srv6_route_del(const void *request, struct api_ctx *) {
 	const struct gr_srv6_route_del_req *req = request;
 	int ret;
 
@@ -155,7 +155,7 @@ static struct api_out srv6_route_del(const void *request, void ** /*response*/) 
 	if (ret == -ENOENT && req->missing_ok)
 		ret = 0;
 
-	return api_out(-ret, 0);
+	return api_out(-ret, 0, NULL);
 }
 
 struct list_context {
@@ -180,7 +180,7 @@ static void nh_srv6_list_cb(struct nexthop *nh, void *priv) {
 	gr_vec_add(ctx->nhs, nh);
 }
 
-static struct api_out srv6_route_list(const void *request, void **response) {
+static struct api_out srv6_route_list(const void *request, struct api_ctx *) {
 	const struct gr_srv6_route_list_req *req = request;
 	struct gr_srv6_route_list_resp *resp;
 	struct list_context ctx = {.vrf_id = req->vrf_id, .nhs = NULL, .len = sizeof(*resp)};
@@ -192,7 +192,7 @@ static struct api_out srv6_route_list(const void *request, void **response) {
 	nexthop_iter(nh_srv6_list_cb, &ctx);
 
 	if ((resp = calloc(1, ctx.len)) == NULL) {
-		return api_out(ENOMEM, 0);
+		return api_out(ENOMEM, 0, NULL);
 	}
 	resp->n_route = 0;
 
@@ -227,28 +227,26 @@ static struct api_out srv6_route_list(const void *request, void **response) {
 	assert(ptr - (void *)resp <= ctx.len);
 	gr_vec_free(ctx.nhs);
 
-	*response = resp;
-
-	return api_out(0, ctx.len);
+	return api_out(0, ctx.len, resp);
 }
 
 struct nexthop *tunsrc_nh = NULL;
 
-static struct api_out srv6_tunsrc_clear(const void * /*request*/, void ** /*response*/) {
+static struct api_out srv6_tunsrc_clear(const void * /*request*/, struct api_ctx *) {
 	if (tunsrc_nh) {
 		nexthop_decref(tunsrc_nh);
 		tunsrc_nh = NULL;
 	}
 
-	return api_out(0, 0);
+	return api_out(0, 0, NULL);
 }
 
-static struct api_out srv6_tunsrc_set(const void *request, void ** /*response*/) {
+static struct api_out srv6_tunsrc_set(const void *request, struct api_ctx *ctx) {
 	const struct gr_srv6_tunsrc_set_req *req = request;
 	struct nexthop *nh;
 
 	if (rte_ipv6_addr_is_unspec(&req->addr))
-		return srv6_tunsrc_clear(NULL, NULL);
+		return srv6_tunsrc_clear(NULL, ctx);
 
 	struct gr_nexthop base = {
 		.type = GR_NH_T_L3,
@@ -266,28 +264,27 @@ static struct api_out srv6_tunsrc_set(const void *request, void ** /*response*/)
 		nexthop_decref(tunsrc_nh);
 
 	if ((nh = nexthop_new(&base)) == NULL)
-		return api_out(-errno, 0);
+		return api_out(-errno, 0, NULL);
 
 	tunsrc_nh = nh;
 	nexthop_incref(nh);
 
-	return api_out(0, 0);
+	return api_out(0, 0, NULL);
 }
 
-static struct api_out srv6_tunsrc_show(const void * /*request*/, void **response) {
+static struct api_out srv6_tunsrc_show(const void * /*request*/, struct api_ctx *) {
 	const struct rte_ipv6_addr unspec = RTE_IPV6_ADDR_UNSPEC;
 	struct gr_srv6_tunsrc_show_resp *resp;
 
 	if ((resp = calloc(1, sizeof(*resp))) == NULL)
-		return api_out(-ENOMEM, 0);
+		return api_out(-ENOMEM, 0, NULL);
 
 	if (tunsrc_nh)
 		resp->addr = tunsrc_nh->ipv6;
 	else
 		resp->addr = unspec;
 
-	*response = resp;
-	return api_out(0, sizeof(*resp));
+	return api_out(0, sizeof(*resp), resp);
 }
 
 // srv6 headend module /////////////////////////////////////////////////////


### PR DESCRIPTION
All API requests that return a list of objects in a single response now return multiple responses, one per object. All streaming responses have the same for_id value matching the initial request ID. Streaming responses are always ended by an empty response with no payload.

Add a convenience gr_api_client_stream_foreach macro that will send the request and iterate over all responses that match the request ID and stop on the first error or on the first empty response.
    
Adjust all API headers to reflect this new paradigm. Streaming responses are marked under comments with the following syntax:

```c    
// STREAM(<payload type>);
```

Requesting an iterating over all streamed responses now look like this:

```c
struct gr_ip4_route_list_req = {.vrf_id = 0};
const struct gr_ip4_route *r;
int ret;

gr_api_client_stream_foreach (r, ret, client, GR_IP4_ROUTE_LIST, sizeof(req), &req) {
        do stuff with r;
}
if (ret < 0)
        handle error;
```

Update grcli and frr code accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List endpoints now stream results incrementally; added client-side streaming iterator for large datasets.

* **Refactor**
  * API shifted to per-request contexts with separate send/receive and unified status+payload returns.
  * Public data/layouts clarified (separate public/private sizes, flexible interface info).

* **CLI**
  * Command listings show richer tables (more columns, name resolution) and stream output to reduce memory usage.

* **Chores**
  * Build/coverage and sanitizer settings adjusted; tests/benchmarks increased workload and improved failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->