### PR TITLE
Add Iliad CodeX using qodo

### DIFF
--- a/.github/workflows/codex_iliad.yml
+++ b/.github/workflows/codex_iliad.yml
@@ -1,0 +1,48 @@
+name: PR Agent
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+jobs:
+  pr_agent_job:
+    if: >
+      ${{
+        github.event.sender.type != 'Bot' &&
+        (
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.fork == false
+        ) &&
+        (
+          github.event_name != 'issue_comment' ||
+          github.event.issue.pull_request != null
+        )
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+
+    steps:
+      - name: Run PR-Agent
+        uses: qodo-ai/pr-agent@v0.30
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          # --- Model Configuration ---
+          config.model: "openai/Qwen/Qwen3-235B-A22B-Instruct-2507" # Or use real model name below
+          config.fallback_models: "openai/Qwen/Qwen3-235B-A22B-Instruct-2507"
+          config.custom_model_max_tokens: "128000"
+
+          # --- OpenAI-Compatible vLLM Endpoint ---
+          # get your OPENAI_KEY from https://codex.datax.iliad.fr/
+          OPENAI.API_BASE: "https://codex.datax.iliad.fr/v1"
+          OPENAI.KEY: ${{ secrets.CODEX_API_KEY }}
+
+          # --- Automation Settings (Optional) ---
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "true"
+          github_action_config.auto_improve: "true"


### PR DESCRIPTION
See https://qodo-merge-docs.qodo.ai/ for more information. It is configured with Iliad CodeX, https://codex.datax.iliad.fr/ which is WIP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI workflow that runs an AI-powered PR agent to auto-review, describe, and suggest improvements for pull requests.
  * Triggers on PR open/reopen/ready-for-review and on relevant issue comments; includes safeguards to skip bot senders and exclude forked PRs.
  * Grants necessary repo permissions for automation; no changes to application behavior or UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->