### PR TITLE
nexthop: rework public and internal structures

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -6,4 +6,5 @@ skip =
 	build/*,
 	subprojects/*,
 ignore-words-list =
+	ND,
 	te,

--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ show                 Display information about the configuration.
 clear                Clear counters or temporary entries.
 set                  Modify existing objects in the configuration.
 grout# show interface
-NAME  ID  FLAGS       VRF  TYPE  INFO
-p0    1   up running  0    port  devargs=0000:8a:00.0 mac=30:3e:a7:0b:eb:c0
-p1    2   up running  0    port  devargs=0000:8a:00.1 mac=30:3e:a7:0b:eb:c1
+NAME  ID   FLAGS       MODE  DOMAIN  TYPE  INFO
+p0    256  up running  L3    0       port  devargs=0000:8a:00.0 mac=30:3e:a7:0b:eb:c0
+p1    257  up running  L3    0       port  devargs=0000:8a:00.1 mac=30:3e:a7:0b:eb:c1
 grout# show affinity qmap
 IFACE  RXQ_ID  CPU_ID  ENABLED
 p0     0       2       1
@@ -168,15 +168,17 @@ IFACE  ADDRESS
 p0     172.16.0.2/24
 p1     172.16.1.2/24
 grout# show ip route
-DESTINATION    NEXT_HOP
-172.16.0.0/24  172.16.0.2
-172.16.1.0/24  172.16.1.2
-0.0.0.0/0      172.16.1.183
+VRF  DESTINATION    NEXT_HOP
+0    172.16.0.0/24  type=L3 iface=p0 vrf=0 origin=link af=IPv4 addr=172.16.0.2/24 mac=22:43:d9:2d:dd:58 static local gateway link
+0    172.16.1.0/24  type=L3 iface=p1 vrf=0 origin=link af=IPv4 addr=172.16.1.2/24 mac=1e:34:18:0e:a8:38 static local gateway link
+0    0.0.0.0/0      type=L3 id=1 iface=p1 vrf=0 origin=user af=IPv4 addr=172.16.1.183 state=new gateway
 grout# show nexthop
-VRF  IP            MAC                IFACE  QUEUE  AGE  STATE
-0    172.16.0.2    30:3e:a7:0b:eb:c0  p0     0      0    reachable static local link
-0    172.16.1.2    30:3e:a7:0b:eb:c1  p1     0      0    reachable static local link
-0    172.16.1.183  ??:??:??:??:??:??  ?      0      ?    gateway
+VRF  ID  ORIGIN  IFACE  TYPE  INFO
+0        link    p0     L3    af=IPv6 addr=fe80::2243:d9ff:fe2d:dd58/64 mac=22:43:d9:2d:dd:58 static local gateway link
+0        link    p1     L3    af=IPv6 addr=fe80::1e34:18ff:fe0e:a838/64 mac=1e:34:18:0e:a8:38 static local gateway link
+0        link    p0     L3    af=IPv4 addr=172.16.0.2/24 mac=22:43:d9:2d:dd:58 static local gateway link
+0        link    p1     L3    af=IPv4 addr=172.16.1.2/24 mac=1e:34:18:0e:a8:38 static local gateway link
+0    1   user    p1     L3    af=IPv4 addr=172.16.1.183 state=new gateway
 grout#
 
 ```

--- a/frr/rt_grout.c
+++ b/frr/rt_grout.c
@@ -271,6 +271,24 @@ static int grout_gr_nexthop_to_frr_nexthop(
 		nexthop_add_srv6_seg6local(nh, action, &ctx);
 		break;
 	}
+	case GR_NH_T_SR6_OUTPUT: {
+		enum srv6_headend_behavior encap_behavior = SRV6_HEADEND_BEHAVIOR_H_ENCAPS;
+		const struct gr_nexthop_info_srv6 *sr6;
+
+		sr6 = (const struct gr_nexthop_info_srv6 *)gr_nh->info;
+
+		switch (sr6->encap_behavior) {
+		case SR_H_ENCAPS:
+			encap_behavior = SRV6_HEADEND_BEHAVIOR_H_ENCAPS;
+			break;
+		case SR_H_ENCAPS_RED:
+			encap_behavior = SRV6_HEADEND_BEHAVIOR_H_ENCAPS_RED;
+			break;
+		}
+
+		nexthop_add_srv6_seg6(nh, (void *)sr6->seglist, sr6->n_seglist, encap_behavior);
+		break;
+	}
 	default:
 		gr_log_err(
 			"sync %s nexthops from grout not supported", gr_nh_type_name(gr_nh->type)

--- a/frr/rt_grout.c
+++ b/frr/rt_grout.c
@@ -394,130 +394,6 @@ void grout_route6_change(bool new, struct gr_ip6_route *gr_r6) {
 	);
 }
 
-static_assert(SRV6_MAX_SEGS <= GR_SRV6_ROUTE_SEGLIST_COUNT_MAX);
-
-static enum zebra_dplane_result grout_add_del_srv6_route(
-	const struct prefix *p,
-	gr_nh_origin_t origin,
-	struct nexthop *nh,
-	vrf_id_t vrf_id,
-	bool new
-) {
-	union {
-		struct {
-			struct gr_srv6_route_add_req rsrv6_add;
-			struct rte_ipv6_addr seglist[SRV6_MAX_SEGS];
-		};
-		struct gr_srv6_route_del_req rsrv6_del;
-	} req;
-	struct seg6_seg_stack *segs = nh->nh_srv6->seg6_segs;
-	struct gr_srv6_route *srv6_route;
-	struct gr_srv6_route_key *key;
-	uint32_t req_type;
-	size_t req_len;
-	int i;
-
-	if (new) {
-		req.rsrv6_add = (struct gr_srv6_route_add_req) {
-			.r.key.vrf_id = vrf_id,
-			.exist_ok = true,
-			.origin = origin,
-		};
-		srv6_route = &req.rsrv6_add.r;
-		key = &srv6_route->key;
-		req_type = GR_SRV6_ROUTE_ADD;
-		req_len = sizeof(struct gr_srv6_route_add_req);
-	} else {
-		req.rsrv6_del = (struct gr_srv6_route_del_req) {
-			.key.vrf_id = vrf_id,
-			.missing_ok = false,
-		};
-		srv6_route = NULL;
-		key = &req.rsrv6_del.key;
-		req_type = GR_SRV6_ROUTE_DEL;
-		req_len = sizeof(struct gr_srv6_route_del_req);
-	}
-	*key = (struct gr_srv6_route_key) {.vrf_id = vrf_id, .is_dest6 = (p->family == AF_INET6)};
-
-	if (key->is_dest6) {
-		memcpy(key->dest6.ip.a, p->u.prefix6.s6_addr, sizeof(key->dest6.ip.a));
-		key->dest6.prefixlen = p->prefixlen;
-
-		gr_log_debug(
-			"%s srv6 route %pI6/%u (origin %s) on vrf %u",
-			new ? "add" : "del",
-			&key->dest6.ip,
-			key->dest6.prefixlen,
-			gr_nh_origin_name(origin),
-			vrf_id
-		);
-
-	} else {
-		key->dest4.ip = p->u.prefix4.s_addr;
-		key->dest4.prefixlen = p->prefixlen;
-
-		gr_log_debug(
-			"%s srv6 route %pI4/%u (origin %s) on vrf %u",
-			new ? "add" : "del",
-			&key->dest4.ip,
-			key->dest4.prefixlen,
-			gr_nh_origin_name(origin),
-			vrf_id
-		);
-	}
-
-	// just need key to delete
-	if (!new)
-		goto end;
-
-	switch (segs->encap_behavior) {
-	case SRV6_HEADEND_BEHAVIOR_H_ENCAPS:
-		srv6_route->nh.encap_behavior = SR_H_ENCAPS;
-		break;
-	case SRV6_HEADEND_BEHAVIOR_H_ENCAPS_RED:
-		srv6_route->nh.encap_behavior = SR_H_ENCAPS_RED;
-		break;
-	default:
-		zlog_err(
-			"%s: encap behavior '%s' not supported by grout",
-			__func__,
-			srv6_headend_behavior2str(segs->encap_behavior, true)
-		);
-		return ZEBRA_DPLANE_REQUEST_FAILURE;
-	}
-
-	if (segs->num_segs > SRV6_MAX_SEGS) {
-		zlog_err(
-			"%s: too many segments %u (max zebra %u, max grout %u)",
-			__func__,
-			segs->num_segs,
-			SRV6_MAX_SEGS,
-			GR_SRV6_ROUTE_SEGLIST_COUNT_MAX
-		);
-		return ZEBRA_DPLANE_REQUEST_FAILURE;
-	}
-
-	srv6_route->nh.n_seglist = segs->num_segs;
-	for (i = 0; i < segs->num_segs; i++) {
-		memcpy(
-			&srv6_route->nh.seglist[i], &segs->seg[i], sizeof(srv6_route->nh.seglist[i])
-		);
-		req_len += sizeof(srv6_route->nh.seglist[i]);
-	}
-
-end:
-
-	if (!is_selfroute(origin)) {
-		gr_log_debug("no frr route, skip it");
-		return ZEBRA_DPLANE_REQUEST_SUCCESS;
-	}
-
-	if (grout_client_send_recv(req_type, req_len, &req, NULL) < 0)
-		return ZEBRA_DPLANE_REQUEST_FAILURE;
-
-	return ZEBRA_DPLANE_REQUEST_SUCCESS;
-}
-
 enum zebra_dplane_result grout_add_del_route(struct zebra_dplane_ctx *ctx) {
 	union {
 		struct gr_ip4_route_add_req r4_add;
@@ -527,10 +403,8 @@ enum zebra_dplane_result grout_add_del_route(struct zebra_dplane_ctx *ctx) {
 	} req;
 	uint32_t nh_id = dplane_ctx_get_nhe_id(ctx);
 	uint32_t vrf_id = dplane_ctx_get_vrf(ctx);
-	const struct nexthop_group *ng;
 	const struct prefix *p;
 	gr_nh_origin_t origin;
-	struct nexthop *nh;
 	uint32_t req_type;
 	size_t req_len;
 	bool new;
@@ -548,20 +422,6 @@ enum zebra_dplane_result grout_add_del_route(struct zebra_dplane_ctx *ctx) {
 
 	origin = zebra2origin(dplane_ctx_get_type(ctx));
 	new = dplane_ctx_get_op(ctx) != DPLANE_OP_ROUTE_DELETE;
-
-	ng = dplane_ctx_get_ng(ctx);
-	nh = ng->nexthop;
-	if (nh && nh->nh_srv6 && nh->nh_srv6->seg6_segs && nh->nh_srv6->seg6_segs->num_segs
-	    && !sid_zero(nh->nh_srv6->seg6_segs)) {
-		if (nexthop_group_nexthop_num(ng) > 1) {
-			gr_log_err(
-				"impossible to add/del srv6 route with several nexthop (not "
-				"supported)"
-			);
-			return ZEBRA_DPLANE_REQUEST_FAILURE;
-		}
-		return grout_add_del_srv6_route(p, origin, nh, vrf_id, new);
-	}
 
 	if (new && nh_id == 0) {
 		gr_log_err("impossible to add route with no nexthop id");
@@ -670,6 +530,7 @@ static enum zebra_dplane_result
 grout_add_nexthop(uint32_t nh_id, gr_nh_origin_t origin, const struct nexthop *nh) {
 	enum zebra_dplane_result ret = ZEBRA_DPLANE_REQUEST_FAILURE;
 	struct gr_nexthop_info_srv6_local *sr6_local;
+	struct gr_nexthop_info_srv6 *sr6;
 	struct gr_nh_add_req *req = NULL;
 	struct gr_nexthop_info_l3 *l3;
 	size_t len = sizeof(*req);
@@ -685,6 +546,11 @@ grout_add_nexthop(uint32_t nh_id, gr_nh_origin_t origin, const struct nexthop *n
 		    && nh->nh_srv6->seg6local_action != ZEBRA_SEG6_LOCAL_ACTION_UNSPEC) {
 			len += sizeof(*sr6_local);
 			type = GR_NH_T_SR6_LOCAL;
+		} else if (nh->nh_srv6 != NULL && nh->nh_srv6->seg6_segs != NULL
+			   && nh->nh_srv6->seg6_segs->num_segs > 0) {
+			len += sizeof(*sr6)
+				+ nh->nh_srv6->seg6_segs->num_segs * sizeof(sr6->seglist[0]);
+			type = GR_NH_T_SR6_OUTPUT;
 		} else {
 			len += sizeof(*l3);
 			type = GR_NH_T_L3;
@@ -778,6 +644,33 @@ grout_add_nexthop(uint32_t nh_id, gr_nh_origin_t origin, const struct nexthop *n
 			gr_log_debug("not supported next-c-sid for srv6 local");
 
 		break;
+	case GR_NH_T_SR6_OUTPUT:
+		sr6 = (struct gr_nexthop_info_srv6 *)req->nh.info;
+
+		switch (nh->nh_srv6->seg6_segs->encap_behavior) {
+		case SRV6_HEADEND_BEHAVIOR_H_ENCAPS:
+			sr6->encap_behavior = SR_H_ENCAPS;
+			break;
+		case SRV6_HEADEND_BEHAVIOR_H_ENCAPS_RED:
+			sr6->encap_behavior = SR_H_ENCAPS_RED;
+			break;
+		default:
+			gr_log_err(
+				"encap behavior '%s' not supported by grout",
+				srv6_headend_behavior2str(
+					nh->nh_srv6->seg6_segs->encap_behavior, true
+				)
+			);
+			goto out;
+		}
+
+		sr6->n_seglist = nh->nh_srv6->seg6_segs->num_segs;
+		for (unsigned i = 0; i < nh->nh_srv6->seg6_segs->num_segs; i++)
+			memcpy(&sr6->seglist[i],
+			       &nh->nh_srv6->seg6_segs->seg[i],
+			       sizeof(sr6->seglist[i]));
+
+		break;
 	case GR_NH_T_BLACKHOLE:
 	case GR_NH_T_REJECT:
 		req->nh.iface_id = GR_IFACE_ID_UNDEF;
@@ -800,7 +693,6 @@ out:
 
 enum zebra_dplane_result grout_add_del_nexthop(struct zebra_dplane_ctx *ctx) {
 	uint32_t nh_id = dplane_ctx_get_nhe_id(ctx);
-	const struct nexthop *nh;
 	gr_nh_origin_t origin;
 
 	origin = zebra2origin(dplane_ctx_get_nhe_type(ctx));
@@ -821,16 +713,10 @@ enum zebra_dplane_result grout_add_del_nexthop(struct zebra_dplane_ctx *ctx) {
 		return ZEBRA_DPLANE_REQUEST_FAILURE;
 	}
 
-	nh = dplane_ctx_get_nhe_ng(ctx)->nexthop;
-	if (nh->nh_srv6 && nh->nh_srv6->seg6local_action == ZEBRA_SEG6_LOCAL_ACTION_UNSPEC) {
-		gr_log_err("impossible to add/del srv6 nexthop (not supported)");
-		return ZEBRA_DPLANE_REQUEST_SUCCESS;
-	}
-
 	if (dplane_ctx_get_op(ctx) == DPLANE_OP_NH_DELETE)
 		return grout_del_nexthop(nh_id);
 
-	return grout_add_nexthop(nh_id, origin, nh);
+	return grout_add_nexthop(nh_id, origin, dplane_ctx_get_nhe_ng(ctx)->nexthop);
 }
 
 void grout_nexthop_change(bool new, struct gr_nexthop *gr_nh, bool startup) {

--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -315,10 +315,6 @@ static const char *gr_req_type_to_str(uint32_t e) {
 		return TOSTRING(GR_NH_ADD);
 	case GR_NH_DEL:
 		return TOSTRING(GR_NH_DEL);
-	case GR_SRV6_LOCALSID_ADD:
-		return TOSTRING(GR_SRV6_LOCALSID_ADD);
-	case GR_SRV6_LOCALSID_DEL:
-		return TOSTRING(GR_SRV6_LOCALSID_DEL);
 	case GR_SRV6_ROUTE_ADD:
 		return TOSTRING(GR_SRV6_ROUTE_ADD);
 	case GR_SRV6_ROUTE_DEL:

--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -315,10 +315,6 @@ static const char *gr_req_type_to_str(uint32_t e) {
 		return TOSTRING(GR_NH_ADD);
 	case GR_NH_DEL:
 		return TOSTRING(GR_NH_DEL);
-	case GR_SRV6_ROUTE_ADD:
-		return TOSTRING(GR_SRV6_ROUTE_ADD);
-	case GR_SRV6_ROUTE_DEL:
-		return TOSTRING(GR_SRV6_ROUTE_DEL);
 	case GR_INFRA_IFACE_LIST:
 		return TOSTRING(GR_INFRA_IFACE_LIST);
 	case GR_IP4_ADDR_LIST:

--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -146,7 +146,9 @@ route6:
 }
 
 static void grout_sync_nhs(struct event *e) {
-	struct gr_nh_list_req nh_req = {.vrf_id = EVENT_VAL(e), .all = false};
+	struct gr_nh_list_req nh_req = {
+		.vrf_id = EVENT_VAL(e), .type = GR_NH_T_ALL, .include_internal = false
+	};
 	struct gr_nexthop *nh;
 	int ret;
 

--- a/modules/infra/api/gr_nexthop.h
+++ b/modules/infra/api/gr_nexthop.h
@@ -74,24 +74,34 @@ typedef enum : uint8_t {
 
 #define GR_NH_ID_UNSET UINT32_C(0)
 
-//! Nexthop structure exposed to the API.
-struct gr_nexthop {
+// Generic struct for all nexthops.
+struct gr_nexthop_base {
 	gr_nh_type_t type;
-	addr_family_t af;
+	gr_nh_origin_t origin;
+	uint16_t iface_id; //!< interface associated with this nexthop
+	uint16_t vrf_id; //!< L3 VRF domain
+	uint32_t nh_id; //!< Arbitrary ID set by user. Zero means "unset".
+};
+
+// Info for GR_NH_T_L3 nexthops
+struct gr_nexthop_info_l3 {
 	gr_nh_state_t state;
 	gr_nh_flags_t flags; //!< bit mask of GR_NH_F_*
-	uint32_t nh_id; //!< Arbitrary ID set by user. Zero means "unset".
-	uint16_t vrf_id; //!< L3 VRF domain
-	uint16_t iface_id; //!< interface associated with this nexthop
-	struct rte_ether_addr mac; //!< link-layer address
+	addr_family_t af;
 	uint8_t prefixlen; //!< only has meaning with GR_NH_F_LOCAL
-	gr_nh_origin_t origin;
 	union {
 		struct {
 		} addr;
 		ip4_addr_t ipv4;
 		struct rte_ipv6_addr ipv6;
 	};
+	struct rte_ether_addr mac; //!< link-layer address
+};
+
+//! Nexthop structure exposed to the API.
+struct gr_nexthop {
+	BASE(gr_nexthop_base);
+	uint8_t info[]; //!< Type specific nexthop info.
 };
 
 //! Nexthop events.
@@ -267,8 +277,8 @@ struct gr_infra_nh_config_set_req {
 #define GR_NH_ADD REQUEST_TYPE(GR_INFRA_MODULE, 0x0071)
 
 struct gr_nh_add_req {
-	struct gr_nexthop nh;
 	uint8_t exist_ok;
+	struct gr_nexthop nh;
 };
 
 // struct gr_nh_add_resp { };

--- a/modules/infra/api/gr_nexthop.h
+++ b/modules/infra/api/gr_nexthop.h
@@ -32,6 +32,7 @@ typedef enum : uint8_t {
 	GR_NH_T_DNAT,
 	GR_NH_T_BLACKHOLE,
 	GR_NH_T_REJECT,
+#define GR_NH_T_ALL UINT8_C(0xff)
 } gr_nh_type_t;
 
 // Route install origin values shared by IPv4 and IPv6.
@@ -296,7 +297,8 @@ struct gr_nh_del_req {
 
 struct gr_nh_list_req {
 	uint16_t vrf_id;
-	bool all;
+	gr_nh_type_t type;
+	bool include_internal;
 };
 
 // STREAM(struct gr_nexthop);

--- a/modules/infra/cli/gr_cli_nexthop.h
+++ b/modules/infra/cli/gr_cli_nexthop.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025 Robin Jarry
+
+#pragma once
+
+#include <gr_nexthop.h>
+
+#include <stdio.h>
+#include <sys/queue.h>
+
+struct gr_cli_nexthop_formatter {
+	const char *name;
+	gr_nh_type_t type;
+	ssize_t (*format)(char *buf, size_t len, const struct gr_nexthop *);
+	STAILQ_ENTRY(gr_cli_nexthop_formatter) entries;
+};
+
+void gr_cli_nexthop_register_formatter(struct gr_cli_nexthop_formatter *);
+
+ssize_t gr_cli_format_nexthop(
+	char *buf,
+	size_t len,
+	struct gr_api_client *,
+	const struct gr_nexthop *,
+	bool with_base_info
+);

--- a/modules/infra/cli/gr_cli_nexthop.h
+++ b/modules/infra/cli/gr_cli_nexthop.h
@@ -11,7 +11,7 @@
 struct gr_cli_nexthop_formatter {
 	const char *name;
 	gr_nh_type_t type;
-	ssize_t (*format)(char *buf, size_t len, const struct gr_nexthop *);
+	ssize_t (*format)(char *buf, size_t len, const void *nexthop_info);
 	STAILQ_ENTRY(gr_cli_nexthop_formatter) entries;
 };
 

--- a/modules/ip/api/gr_ip4.h
+++ b/modules/ip/api/gr_ip4.h
@@ -17,9 +17,9 @@ struct gr_ip4_ifaddr {
 
 struct gr_ip4_route {
 	struct ip4_net dest;
-	struct gr_nexthop nh;
 	uint16_t vrf_id;
 	gr_nh_origin_t origin;
+	struct gr_nexthop nh;
 };
 
 #define GR_IP4_MODULE 0xf00d

--- a/modules/ip/cli/route.c
+++ b/modules/ip/cli/route.c
@@ -7,6 +7,7 @@
 #include <gr_cli.h>
 #include <gr_cli_event.h>
 #include <gr_cli_iface.h>
+#include <gr_cli_nexthop.h>
 #include <gr_ip4.h>
 #include <gr_net_types.h>
 #include <gr_table.h>
@@ -51,6 +52,7 @@ static cmd_status_t route4_del(struct gr_api_client *c, const struct ec_pnode *p
 static cmd_status_t route4_list(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip4_route_list_req req = {.vrf_id = GR_VRF_ID_ALL};
 	const struct gr_ip4_route *route;
+	char buf[128];
 	int ret;
 
 	if (arg_u16(p, "VRF", &req.vrf_id) < 0 && errno != ENOENT)
@@ -60,42 +62,14 @@ static cmd_status_t route4_list(struct gr_api_client *c, const struct ec_pnode *
 	scols_table_new_column(table, "VRF", 0, 0);
 	scols_table_new_column(table, "DESTINATION", 0, 0);
 	scols_table_new_column(table, "NEXT_HOP", 0, 0);
-	scols_table_new_column(table, "ORIGIN", 0, 0);
-	scols_table_new_column(table, "ID", 0, 0);
-	scols_table_new_column(table, "NEXT_HOP_VRF", 0, 0);
 	scols_table_set_column_separator(table, "  ");
 
 	gr_api_client_stream_foreach (route, ret, c, GR_IP4_ROUTE_LIST, sizeof(req), &req) {
 		struct libscols_line *line = scols_table_new_line(table, NULL);
 		scols_line_sprintf(line, 0, "%u", route->vrf_id);
 		scols_line_sprintf(line, 1, IP4_F "/%hhu", &route->dest.ip, route->dest.prefixlen);
-		if (route->nh.type == GR_NH_T_BLACKHOLE)
-			scols_line_sprintf(line, 2, "blackhole");
-		else if (route->nh.type == GR_NH_T_REJECT)
-			scols_line_sprintf(line, 2, "reject");
-		else
-			switch (route->nh.af) {
-			case GR_AF_UNSPEC:
-				struct gr_iface *iface = iface_from_id(c, route->nh.iface_id);
-				if (iface == NULL)
-					scols_line_sprintf(line, 2, "%u", route->nh.iface_id);
-				else
-					scols_line_sprintf(line, 2, "%s", iface->name);
-				free(iface);
-				break;
-			case GR_AF_IP4:
-				scols_line_sprintf(line, 2, IP4_F, &route->nh.ipv4);
-				break;
-			case GR_AF_IP6:
-				scols_line_sprintf(line, 2, IP6_F, &route->nh.ipv6);
-				break;
-			}
-		scols_line_sprintf(line, 3, "%s", gr_nh_origin_name(route->origin));
-		if (route->nh.nh_id != GR_NH_ID_UNSET)
-			scols_line_sprintf(line, 4, "%u", route->nh.nh_id);
-		else
-			scols_line_set_data(line, 4, "");
-		scols_line_sprintf(line, 5, "%u", route->nh.vrf_id);
+		if (gr_cli_format_nexthop(buf, sizeof(buf), c, &route->nh, true) > 0)
+			scols_line_set_data(line, 2, buf);
 	}
 
 	scols_print_table(table);
@@ -108,6 +82,7 @@ static cmd_status_t route4_get(struct gr_api_client *c, const struct ec_pnode *p
 	const struct gr_ip4_route_get_resp *resp;
 	struct gr_ip4_route_get_req req = {0};
 	void *resp_ptr = NULL;
+	char buf[128];
 
 	if (arg_ip4(p, "DEST", &req.dest) < 0) {
 		if (errno == ENOENT)
@@ -121,16 +96,10 @@ static cmd_status_t route4_get(struct gr_api_client *c, const struct ec_pnode *p
 		return CMD_ERROR;
 
 	resp = resp_ptr;
-	printf(IP4_F " via " IP4_F " lladdr " ETH_F, &req.dest, &resp->nh.ipv4, &resp->nh.mac);
-	if (resp->nh.nh_id != GR_NH_ID_UNSET)
-		printf(" id %u", resp->nh.nh_id);
-	struct gr_iface *iface = iface_from_id(c, resp->nh.iface_id);
-	if (iface != NULL)
-		printf(" iface %s", iface->name);
-	else
-		printf(" iface %u", resp->nh.iface_id);
-	free(iface);
-	printf("\n");
+
+	buf[0] = '\0';
+	gr_cli_format_nexthop(buf, sizeof(buf), c, &resp->nh, true);
+	printf(IP4_F " via %s\n", &req.dest, buf);
 	free(resp_ptr);
 
 	return CMD_SUCCESS;
@@ -183,6 +152,7 @@ static struct gr_cli_context ctx = {
 static void route_event_print(uint32_t event, const void *obj) {
 	const struct gr_ip4_route *r = obj;
 	const char *action;
+	char buf[128];
 
 	switch (event) {
 	case GR_EVENT_IP_ROUTE_ADD:
@@ -196,28 +166,14 @@ static void route_event_print(uint32_t event, const void *obj) {
 		break;
 	}
 
-	printf("route %s: vrf=%u " IP4_F "/%hhu via",
+	buf[0] = '\0';
+	gr_cli_format_nexthop(buf, sizeof(buf), NULL, &r->nh, true);
+	printf("route %s: vrf=%u " IP4_F "/%hhu via %s\n",
 	       action,
 	       r->vrf_id,
 	       &r->dest.ip,
-	       r->dest.prefixlen);
-
-	printf(" type=%s", gr_nh_type_name(r->nh.type));
-
-	if (r->nh.nh_id != GR_NH_ID_UNSET)
-		printf(" id=%u", r->nh.nh_id);
-
-	printf(" vrf=%u af=%s", r->nh.vrf_id, gr_af_name(r->nh.af));
-
-	if (r->nh.af != GR_AF_UNSPEC)
-		printf(" " ADDR_F, ADDR_W(r->nh.af), &r->nh.addr);
-	else if (r->nh.iface_id != GR_IFACE_ID_UNDEF)
-		printf(" iface=%u", r->nh.iface_id);
-
-	if (r->origin != GR_NH_ORIGIN_UNSPEC)
-		printf(" origin=%s", gr_nh_origin_name(r->origin));
-
-	printf("\n");
+	       r->dest.prefixlen,
+	       buf);
 }
 
 static struct gr_cli_event_printer printer = {

--- a/modules/ip/control/route.c
+++ b/modules/ip/control/route.c
@@ -125,6 +125,13 @@ struct nexthop *rib4_lookup_exact(uint16_t vrf_id, ip4_addr_t ip, uint8_t prefix
 	return nh_id_to_ptr(nh_id);
 }
 
+struct route4_event {
+	struct ip4_net dest;
+	uint16_t vrf_id;
+	gr_nh_origin_t origin;
+	const struct nexthop *nh;
+};
+
 static int rib4_insert_or_replace(
 	uint16_t vrf_id,
 	ip4_addr_t ip,
@@ -162,8 +169,6 @@ static int rib4_insert_or_replace(
 		}
 	}
 
-	nh->flags |= GR_NH_F_GATEWAY;
-
 	rte_rib_set_nh(rn, nh_ptr_to_id(nh));
 	o = rte_rib_get_ext(rn);
 	gr_nh_origin_t old_origin = origin;
@@ -174,11 +179,11 @@ static int rib4_insert_or_replace(
 	if (origin != GR_NH_ORIGIN_INTERNAL) {
 		gr_event_push(
 			GR_EVENT_IP_ROUTE_ADD,
-			&(struct gr_ip4_route) {
-				{ip, prefixlen},
-				nh->base,
-				vrf_id,
-				origin,
+			&(const struct route4_event) {
+				.dest = {ip, prefixlen},
+				.vrf_id = vrf_id,
+				.origin = origin,
+				.nh = nh,
 			}
 		);
 	}
@@ -235,11 +240,11 @@ int rib4_delete(uint16_t vrf_id, ip4_addr_t ip, uint8_t prefixlen, gr_nh_type_t 
 	if (origin != GR_NH_ORIGIN_INTERNAL) {
 		gr_event_push(
 			GR_EVENT_IP_ROUTE_DEL,
-			&(struct gr_ip4_route) {
-				{ip, prefixlen},
-				nh->base,
-				vrf_id,
-				origin,
+			&(const struct route4_event) {
+				.dest = {ip, prefixlen},
+				.vrf_id = vrf_id,
+				.origin = origin,
+				.nh = nh,
 			}
 		);
 	}
@@ -274,16 +279,19 @@ static struct api_out route4_add(const void *request, struct api_ctx *) {
 
 		// if the route gateway is reachable via a prefix route,
 		// create a new unresolved nexthop
-		if (nh->ipv4 != req->nh) {
-			nh = nexthop_new(&(struct gr_nexthop) {
-				.type = GR_NH_T_L3,
-				.af = GR_AF_IP4,
-				.flags = GR_NH_F_GATEWAY,
-				.vrf_id = req->vrf_id,
-				.iface_id = nh->iface_id,
-				.ipv4 = req->nh,
-				.origin = req->origin,
-			});
+		if (nh->type != GR_NH_T_L3 || nexthop_info_l3(nh)->ipv4 != req->nh) {
+			nh = nexthop_new(
+				&(struct gr_nexthop_base) {
+					.type = GR_NH_T_L3,
+					.iface_id = nh->iface_id,
+					.vrf_id = req->vrf_id,
+					.origin = req->origin,
+				},
+				&(struct gr_nexthop_info_l3) {
+					.af = GR_AF_IP4,
+					.ipv4 = req->nh,
+				}
+			);
 			if (nh == NULL)
 				return api_out(errno, 0, NULL);
 		}
@@ -309,27 +317,24 @@ static struct api_out route4_del(const void *request, struct api_ctx *) {
 	if (ret == -ENOENT && req->missing_ok)
 		ret = 0;
 
-	if (nh && nh->ref_count == 1)
-		nh->flags &= ~GR_NH_F_GATEWAY;
-
 	return api_out(-ret, 0, NULL);
 }
 
 static struct api_out route4_get(const void *request, struct api_ctx *) {
 	const struct gr_ip4_route_get_req *req = request;
-	struct gr_ip4_route_get_resp *resp = NULL;
 	const struct nexthop *nh = NULL;
+	struct gr_nexthop *pub = NULL;
+	size_t len;
 
 	nh = rib4_lookup(req->vrf_id, req->dest);
 	if (nh == NULL)
 		return api_out(ENETUNREACH, 0, NULL);
 
-	if ((resp = calloc(1, sizeof(*resp))) == NULL)
-		return api_out(ENOMEM, 0, NULL);
+	pub = nexthop_to_api(nh, &len);
+	if (pub == NULL)
+		return api_out(errno, 0, NULL);
 
-	resp->nh = nh->base;
-
-	return api_out(0, sizeof(*resp), resp);
+	return api_out(0, len, pub);
 }
 
 void rib4_iter(uint16_t vrf_id, rib4_iter_cb_t cb, void *priv) {
@@ -364,6 +369,11 @@ void rib4_iter(uint16_t vrf_id, rib4_iter_cb_t cb, void *priv) {
 	}
 }
 
+struct route4_iterator {
+	struct api_ctx *ctx;
+	int ret;
+};
+
 static void route4_list_cb(
 	uint16_t vrf_id,
 	ip4_addr_t ip,
@@ -372,24 +382,44 @@ static void route4_list_cb(
 	const struct nexthop *nh,
 	void *priv
 ) {
-	if (origin != GR_NH_ORIGIN_INTERNAL) {
-		struct api_ctx *ctx = priv;
-		struct gr_ip4_route r = {
-			.vrf_id = vrf_id,
-			.dest = {ip, prefixlen},
-			.nh = nh->base,
-			.origin = origin,
-		};
-		api_send(ctx, sizeof(r), &r);
+	struct route4_iterator *iter = priv;
+	if (origin != GR_NH_ORIGIN_INTERNAL && iter->ret == 0) {
+		struct gr_ip4_route *r;
+		struct gr_nexthop *pub;
+		size_t nh_len, len;
+
+		pub = nexthop_to_api(nh, &nh_len);
+		if (pub == NULL) {
+			iter->ret = errno;
+			LOG(ERR, "nexthop_export: %s", strerror(errno));
+			return;
+		}
+
+		len = sizeof(*r) - sizeof(r->nh) + nh_len;
+		r = malloc(len);
+		if (r != NULL) {
+			r->vrf_id = vrf_id;
+			r->dest.ip = ip;
+			r->dest.prefixlen = prefixlen;
+			r->origin = origin;
+			memcpy(&r->nh, pub, nh_len);
+			api_send(iter->ctx, len, r);
+		} else {
+			LOG(ERR, "cannot allocate memory");
+			iter->ret = ENOMEM;
+		}
+		free(pub);
+		free(r);
 	}
 }
 
 static struct api_out route4_list(const void *request, struct api_ctx *ctx) {
 	const struct gr_ip4_route_list_req *req = request;
+	struct route4_iterator iter = {.ctx = ctx, .ret = 0};
 
-	rib4_iter(req->vrf_id, route4_list_cb, (void *)ctx);
+	rib4_iter(req->vrf_id, route4_list_cb, &iter);
 
-	return api_out(0, 0, NULL);
+	return api_out(iter.ret, 0, NULL);
 }
 
 static void route4_init(struct event_base *) {
@@ -475,6 +505,34 @@ telemetry_rib4_stats_get(const char * /*cmd*/, const char * /*params*/, struct r
 	return 0;
 }
 
+static int serialize_route4_event(const void *obj, void **buf) {
+	const struct route4_event *priv = obj;
+	struct gr_ip4_route *r;
+	struct gr_nexthop *nh;
+	size_t nh_len;
+	int len;
+
+	nh = nexthop_to_api(priv->nh, &nh_len);
+	if (nh == NULL)
+		return -errno;
+
+	len = sizeof(*r) - sizeof(r->nh) + nh_len;
+
+	r = malloc(len);
+	if (r == NULL) {
+		len = -errno;
+	} else {
+		r->vrf_id = priv->vrf_id;
+		r->dest = priv->dest;
+		r->origin = priv->origin;
+		memcpy(&r->nh, nh, nh_len);
+		*buf = r;
+	}
+	free(nh);
+
+	return len;
+}
+
 static struct gr_api_handler route4_add_handler = {
 	.name = "ipv4 route add",
 	.request_type = GR_IP4_ROUTE_ADD,
@@ -497,7 +555,7 @@ static struct gr_api_handler route4_list_handler = {
 };
 
 static struct gr_event_serializer route_serializer = {
-	.size = sizeof(struct gr_ip4_route),
+	.callback = serialize_route4_event,
 	.ev_count = 2,
 	.ev_types = {GR_EVENT_IP_ROUTE_ADD, GR_EVENT_IP_ROUTE_DEL},
 };

--- a/modules/ip/datapath/arp_output_reply.c
+++ b/modules/ip/datapath/arp_output_reply.c
@@ -27,6 +27,7 @@ static uint16_t arp_output_reply_process(
 	uint16_t nb_objs
 ) {
 	struct eth_output_mbuf_data *eth_data;
+	const struct nexthop_info_l3 *l3;
 	const struct nexthop *local;
 	const struct iface *iface;
 	struct rte_arp_hdr *arp;
@@ -45,6 +46,7 @@ static uint16_t arp_output_reply_process(
 			edge = ERROR;
 			goto next;
 		}
+		l3 = nexthop_info_l3(local);
 
 		// Reuse mbuf to craft an ARP reply.
 		rte_pktmbuf_trim(mbuf, rte_pktmbuf_pkt_len(mbuf));
@@ -55,7 +57,7 @@ static uint16_t arp_output_reply_process(
 		arp->arp_data.arp_tha = arp->arp_data.arp_sha;
 		iface_get_eth_addr(iface->id, &arp->arp_data.arp_sha);
 		arp->arp_data.arp_tip = arp->arp_data.arp_sip;
-		arp->arp_data.arp_sip = local->ipv4;
+		arp->arp_data.arp_sip = l3->ipv4;
 
 		// Prepare ethernet layer info.
 		eth_data = eth_output_mbuf_data(mbuf);

--- a/modules/ip/datapath/fib4.c
+++ b/modules/ip/datapath/fib4.c
@@ -106,14 +106,8 @@ int fib4_insert(uint16_t vrf_id, ip4_addr_t ip, uint8_t prefixlen, const struct 
 	struct rte_fib *fib;
 	int ret;
 
-	if (nh->ref_count == 0)
-		ABORT("nexthop has ref_count==0: vrf=%u iface=%u " IP4_F,
-		      nh->vrf_id,
-		      nh->iface_id,
-		      &nh->ipv4);
-
-	if (rte_lcore_has_role(rte_lcore_id(), ROLE_NON_EAL))
-		ABORT("fib4 modified from datapath thread");
+	assert(nh->ref_count > 0);
+	assert(!rte_lcore_has_role(rte_lcore_id(), ROLE_NON_EAL));
 
 	fib = get_or_create_fib(vrf_id);
 	if (fib == NULL)
@@ -129,8 +123,7 @@ int fib4_remove(uint16_t vrf_id, ip4_addr_t ip, uint8_t prefixlen) {
 	struct rte_fib *fib;
 	int ret;
 
-	if (rte_lcore_has_role(rte_lcore_id(), ROLE_NON_EAL))
-		ABORT("fib4 modified from datapath thread");
+	assert(!rte_lcore_has_role(rte_lcore_id(), ROLE_NON_EAL));
 
 	fib = get_fib(vrf_id);
 	if (fib == NULL)

--- a/modules/ip6/api/gr_ip6.h
+++ b/modules/ip6/api/gr_ip6.h
@@ -17,9 +17,9 @@ struct gr_ip6_ifaddr {
 
 struct gr_ip6_route {
 	struct ip6_net dest;
-	struct gr_nexthop nh;
 	uint16_t vrf_id;
 	gr_nh_origin_t origin;
+	struct gr_nexthop nh;
 };
 
 #define GR_IP6_MODULE 0xfeed

--- a/modules/ip6/cli/route.c
+++ b/modules/ip6/cli/route.c
@@ -7,6 +7,7 @@
 #include <gr_cli.h>
 #include <gr_cli_event.h>
 #include <gr_cli_iface.h>
+#include <gr_cli_nexthop.h>
 #include <gr_ip6.h>
 #include <gr_net_types.h>
 #include <gr_table.h>
@@ -51,6 +52,7 @@ static cmd_status_t route6_del(struct gr_api_client *c, const struct ec_pnode *p
 static cmd_status_t route6_list(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip6_route_list_req req = {.vrf_id = GR_VRF_ID_ALL};
 	const struct gr_ip6_route *route;
+	char buf[128];
 	int ret;
 
 	if (arg_u16(p, "VRF", &req.vrf_id) < 0 && errno != ENOENT)
@@ -60,42 +62,14 @@ static cmd_status_t route6_list(struct gr_api_client *c, const struct ec_pnode *
 	scols_table_new_column(table, "VRF", 0, 0);
 	scols_table_new_column(table, "DESTINATION", 0, 0);
 	scols_table_new_column(table, "NEXT_HOP", 0, 0);
-	scols_table_new_column(table, "ORIGIN", 0, 0);
-	scols_table_new_column(table, "ID", 0, 0);
-	scols_table_new_column(table, "NEXT_HOP_VRF", 0, 0);
 	scols_table_set_column_separator(table, "  ");
 
 	gr_api_client_stream_foreach (route, ret, c, GR_IP6_ROUTE_LIST, sizeof(req), &req) {
 		struct libscols_line *line = scols_table_new_line(table, NULL);
 		scols_line_sprintf(line, 0, "%u", route->vrf_id);
 		scols_line_sprintf(line, 1, IP6_F "/%hhu", &route->dest, route->dest.prefixlen);
-		if (route->nh.type == GR_NH_T_BLACKHOLE)
-			scols_line_sprintf(line, 2, "blackhole");
-		else if (route->nh.type == GR_NH_T_REJECT)
-			scols_line_sprintf(line, 2, "reject");
-		else
-			switch (route->nh.af) {
-			case GR_AF_UNSPEC:
-				struct gr_iface *iface = iface_from_id(c, route->nh.iface_id);
-				if (iface == NULL)
-					scols_line_sprintf(line, 2, "%u", route->nh.iface_id);
-				else
-					scols_line_sprintf(line, 2, "%s", iface->name);
-				free(iface);
-				break;
-			case GR_AF_IP4:
-				scols_line_sprintf(line, 2, IP4_F, &route->nh.ipv4);
-				break;
-			case GR_AF_IP6:
-				scols_line_sprintf(line, 2, IP6_F, &route->nh.ipv6);
-				break;
-			}
-		scols_line_sprintf(line, 3, "%s", gr_nh_origin_name(route->origin));
-		if (route->nh.nh_id != GR_NH_ID_UNSET)
-			scols_line_sprintf(line, 4, "%u", route->nh.nh_id);
-		else
-			scols_line_set_data(line, 4, "");
-		scols_line_sprintf(line, 5, "%u", route->nh.vrf_id);
+		if (gr_cli_format_nexthop(buf, sizeof(buf), c, &route->nh, true) > 0)
+			scols_line_set_data(line, 2, buf);
 	}
 
 	scols_print_table(table);
@@ -108,6 +82,7 @@ static cmd_status_t route6_get(struct gr_api_client *c, const struct ec_pnode *p
 	const struct gr_ip6_route_get_resp *resp;
 	struct gr_ip6_route_get_req req = {0};
 	void *resp_ptr = NULL;
+	char buf[128];
 
 	if (arg_ip6(p, "DEST", &req.dest) < 0) {
 		if (errno == ENOENT)
@@ -122,16 +97,9 @@ static cmd_status_t route6_get(struct gr_api_client *c, const struct ec_pnode *p
 		return CMD_ERROR;
 
 	resp = resp_ptr;
-	printf(IP6_F " via " IP6_F " lladdr " ETH_F, &req.dest, &resp->nh.ipv6, &resp->nh.mac);
-	if (resp->nh.nh_id != GR_NH_ID_UNSET)
-		printf(" id %u", resp->nh.nh_id);
-	struct gr_iface *iface = iface_from_id(c, resp->nh.iface_id);
-	if (iface != NULL)
-		printf(" iface %s", iface->name);
-	else
-		printf(" iface %u", resp->nh.iface_id);
-	free(iface);
-	printf("\n");
+	buf[0] = '\0';
+	gr_cli_format_nexthop(buf, sizeof(buf), c, &resp->nh, true);
+	printf(IP6_F " via %s\n", &req.dest, buf);
 	free(resp_ptr);
 
 	return CMD_SUCCESS;
@@ -184,6 +152,7 @@ static struct gr_cli_context ctx = {
 static void route_event_print(uint32_t event, const void *obj) {
 	const struct gr_ip6_route *r = obj;
 	const char *action;
+	char buf[128];
 
 	switch (event) {
 	case GR_EVENT_IP6_ROUTE_ADD:
@@ -197,28 +166,14 @@ static void route_event_print(uint32_t event, const void *obj) {
 		break;
 	}
 
-	printf("route6 %s: vrf=%u " IP6_F "/%hhu via",
+	buf[0] = '\0';
+	gr_cli_format_nexthop(buf, sizeof(buf), NULL, &r->nh, true);
+	printf("route6 %s: vrf=%u " IP6_F "/%hhu via %s\n",
 	       action,
 	       r->vrf_id,
 	       &r->dest.ip,
-	       r->dest.prefixlen);
-
-	printf(" type=%s", gr_nh_type_name(r->nh.type));
-
-	if (r->nh.nh_id != GR_NH_ID_UNSET)
-		printf(" id=%u", r->nh.nh_id);
-
-	printf(" vrf=%u af=%s", r->nh.vrf_id, gr_af_name(r->nh.af));
-
-	if (r->nh.af != GR_AF_UNSPEC)
-		printf(" " ADDR_F, ADDR_W(r->nh.af), &r->nh.addr);
-	else if (r->nh.iface_id != GR_IFACE_ID_UNDEF)
-		printf(" iface=%u", r->nh.iface_id);
-
-	if (r->origin != GR_NH_ORIGIN_UNSPEC)
-		printf(" origin=%s", gr_nh_origin_name(r->origin));
-
-	printf("\n");
+	       r->dest.prefixlen,
+	       buf);
 }
 
 static struct gr_cli_event_printer printer = {

--- a/modules/ip6/datapath/fib6.c
+++ b/modules/ip6/datapath/fib6.c
@@ -111,14 +111,8 @@ int fib6_insert(
 	struct rte_fib6 *fib;
 	int ret;
 
-	if (nh->ref_count == 0)
-		ABORT("nexthop has ref_count==0: vrf=%u iface=%u " IP6_F,
-		      nh->vrf_id,
-		      nh->iface_id,
-		      &nh->ipv6);
-
-	if (rte_lcore_has_role(rte_lcore_id(), ROLE_NON_EAL))
-		ABORT("fib6 modified from datapath thread");
+	assert(nh->ref_count > 0);
+	assert(!rte_lcore_has_role(rte_lcore_id(), ROLE_NON_EAL));
 
 	fib = get_or_create_fib6(vrf_id);
 	if (fib == NULL)
@@ -142,8 +136,7 @@ int fib6_remove(
 	struct rte_fib6 *fib;
 	int ret;
 
-	if (rte_lcore_has_role(rte_lcore_id(), ROLE_NON_EAL))
-		ABORT("fib6 modified from datapath thread");
+	assert(!rte_lcore_has_role(rte_lcore_id(), ROLE_NON_EAL));
 
 	fib = get_fib6(vrf_id);
 	if (fib == NULL)

--- a/modules/ip6/datapath/icmp6_input.c
+++ b/modules/ip6/datapath/icmp6_input.c
@@ -65,7 +65,7 @@ icmp6_input_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 					next = NO_LOCAL_ADDR;
 					goto next;
 				}
-				tmp_ip = local->ipv6;
+				tmp_ip = nexthop_info_l3(local)->ipv6;
 			} else {
 				// swap source/destination addresses
 				tmp_ip = d->dst;

--- a/modules/ip6/datapath/icmp6_local_send.c
+++ b/modules/ip6/datapath/icmp6_local_send.c
@@ -46,7 +46,7 @@ int icmp6_local_send(
 	const struct nexthop *local;
 	int ret;
 
-	if ((local = addr6_get_preferred(gw->iface_id, &gw->ipv6)) == NULL)
+	if ((local = addr6_get_preferred(gw->iface_id, &nexthop_info_l3(gw)->ipv6)) == NULL)
 		return -errno;
 
 	if ((msg = calloc(1, sizeof(struct ctl_to_stack))) == NULL)
@@ -56,7 +56,7 @@ int icmp6_local_send(
 	msg->ident = ident;
 	msg->hop_limit = hop_limit;
 	msg->dst = *dst;
-	msg->src = local->ipv6;
+	msg->src = nexthop_info_l3(local)->ipv6;
 
 	if ((ret = post_to_stack(ctl_icmp6_request, msg)) < 0) {
 		free(msg);

--- a/modules/ip6/datapath/ip6_error.c
+++ b/modules/ip6/datapath/ip6_error.c
@@ -24,12 +24,13 @@ static uint16_t
 ip6_error_process(struct rte_graph *graph, struct rte_node *node, void **objs, uint16_t nb_objs) {
 	struct icmp6_err_dest_unreach *du;
 	struct icmp6_err_ttl_exceeded *te;
+	const struct nexthop_info_l3 *l3;
 	struct ip6_local_mbuf_data *d;
 	const struct iface *iface;
+	const struct nexthop *nh;
 	struct rte_ipv6_hdr *ip;
 	icmp6_type_t icmp_type;
 	struct rte_mbuf *mbuf;
-	struct nexthop *nh;
 	struct icmp6 *icmp6;
 	rte_edge_t edge;
 
@@ -96,8 +97,9 @@ ip6_error_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 			edge = NO_IP;
 			goto next;
 		}
+		l3 = nexthop_info_l3(nh);
 		d = ip6_local_mbuf_data(mbuf);
-		d->src = nh->ipv6;
+		d->src = l3->ipv6;
 		d->dst = ip->src_addr;
 		d->len = rte_pktmbuf_pkt_len(mbuf);
 		d->iface = iface;

--- a/modules/ip6/datapath/ip6_output.c
+++ b/modules/ip6/datapath/ip6_output.c
@@ -50,6 +50,7 @@ void ip6_output_register_nexthop_type(gr_nh_type_t type, const char *next_node) 
 static uint16_t
 ip6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, uint16_t nb_objs) {
 	struct eth_output_mbuf_data *eth_data;
+	const struct nexthop_info_l3 *l3;
 	const struct iface *iface;
 	const struct nexthop *nh;
 	struct rte_ipv6_hdr *ip;
@@ -97,22 +98,22 @@ ip6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 		if (edge != ETH_OUTPUT)
 			goto next;
 
-		// clang-format off
+		l3 = nexthop_info_l3(nh);
+
 		if (!rte_ipv6_addr_is_mcast(&ip->dst_addr)
-		    && (nh->state != GR_NH_S_REACHABLE
-			|| (nh->flags & GR_NH_F_LINK
-			    && !rte_ipv6_addr_eq(&ip->dst_addr, &nh->ipv6)))) {
+		    && (l3->state != GR_NH_S_REACHABLE
+			|| (l3->flags & GR_NH_F_LINK
+			    && !rte_ipv6_addr_eq(&ip->dst_addr, &l3->ipv6)))) {
 			edge = HOLD;
 			goto next;
 		}
-		// clang-format on
 
 		// Prepare ethernet layer info.
 		eth_data = eth_output_mbuf_data(mbuf);
 		if (rte_ipv6_addr_is_mcast(&ip->dst_addr))
 			rte_ether_mcast_from_ipv6(&eth_data->dst, &ip->dst_addr);
 		else
-			eth_data->dst = nh->mac;
+			eth_data->dst = l3->mac;
 		eth_data->ether_type = RTE_BE16(RTE_ETHER_TYPE_IPV6);
 		sent++;
 next:

--- a/modules/policy/api/dnat44.c
+++ b/modules/policy/api/dnat44.c
@@ -9,49 +9,121 @@
 #include <gr_nat_datapath.h>
 #include <gr_vec.h>
 
-static bool dnat44_data_priv_equal(const struct nexthop *a, const struct nexthop *b) {
-	struct dnat44_nh_data *ad, *bd;
+static bool dnat44_nh_equal(const struct nexthop *a, const struct nexthop *b) {
+	struct nexthop_info_dnat *ad, *bd;
 
 	assert(a->type == GR_NH_T_DNAT);
 	assert(b->type == GR_NH_T_DNAT);
 
-	ad = dnat44_nh_data(a);
-	bd = dnat44_nh_data(b);
+	ad = nexthop_info_dnat(a);
+	bd = nexthop_info_dnat(b);
 
-	return ad->replace == bd->replace;
+	return ad->match == bd->match && ad->replace == bd->replace;
 }
 
-static int dnat44_data_priv_add(
-	struct nexthop *nh,
-	struct iface *iface,
-	ip4_addr_t match,
-	ip4_addr_t replace
-) {
-	struct dnat44_nh_data *data;
-
-	data = dnat44_nh_data(nh);
-	data->replace = replace;
-
-	return snat44_static_policy_add(iface, replace, match);
-}
-
-static void dnat44_data_priv_del(struct nexthop *nh) {
+static void dnat44_nh_free(struct nexthop *nh) {
+	struct nexthop_info_dnat *dnat = nexthop_info_dnat(nh);
 	struct iface *iface;
 
-	nh->type = GR_NH_T_L3;
+	nexthop_decref(dnat->arp);
 
 	iface = iface_from_id(nh->iface_id);
 	if (iface == NULL)
 		return;
 
-	snat44_static_policy_del(iface, nh->ipv4);
+	snat44_static_policy_del(iface, dnat->replace);
+}
+
+static int dnat44_nh_import_info(struct nexthop *nh, const void *info) {
+	struct nexthop_info_dnat *priv = nexthop_info_dnat(nh);
+	const struct gr_nexthop_info_dnat *pub = info;
+	struct nexthop *arp = NULL;
+	struct iface *iface;
+	int ret;
+
+	iface = iface_from_id(nh->iface_id);
+	if (iface == NULL)
+		return -errno;
+
+	if (priv->replace != 0 && priv->match != 0)
+		snat44_static_policy_del(iface, priv->replace);
+
+	ret = snat44_static_policy_add(iface, pub->replace, pub->match);
+	if (ret < 0)
+		return -errno;
+
+	// Add an internal L3 nexthop to respond to ARP requests.
+	arp = nexthop_new(
+		&(struct gr_nexthop_base) {
+			.type = GR_NH_T_L3,
+			.iface_id = iface->id,
+			.vrf_id = iface->vrf_id,
+			.origin = GR_NH_ORIGIN_INTERNAL,
+		},
+		&(struct gr_nexthop_info_l3) {
+			.af = GR_AF_IP4,
+			.flags = GR_NH_F_STATIC | GR_NH_F_LOCAL,
+			.ipv4 = pub->match,
+		}
+	);
+	if (arp == NULL) {
+		ret = -errno;
+		goto fail;
+	}
+
+	if (priv->match != 0)
+		rib4_delete(iface->vrf_id, priv->match, 32, GR_NH_T_DNAT);
+
+	ret = rib4_insert(iface->vrf_id, pub->match, 32, GR_NH_ORIGIN_INTERNAL, nh);
+	if (ret < 0)
+		goto fail;
+
+	priv->base = *pub;
+
+	if (priv->arp != NULL) {
+		nexthop_decref(priv->arp);
+		priv->arp = NULL;
+	}
+	priv->arp = arp;
+	nexthop_incref(arp);
+
+	return 0;
+fail:
+	snat44_static_policy_del(iface, pub->replace);
+	if (arp != NULL)
+		nexthop_decref(arp);
+	return errno_set(-ret);
+}
+
+static struct gr_nexthop *dnat44_nh_to_api(const struct nexthop *nh, size_t *len) {
+	const struct nexthop_info_dnat *dnat_priv = nexthop_info_dnat(nh);
+	struct gr_nexthop_info_dnat *dnat_pub;
+	struct gr_nexthop *pub;
+
+	pub = malloc(sizeof(*pub) + sizeof(*dnat_pub));
+	if (pub == NULL)
+		return errno_set_null(ENOMEM);
+
+	pub->base = nh->base;
+	dnat_pub = (struct gr_nexthop_info_dnat *)pub->info;
+	*dnat_pub = dnat_priv->base;
+
+	*len = sizeof(*pub) + sizeof(*dnat_pub);
+
+	return pub;
 }
 
 static struct api_out dnat44_add(const void *request, struct api_ctx *) {
 	const struct gr_dnat44_add_req *req = request;
 	struct iface *iface;
 	struct nexthop *nh;
-	int ret;
+	ip4_addr_t replace;
+
+	if (snat44_static_lookup_translation(req->policy.iface_id, req->policy.match, &replace)) {
+		if (req->exist_ok && replace == req->policy.replace)
+			return api_out(0, 0, NULL);
+		return api_out(EEXIST, 0, NULL);
+	}
 
 	iface = iface_from_id(req->policy.iface_id);
 	if (iface == NULL)
@@ -64,33 +136,21 @@ static struct api_out dnat44_add(const void *request, struct api_ctx *) {
 		return api_out(EADDRINUSE, 0, NULL);
 	}
 
-	nh = nexthop_new(&(struct gr_nexthop) {
-		.type = GR_NH_T_DNAT,
-		.af = GR_AF_IP4,
-		.flags = GR_NH_F_LOCAL | GR_NH_F_STATIC,
-		.state = GR_NH_S_REACHABLE,
-		.vrf_id = iface->vrf_id,
-		.iface_id = iface->id,
-		.ipv4 = req->policy.match,
-		.origin = GR_NH_ORIGIN_INTERNAL,
-	});
+	nh = nexthop_new(
+		&(struct gr_nexthop_base) {
+			.type = GR_NH_T_DNAT,
+			.iface_id = iface->id,
+			.origin = GR_NH_ORIGIN_INTERNAL,
+		},
+		&(struct gr_nexthop_info_dnat) {
+			.match = req->policy.match,
+			.replace = req->policy.replace,
+		}
+	);
 	if (nh == NULL)
-		return api_out(ENOMEM, 0, NULL);
+		return api_out(errno, 0, NULL);
 
-	ret = dnat44_data_priv_add(nh, iface, req->policy.match, req->policy.replace);
-	if (ret < 0) {
-		if (ret == -EEXIST && req->exist_ok)
-			ret = 0;
-
-		nexthop_decref(nh);
-		return api_out(-ret, 0, NULL);
-	}
-
-	ret = rib4_insert(iface->vrf_id, req->policy.match, 32, GR_NH_ORIGIN_INTERNAL, nh);
-	if (ret == -EEXIST && req->exist_ok)
-		ret = 0;
-
-	return api_out(-ret, 0, NULL);
+	return api_out(0, 0, NULL);
 }
 
 static struct api_out dnat44_del(const void *request, struct api_ctx *) {
@@ -116,20 +176,24 @@ struct dnat44_list_iterator {
 
 static void dnat44_list_iter(struct nexthop *nh, void *priv) {
 	struct dnat44_list_iterator *iter = priv;
-	struct dnat44_nh_data *data;
-
-	if (iter->vrf_id != GR_VRF_ID_ALL && nh->vrf_id != iter->vrf_id)
-		return;
+	const struct nexthop_info_dnat *dnat;
+	const struct iface *iface;
 
 	if (nh->type != GR_NH_T_DNAT)
 		return;
 
-	data = dnat44_nh_data(nh);
+	dnat = nexthop_info_dnat(nh);
+	iface = iface_from_id(nh->iface_id);
+	if (iface == NULL)
+		return;
+
+	if (iter->vrf_id != GR_VRF_ID_ALL && iface->vrf_id != iter->vrf_id)
+		return;
 
 	struct gr_dnat44_policy policy = {
 		.iface_id = nh->iface_id,
-		.match = nh->ipv4,
-		.replace = data->replace,
+		.match = dnat->match,
+		.replace = dnat->replace,
 	};
 	api_send(iter->ctx, sizeof(policy), &policy);
 }
@@ -163,8 +227,10 @@ static struct gr_api_handler list_handler = {
 };
 
 static struct nexthop_type_ops nh_ops = {
-	.equal = dnat44_data_priv_equal,
-	.free = dnat44_data_priv_del,
+	.equal = dnat44_nh_equal,
+	.free = dnat44_nh_free,
+	.import_info = dnat44_nh_import_info,
+	.to_api = dnat44_nh_to_api,
 };
 
 RTE_INIT(_init) {

--- a/modules/policy/api/gr_nat.h
+++ b/modules/policy/api/gr_nat.h
@@ -3,7 +3,10 @@
 
 #pragma once
 
+#include <gr_api.h>
+#include <gr_macro.h>
 #include <gr_net_types.h>
+#include <gr_nexthop.h>
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -11,6 +14,11 @@
 #define GR_NAT_MODULE 0x0bad
 
 // dnat44 //////////////////////////////////////////////////////////////////////
+
+struct gr_nexthop_info_dnat {
+	ip4_addr_t match;
+	ip4_addr_t replace;
+};
 
 struct gr_dnat44_policy {
 	uint16_t iface_id;

--- a/modules/policy/cli/dnat44.c
+++ b/modules/policy/cli/dnat44.c
@@ -6,6 +6,7 @@
 #include <gr_api.h>
 #include <gr_cli.h>
 #include <gr_cli_iface.h>
+#include <gr_cli_nexthop.h>
 #include <gr_nat.h>
 #include <gr_net_types.h>
 #include <gr_table.h>
@@ -87,6 +88,17 @@ static cmd_status_t dnat44_list(struct gr_api_client *c, const struct ec_pnode *
 	return ret < 0 ? CMD_ERROR : CMD_SUCCESS;
 }
 
+static ssize_t format_nexthop_info_dnat(char *buf, size_t len, const void *info) {
+	const struct gr_nexthop_info_dnat *dnat = info;
+	return snprintf(buf, len, "match=" IP4_F " replace=" IP4_F, &dnat->match, &dnat->replace);
+}
+
+static struct gr_cli_nexthop_formatter dnat_formatter = {
+	.name = "dnat",
+	.type = GR_NH_T_DNAT,
+	.format = format_nexthop_info_dnat,
+};
+
 static int ctx_init(struct ec_node *root) {
 	int ret;
 
@@ -131,4 +143,5 @@ static struct gr_cli_context ctx = {
 
 static void __attribute__((constructor, used)) init(void) {
 	register_context(&ctx);
+	gr_cli_nexthop_register_formatter(&dnat_formatter);
 }

--- a/modules/policy/datapath/dnat44_static.c
+++ b/modules/policy/datapath/dnat44_static.c
@@ -24,8 +24,9 @@ static uint16_t dnat44_static_process(
 	void **objs,
 	uint16_t nb_objs
 ) {
+	const struct nexthop_info_dnat *dnat;
+	const struct nexthop_info_l3 *l3;
 	struct ip_output_mbuf_data *d;
-	struct dnat44_nh_data *data;
 	struct rte_ipv4_hdr *ip;
 	struct rte_mbuf *mbuf;
 	uint16_t i, frag;
@@ -35,9 +36,9 @@ static uint16_t dnat44_static_process(
 		mbuf = objs[i];
 
 		d = ip_output_mbuf_data(mbuf);
-		data = dnat44_nh_data(d->nh);
+		dnat = nexthop_info_dnat(d->nh);
 		ip = rte_pktmbuf_mtod(mbuf, struct rte_ipv4_hdr *);
-		ip->hdr_checksum = fixup_checksum_32(ip->hdr_checksum, ip->dst_addr, data->replace);
+		ip->hdr_checksum = fixup_checksum_32(ip->hdr_checksum, ip->dst_addr, dnat->replace);
 
 		frag = rte_be_to_cpu_16(ip->fragment_offset) & RTE_IPV4_HDR_OFFSET_MASK;
 		if (frag == 0) {
@@ -48,7 +49,7 @@ static uint16_t dnat44_static_process(
 					mbuf, struct rte_tcp_hdr *, rte_ipv4_hdr_len(ip)
 				);
 				tcp->cksum = fixup_checksum_32(
-					tcp->cksum, ip->dst_addr, data->replace
+					tcp->cksum, ip->dst_addr, dnat->replace
 				);
 				break;
 			}
@@ -58,7 +59,7 @@ static uint16_t dnat44_static_process(
 				);
 				if (udp->dgram_cksum != RTE_BE16(0)) {
 					udp->dgram_cksum = fixup_checksum_32(
-						udp->dgram_cksum, ip->dst_addr, data->replace
+						udp->dgram_cksum, ip->dst_addr, dnat->replace
 					);
 					if (udp->dgram_cksum == RTE_BE16(0)) {
 						// Prevent UDP checksum from becoming 0 (RFC 768).
@@ -72,16 +73,21 @@ static uint16_t dnat44_static_process(
 
 		// Modify the address *after* updating the TCP/UDP checksum.
 		// We need the old address value to fixup the checksum properly.
-		ip->dst_addr = data->replace;
+		ip->dst_addr = dnat->replace;
 
 		d->nh = fib4_lookup(d->iface->vrf_id, ip->dst_addr);
 
 		if (d->nh == NULL)
 			edge = NO_ROUTE;
-		else if (d->nh->flags & GR_NH_F_LOCAL && ip->dst_addr == d->nh->ipv4)
-			edge = LOCAL;
-		else
+		else if (d->nh->type == GR_NH_T_L3) {
+			l3 = nexthop_info_l3(d->nh);
+			if (l3->flags & GR_NH_F_LOCAL && ip->dst_addr == l3->ipv4)
+				edge = LOCAL;
+			else
+				edge = FORWARD;
+		} else {
 			edge = FORWARD;
+		}
 
 		if (gr_mbuf_is_traced(mbuf)) {
 			struct rte_ipv4_hdr *t = gr_mbuf_trace_add(mbuf, node, sizeof(*t));

--- a/modules/policy/datapath/gr_nat_datapath.h
+++ b/modules/policy/datapath/gr_nat_datapath.h
@@ -4,12 +4,16 @@
 #pragma once
 
 #include <gr_iface.h>
+#include <gr_nat.h>
 #include <gr_net_types.h>
 #include <gr_nh_control.h>
 
 #include <rte_ip.h>
 
-GR_NH_PRIV_DATA_TYPE(dnat44_nh_data, { ip4_addr_t replace; });
+GR_NH_TYPE_INFO(GR_NH_T_DNAT, nexthop_info_dnat, {
+	BASE(gr_nexthop_info_dnat);
+	struct nexthop *arp;
+});
 
 static inline rte_be16_t
 fixup_checksum_16(rte_be16_t old_cksum, rte_be16_t old_field, rte_be16_t new_field) {

--- a/modules/srv6/api/gr_srv6.h
+++ b/modules/srv6/api/gr_srv6.h
@@ -116,37 +116,7 @@ typedef enum : uint8_t {
 } gr_srv6_flags_t;
 
 struct gr_nexthop_info_srv6_local {
-	struct rte_ipv6_addr lsid;
 	uint16_t out_vrf_id;
 	gr_srv6_behavior_t behavior;
 	gr_srv6_flags_t flags;
 };
-
-struct gr_srv6_localsid {
-	BASE(gr_nexthop_info_srv6_local);
-	uint16_t vrf_id;
-};
-
-#define GR_SRV6_LOCALSID_ADD REQUEST_TYPE(GR_SRV6_MODULE, 0x0021)
-
-struct gr_srv6_localsid_add_req {
-	struct gr_srv6_localsid l;
-	gr_nh_origin_t origin;
-	uint8_t exist_ok;
-};
-
-#define GR_SRV6_LOCALSID_DEL REQUEST_TYPE(GR_SRV6_MODULE, 0x0022)
-
-struct gr_srv6_localsid_del_req {
-	struct rte_ipv6_addr lsid;
-	uint16_t vrf_id;
-	uint8_t missing_ok;
-};
-
-#define GR_SRV6_LOCALSID_LIST REQUEST_TYPE(GR_SRV6_MODULE, 0x0023)
-
-struct gr_srv6_localsid_list_req {
-	uint16_t vrf_id;
-};
-
-// STREAM(struct gr_srv6_localsid);

--- a/modules/srv6/api/gr_srv6.h
+++ b/modules/srv6/api/gr_srv6.h
@@ -27,42 +27,7 @@ struct gr_nexthop_info_srv6 {
 	struct rte_ipv6_addr seglist[];
 };
 
-struct gr_srv6_route_key {
-	union {
-		struct ip4_net dest4;
-		struct ip6_net dest6;
-	};
-	bool is_dest6;
-	uint16_t vrf_id;
-};
-
-struct gr_srv6_route {
-	struct gr_srv6_route_key key;
-	struct gr_nexthop_info_srv6 nh;
-};
-
-#define GR_SRV6_ROUTE_ADD REQUEST_TYPE(GR_SRV6_MODULE, 0x0001)
-
-struct gr_srv6_route_add_req {
-	uint8_t exist_ok;
-	gr_nh_origin_t origin;
-	struct gr_srv6_route r;
-};
-
-#define GR_SRV6_ROUTE_DEL REQUEST_TYPE(GR_SRV6_MODULE, 0x0002)
-
-struct gr_srv6_route_del_req {
-	struct gr_srv6_route_key key;
-	uint8_t missing_ok;
-};
-
-#define GR_SRV6_ROUTE_LIST REQUEST_TYPE(GR_SRV6_MODULE, 0x0004)
-
-struct gr_srv6_route_list_req {
-	uint16_t vrf_id;
-};
-
-// STREAM(struct gr_srv6_route);
+// sr tun src //////////////////////////////////////////////////////
 
 #define GR_SRV6_TUNSRC_SET REQUEST_TYPE(GR_SRV6_MODULE, 0x0005)
 struct gr_srv6_tunsrc_set_req {

--- a/modules/srv6/control/gr_srv6_nexthop.h
+++ b/modules/srv6/control/gr_srv6_nexthop.h
@@ -3,29 +3,24 @@
 
 #pragma once
 
+#include <gr_ip6_control.h>
 #include <gr_nh_control.h>
 #include <gr_srv6.h>
 
 //
 // srv6 local data stored in nexthop priv
 //
-GR_NH_PRIV_DATA_TYPE(srv6_localsid_nh_priv, {
-	gr_srv6_behavior_t behavior;
-	uint16_t out_vrf_id;
-	uint8_t flags;
-});
-
-struct srv6_encap_data {
-	gr_srv6_encap_behavior_t encap;
-	uint16_t n_seglist;
-	struct rte_ipv6_addr seglist[];
-};
+GR_NH_TYPE_INFO(GR_NH_T_SR6_LOCAL, nexthop_info_srv6_local, { BASE(gr_nexthop_info_srv6_local); });
 
 //
 // srv6 encap data is allocated dynamically.
 // A pointer to it is stored in nexthop priv.
 //
-GR_NH_PRIV_DATA_TYPE(srv6_encap_nh_priv, { struct srv6_encap_data *d; });
+GR_NH_TYPE_INFO(GR_NH_T_SR6_OUTPUT, nexthop_info_srv6_output, {
+	gr_srv6_encap_behavior_t encap;
+	uint16_t n_seglist;
+	struct rte_ipv6_addr *seglist;
+});
 
 extern struct nexthop *tunsrc_nh;
 static inline const struct nexthop *

--- a/modules/srv6/control/localsid.c
+++ b/modules/srv6/control/localsid.c
@@ -9,7 +9,6 @@
 #include <gr_srv6.h>
 #include <gr_srv6_nexthop.h>
 
-// localsid /////////////////////////////////////////////////////////////
 static bool srv6_local_nh_equal(const struct nexthop *a, const struct nexthop *b) {
 	struct nexthop_info_srv6_local *ad, *bd;
 
@@ -20,14 +19,14 @@ static bool srv6_local_nh_equal(const struct nexthop *a, const struct nexthop *b
 	bd = nexthop_info_srv6_local(b);
 
 	return ad->behavior == bd->behavior && ad->out_vrf_id == bd->out_vrf_id
-		&& ad->flags == bd->flags && rte_ipv6_addr_eq(&ad->lsid, &bd->lsid);
+		&& ad->flags == bd->flags;
 }
 
 static int srv6_local_nh_import_info(struct nexthop *nh, const void *info) {
 	struct nexthop_info_srv6_local *priv = nexthop_info_srv6_local(nh);
-	const struct gr_srv6_localsid *pub = info;
+	const struct gr_nexthop_info_srv6_local *pub = info;
 
-	priv->base = pub->base;
+	priv->base = *pub;
 
 	return 0;
 }
@@ -50,92 +49,6 @@ static struct gr_nexthop *srv6_local_nh_to_api(const struct nexthop *nh, size_t 
 	return pub;
 }
 
-static struct api_out srv6_localsid_add(const void *request, struct api_ctx *) {
-	const struct gr_srv6_localsid_add_req *req = request;
-	struct nexthop *nh;
-	int r;
-
-	nh = nexthop_new(
-		&(struct gr_nexthop_base) {
-			.type = GR_NH_T_SR6_LOCAL,
-			.vrf_id = req->l.vrf_id,
-			.iface_id = GR_IFACE_ID_UNDEF,
-			.origin = req->origin,
-		},
-		&req->l
-	);
-	if (nh == NULL)
-		return api_out(errno, 0, NULL);
-
-	r = rib6_insert(req->l.vrf_id, GR_IFACE_ID_UNDEF, &req->l.lsid, 128, req->origin, nh);
-	if (r == -EEXIST && req->exist_ok)
-		r = 0;
-
-	return api_out(-r, 0, NULL);
-}
-
-static struct api_out srv6_localsid_del(const void *request, struct api_ctx *) {
-	const struct gr_srv6_localsid_del_req *req = request;
-	int ret;
-
-	ret = rib6_delete(req->vrf_id, GR_IFACE_ID_UNDEF, &req->lsid, 128, GR_NH_T_SR6_LOCAL);
-	if (ret == -ENOENT && req->missing_ok)
-		ret = 0;
-
-	return api_out(-ret, 0, NULL);
-}
-
-struct list_context {
-	uint16_t vrf_id;
-	struct api_ctx *ctx;
-};
-
-static void nh_srv6_list_cb(struct nexthop *nh, void *priv) {
-	const struct nexthop_info_srv6_local *local;
-	struct list_context *ctx = priv;
-
-	if ((nh->type != GR_NH_T_SR6_LOCAL)
-	    || (nh->vrf_id != ctx->vrf_id && ctx->vrf_id != GR_VRF_ID_ALL))
-		return;
-
-	local = nexthop_info_srv6_local(nh);
-	struct gr_srv6_localsid ldata = {
-		.behavior = local->behavior,
-		.flags = local->flags,
-		.lsid = local->lsid,
-		.out_vrf_id = local->out_vrf_id,
-		.vrf_id = nh->vrf_id,
-	};
-
-	api_send(ctx->ctx, sizeof(ldata), &ldata);
-}
-
-static struct api_out srv6_localsid_list(const void *request, struct api_ctx *ctx) {
-	const struct gr_srv6_localsid_list_req *req = request;
-	struct list_context list_ctx = {.vrf_id = req->vrf_id, .ctx = ctx};
-
-	nexthop_iter(nh_srv6_list_cb, &list_ctx);
-
-	return api_out(0, 0, NULL);
-}
-
-// srv6 localsid module //////////////////////////////////////////////////////
-static struct gr_api_handler srv6_localsid_add_handler = {
-	.name = "sr localsid add",
-	.request_type = GR_SRV6_LOCALSID_ADD,
-	.callback = srv6_localsid_add,
-};
-static struct gr_api_handler srv6_localsid_del_handler = {
-	.name = "sr localsid del",
-	.request_type = GR_SRV6_LOCALSID_DEL,
-	.callback = srv6_localsid_del,
-};
-static struct gr_api_handler srv6_localsid_list_handler = {
-	.name = "sr localsid list",
-	.request_type = GR_SRV6_LOCALSID_LIST,
-	.callback = srv6_localsid_list,
-};
-
 static struct nexthop_type_ops nh_ops = {
 	.equal = srv6_local_nh_equal,
 	.import_info = srv6_local_nh_import_info,
@@ -143,8 +56,5 @@ static struct nexthop_type_ops nh_ops = {
 };
 
 RTE_INIT(srv6_constructor) {
-	gr_register_api_handler(&srv6_localsid_add_handler);
-	gr_register_api_handler(&srv6_localsid_del_handler);
-	gr_register_api_handler(&srv6_localsid_list_handler);
 	nexthop_type_ops_register(GR_NH_T_SR6_LOCAL, &nh_ops);
 }

--- a/modules/srv6/control/route.c
+++ b/modules/srv6/control/route.c
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2025 Olivier Gournet
 
-#include <gr_infra.h>
-#include <gr_ip4_control.h>
-#include <gr_ip6_control.h>
 #include <gr_log.h>
 #include <gr_module.h>
 #include <gr_rcu.h>
@@ -80,166 +77,6 @@ static void srv6_output_nh_del(struct nexthop *nh) {
 	sr6->seglist = NULL;
 }
 
-// srv6 route ////////////////////////////////////////////////////////////////
-static struct api_out srv6_route_add(const void *request, struct api_ctx *) {
-	const struct gr_srv6_route_add_req *req = request;
-	struct nexthop *nh;
-	int ret;
-
-	nh = nexthop_new(
-		&(struct gr_nexthop_base) {
-			.type = GR_NH_T_SR6_OUTPUT,
-			.vrf_id = req->r.key.vrf_id,
-			.origin = req->origin,
-		},
-		&req->r.nh
-	);
-	if (nh == NULL)
-		return api_out(errno, 0, NULL);
-
-	if (req->r.key.is_dest6)
-		ret = rib6_insert(
-			req->r.key.vrf_id,
-			GR_IFACE_ID_UNDEF,
-			&req->r.key.dest6.ip,
-			req->r.key.dest6.prefixlen,
-			req->origin,
-			nh
-		);
-	else
-		ret = rib4_insert(
-			req->r.key.vrf_id,
-			req->r.key.dest4.ip,
-			req->r.key.dest4.prefixlen,
-			req->origin,
-			nh
-		);
-
-	if (ret == -EEXIST && req->exist_ok)
-		ret = 0;
-
-	return api_out(-ret, 0, NULL);
-}
-
-static struct api_out srv6_route_del(const void *request, struct api_ctx *) {
-	const struct gr_srv6_route_del_req *req = request;
-	int ret;
-
-	if (req->key.is_dest6)
-		ret = rib6_delete(
-			req->key.vrf_id,
-			GR_IFACE_ID_UNDEF,
-			&req->key.dest6.ip,
-			req->key.dest6.prefixlen,
-			GR_NH_T_SR6_OUTPUT
-		);
-
-	else
-		ret = rib4_delete(
-			req->key.vrf_id,
-			req->key.dest4.ip,
-			req->key.dest4.prefixlen,
-			GR_NH_T_SR6_OUTPUT
-		);
-
-	if (ret == -ENOENT && req->missing_ok)
-		ret = 0;
-
-	return api_out(-ret, 0, NULL);
-}
-
-struct list_context {
-	uint16_t vrf_id;
-	int ret;
-	struct api_ctx *ctx;
-};
-
-static void route4_list_cb(
-	uint16_t vrf_id,
-	ip4_addr_t ip,
-	uint8_t prefixlen,
-	gr_nh_origin_t,
-	const struct nexthop *nh,
-	void *priv
-) {
-	struct nexthop_info_srv6_output *sr6;
-	struct list_context *ctx = priv;
-	struct gr_srv6_route *r;
-	size_t len;
-
-	if (ctx->ret != 0 || nh->type != GR_NH_T_SR6_OUTPUT)
-		return;
-
-	sr6 = nexthop_info_srv6_output(nh);
-
-	len = sizeof(*r) + sr6->n_seglist * sizeof(r->nh.seglist[0]);
-	r = malloc(len);
-	if (r == NULL) {
-		LOG(ERR, "cannot allocate memory");
-		ctx->ret = ENOMEM;
-		return;
-	}
-
-	r->key.is_dest6 = false;
-	r->key.vrf_id = vrf_id;
-	r->key.dest4.ip = ip;
-	r->key.dest4.prefixlen = prefixlen;
-	r->nh.encap_behavior = sr6->encap;
-	r->nh.n_seglist = sr6->n_seglist;
-	memcpy(r->nh.seglist, sr6->seglist, sr6->n_seglist * sizeof(r->nh.seglist[0]));
-
-	api_send(ctx->ctx, len, r);
-	free(r);
-}
-
-static void route6_list_cb(
-	uint16_t vrf_id,
-	const struct rte_ipv6_addr *ip,
-	uint8_t prefixlen,
-	gr_nh_origin_t,
-	const struct nexthop *nh,
-	void *priv
-) {
-	struct nexthop_info_srv6_output *sr6;
-	struct list_context *ctx = priv;
-	struct gr_srv6_route *r;
-	size_t len;
-
-	if (ctx->ret != 0 || nh->type != GR_NH_T_SR6_OUTPUT)
-		return;
-
-	sr6 = nexthop_info_srv6_output(nh);
-
-	len = sizeof(*r) + sr6->n_seglist * sizeof(r->nh.seglist[0]);
-	r = malloc(len);
-	if (r == NULL) {
-		LOG(ERR, "cannot allocate memory");
-		ctx->ret = ENOMEM;
-		return;
-	}
-
-	r->key.is_dest6 = true;
-	r->key.vrf_id = vrf_id;
-	r->key.dest6.ip = *ip;
-	r->key.dest6.prefixlen = prefixlen;
-	r->nh.encap_behavior = sr6->encap;
-	r->nh.n_seglist = sr6->n_seglist;
-	memcpy(r->nh.seglist, sr6->seglist, sr6->n_seglist * sizeof(r->nh.seglist[0]));
-
-	api_send(ctx->ctx, len, r);
-	free(r);
-}
-
-static struct api_out srv6_route_list(const void *request, struct api_ctx *ctx) {
-	const struct gr_srv6_route_list_req *req = request;
-	struct list_context list_ctx = {.vrf_id = req->vrf_id, .ctx = ctx, .ret = 0};
-
-	rib4_iter(req->vrf_id, route4_list_cb, &list_ctx);
-	rib6_iter(req->vrf_id, route6_list_cb, &list_ctx);
-
-	return api_out(list_ctx.ret, 0, NULL);
-}
-
 struct nexthop *tunsrc_nh = NULL;
 
 static struct api_out srv6_tunsrc_clear(const void * /*request*/, struct api_ctx *) {
@@ -302,21 +139,6 @@ static struct api_out srv6_tunsrc_show(const void * /*request*/, struct api_ctx 
 
 // srv6 headend module /////////////////////////////////////////////////////
 
-static struct gr_api_handler srv6_route_add_handler = {
-	.name = "sr route add",
-	.request_type = GR_SRV6_ROUTE_ADD,
-	.callback = srv6_route_add,
-};
-static struct gr_api_handler srv6_route_del_handler = {
-	.name = "sr route del",
-	.request_type = GR_SRV6_ROUTE_DEL,
-	.callback = srv6_route_del,
-};
-static struct gr_api_handler srv6_route_list_handler = {
-	.name = "sr route list",
-	.request_type = GR_SRV6_ROUTE_LIST,
-	.callback = srv6_route_list,
-};
 static struct gr_api_handler srv6_tunsrc_set_handler = {
 	.name = "sr tunsrc set",
 	.request_type = GR_SRV6_TUNSRC_SET,
@@ -341,9 +163,6 @@ static struct nexthop_type_ops nh_ops = {
 };
 
 RTE_INIT(srv6_constructor) {
-	gr_register_api_handler(&srv6_route_add_handler);
-	gr_register_api_handler(&srv6_route_del_handler);
-	gr_register_api_handler(&srv6_route_list_handler);
 	gr_register_api_handler(&srv6_tunsrc_set_handler);
 	gr_register_api_handler(&srv6_tunsrc_clear_handler);
 	gr_register_api_handler(&srv6_tunsrc_show_handler);

--- a/modules/srv6/datapath/srv6_local.c
+++ b/modules/srv6/datapath/srv6_local.c
@@ -229,7 +229,7 @@ static int process_upper_layer(struct rte_mbuf *m, struct ip6_info *ip6_info) {
 //
 static int process_behav_decap(
 	struct rte_mbuf *m,
-	struct srv6_localsid_nh_priv *sr_d,
+	struct nexthop_info_srv6_local *sr_d,
 	struct ip6_info *ip6_info
 ) {
 	struct rte_ipv6_routing_ext *sr = ip6_info->sr;
@@ -279,7 +279,7 @@ static int process_behav_decap(
 //
 static int process_behav_end(
 	struct rte_mbuf *m,
-	struct srv6_localsid_nh_priv *sr_d,
+	struct nexthop_info_srv6_local *sr_d,
 	struct ip6_info *ip6_info
 ) {
 	struct rte_ipv6_routing_ext *sr = ip6_info->sr;
@@ -321,7 +321,7 @@ static int process_behav_end(
 
 static inline rte_edge_t srv6_local_process_pkt(
 	struct rte_mbuf *m,
-	struct srv6_localsid_nh_priv *sr_d,
+	struct nexthop_info_srv6_local *sr_d,
 	struct ip6_info *ip6_info
 ) {
 	switch (sr_d->behavior) {
@@ -342,7 +342,7 @@ static inline rte_edge_t srv6_local_process_pkt(
 // called from 'ip6_input' node
 static uint16_t
 srv6_local_process(struct rte_graph *graph, struct rte_node *node, void **objs, uint16_t nb_objs) {
-	struct srv6_localsid_nh_priv *sr_d;
+	struct nexthop_info_srv6_local *sr_d;
 	struct trace_srv6_data *t;
 	struct ip6_info ip6_info;
 	struct rte_mbuf *m;
@@ -357,8 +357,7 @@ srv6_local_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 			goto next;
 		}
 
-		sr_d = srv6_localsid_nh_priv(ip6_output_mbuf_data(m)->nh);
-		assert(sr_d != NULL);
+		sr_d = nexthop_info_srv6_local(ip6_output_mbuf_data(m)->nh);
 
 		if (gr_mbuf_is_traced(m)) {
 			t = gr_mbuf_trace_add(m, node, sizeof(*t));

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -168,14 +168,12 @@ set_srv6_localsid() {
 EOF
 
 	# --- wait until grout has the localsid ---------------------------------
-	# Expected "grcli show sr localsid" output pattern:
-	# vrf lsid                         behavior  args
-	# 0   fc00:100:64:10::666          end.dt4   out_vrf=0
-	local grep_pattern="^[[:space:]]*0[[:space:]]+${sid_local}[[:space:]]+${grout_behavior}"
-
-	while ! grcli show sr localsid | grep -qE "${grep_pattern}"; do
+	# Expected "grcli show ip6 route" output pattern:
+	# VRF  DESTINATION        NEXT_HOP
+	# 0    fd00:202::100/128  type=SRv6-local id=12 iface=gr-loop0 vrf=0 origin=zebra behavior=end.dt4 out_vrf=0
+	local grep_pattern="\\<${sid_local}/128[[:space:]]+type=SRv6-local\\>.*\\<behavior=${grout_behavior}\\>"
+	while ! grcli show ip6 route | grep -qE "${grep_pattern}"; do
 		if [ "$count" -ge "$max_tries" ]; then
-			grcli show sr localsid
 			echo "SRv6 localsid ${sid_local} (${grout_behavior}) not found after ${max_tries} attempts."
 			exit 1
 		fi

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -110,7 +110,7 @@ set_ip_route() {
 		local gr_ip="ip"
 	fi
 
-	local grep_pattern="^${vrf_id}[[:space:]]\+${prefix}[[:space:]]\+${next_hop}[[:space:]]"
+	local grep_pattern="^${vrf_id}[[:space:]]\\+${prefix}\\>.*\\<${next_hop}\\>"
 
 	vtysh <<-EOF
 	configure terminal

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -224,14 +224,18 @@ set_srv6_route() {
 EOF
 
     # ----- make BRE pattern for Grout -------------------------------------
+    # Expected output from grcli show ip route
+    #
+    # VRF  DESTINATION      NEXT_HOP
+    # 0    192.168.0.0/16   type=SRv6 id=8 iface=geydsm1 vrf=0 origin=zebra h.encap fd00:202::2
     local sid_regex="${sids[0]}"
     for ((i=1; i<${#sids[@]}; i++)); do
-	    sid_regex+="[[:space:]]\\+${sids[i]}"
+	    sid_regex+="[[:space:]]+${sids[i]}"
     done
-    local grep_pattern="^[[:space:]]*0[[:space:]]\\+${prefix}[[:space:]]\\+h\\.encap[[:space:]]\\+${sid_regex}"
+    local grep_pattern="\\<${prefix}[[:space:]]+type=SRv6\\>.*${sid_regex}"
 
     # ----- wait until Grout shows it --------------------------------------
-    while ! grcli show sr route | grep -q "${grep_pattern}"; do
+    while ! grcli show $gr_ip route | grep -qE "${grep_pattern}"; do
 	    if (( count++ >= max_tries )); then
 		    echo "SRv6 route ${prefix} via ${seg_space} not visible in Grout after ${max_tries}s." >&2
 		    exit 1

--- a/smoke/config_test.sh
+++ b/smoke/config_test.sh
@@ -6,14 +6,16 @@
 
 grcli add interface port p0 devargs net_null0,no-rx=1
 grcli add interface port p1 devargs net_null1,no-rx=1
-grcli add nexthop id 42 address 1.2.3.4 iface p0
-grcli add nexthop id 45 iface p0
-grcli add nexthop id 47 address 1.2.3.7 iface p0
-grcli add nexthop id 1042 address f00:ba4::1 iface p1
-grcli add nexthop id 1047 address f00:ba4::100 iface p1
-grcli add nexthop id 42 address f00:ba4::666 iface p1 # replace existing nexthop
-grcli add nexthop address ba4:f00::1 iface p0 mac ba:d0:ca:ca:00:02
-grcli add nexthop address 4.3.2.1 iface p1 mac ba:d0:ca:ca:00:01
+grcli add nexthop l3 iface p0 id 42 address 1.2.3.4
+grcli add nexthop l3 iface p0 id 45
+grcli add nexthop l3 iface p0 id 47 address 1.2.3.7
+grcli add nexthop l3 iface p1 id 1042 address f00:ba4::1
+grcli add nexthop l3 iface p1 id 1047 address f00:ba4::100
+grcli add nexthop l3 iface p1 id 42 address f00:ba4::666 # replace existing nexthop
+grcli add nexthop l3 iface p0 address ba4:f00::1 mac ba:d0:ca:ca:00:02
+grcli add nexthop l3 iface p1 address 4.3.2.1 mac ba:d0:ca:ca:00:01
+grcli add nexthop blackhole id 666
+grcli add nexthop reject id 123456
 grcli add ip address 10.0.0.1/24 iface p0
 grcli add ip address 10.1.0.1/24 iface p1
 grcli add ip route 0.0.0.0/0 via 10.0.0.2
@@ -37,6 +39,8 @@ grcli show graph full
 grcli show stats software
 grcli show stats hardware
 grcli del nexthop 42
+grcli del nexthop 666
+grcli del nexthop 123456
 
 grcli del interface p0
 grcli del interface p1

--- a/smoke/cross_vrf_forward_test.sh
+++ b/smoke/cross_vrf_forward_test.sh
@@ -13,12 +13,12 @@ grcli add ip address 172.16.0.1/24 iface $p0
 grcli add ip address 172.16.1.1/24 iface $p1
 
 # from 16.0.0.1 to 16.1.0.1, only one route lookup is done
-grcli add nexthop id 2 address 172.16.1.2 iface $p1
+grcli add nexthop l3 iface $p1 id 2 address 172.16.1.2
 grcli add ip route 16.1.0.0/16 via id 2 vrf 1
 grcli add ip route 16.1.0.0/16 via id 2 vrf 2 # required for ARP resolution
 
 # from 16.1.0.1 to 16.0.0.1, two route lookup are done
-grcli add nexthop id 1 iface gr-loop1
+grcli add nexthop l3 iface gr-loop1 id 1
 grcli add ip route 16.0.0.0/16 via id 1 vrf 2
 grcli add ip route 16.0.0.0/16 via 172.16.0.2 vrf 1
 

--- a/smoke/ip6_forward_test.sh
+++ b/smoke/ip6_forward_test.sh
@@ -12,7 +12,7 @@ grcli add interface port $p2 devargs net_tap1,iface=$p2 mac d2:f0:0c:ba:a4:12
 grcli add ip6 address fd00:ba4:1::1/64 iface $p1
 grcli add ip6 address fd00:ba4:2::1/64 iface $p2
 grcli add ip6 route fd00:f00:1::/64 via fd00:ba4:1::2
-grcli add nexthop id 45 iface $p2
+grcli add nexthop l3 iface $p2 id 45
 grcli add ip6 route fd00:f00:2::/64 via id 45
 
 for n in 1 2; do

--- a/smoke/ip_forward_test.sh
+++ b/smoke/ip_forward_test.sh
@@ -12,7 +12,7 @@ grcli add interface port $p1 devargs net_tap1,iface=$p1 mac f0:0d:ac:dc:00:01
 grcli add ip address 172.16.0.1/24 iface $p0
 grcli add ip address 172.16.1.1/24 iface $p1
 grcli add ip route 16.0.0.0/16 via 172.16.0.2
-grcli add nexthop id 45 iface $p1
+grcli add nexthop l3 iface $p1 id 45
 grcli add ip route 16.1.0.0/16 via id 45
 
 for n in 0 1; do

--- a/smoke/nexthop_ageing_test.sh
+++ b/smoke/nexthop_ageing_test.sh
@@ -9,7 +9,7 @@ check_nexthop() {
 	local expect_reacheable="$2"
 	local timeout=5
 	for i in $(seq 1 $timeout); do
-		grcli show nexthop all | grep -qE "$ip.+reachable";
+		grcli show nexthop internal | grep -qE "$ip.+reachable";
 		local result=$?
 
 		if [ "$expect_reacheable" = "true" ] && [ "$result" -eq 0 ]; then

--- a/smoke/srv6_test.sh
+++ b/smoke/srv6_test.sh
@@ -48,7 +48,8 @@ ip netns exec $p1 sysctl -w net.ipv6.conf.$p1.forwarding=1
 ip -n $p0 route add default via 192.168.61.1 dev $p0
 
 # (2)
-grcli add sr route 192.168.0.0/16 seglist fd00:202::2
+grcli add nexthop srv6 seglist fd00:202::2 id 42
+grcli add ip route 192.168.0.0/16 via id 42
 grcli add ip6 route fd00:202::/64 via fd00:102::2
 
 # (3)

--- a/smoke/srv6_test.sh
+++ b/smoke/srv6_test.sh
@@ -62,7 +62,8 @@ ip -n $p1 route add 192.168.61.0/24 encap seg6 mode encap segs fd00:202::100 dev
 ip -n $p1 -6 route add fd00:202::/64 via fd00:102::1 dev $p1
 
 # (6)
-grcli add sr localsid fd00:202::100 behavior end.dt4
+grcli add nexthop srv6-local behavior end.dt4 id 666
+grcli add ip6 route fd00:202::100/128 via id 666
 
 # test
 ip netns exec $p0 ping -c 3 192.168.60.1


### PR DESCRIPTION
Restructure both the public API and internal control plane nexthop representations by separating base attributes from type-specific information. Replace the monolithic structure approach with a flexible info-based design that uses variable-length allocation.

Split the public `gr_nexthop` structure into a base `gr_nexthop_base` containing common attributes (ID, interface, VRF, type, origin) and type-specific info structures accessed through a flexible info field. For L3 nexthops, introduce `gr_nexthop_info_l3` that contains address family, IP addresses, prefix length, state, flags, and MAC addresses that were previously part of the main structure.

Restructure the internal control plane nexthop representation to mirror this approach. Replace direct inheritance from `gr_nexthop` with inheritance from `gr_nexthop_base` and add a fixed-size info field. Implement the `GR_NH_TYPE_INFO` macro system to provide type-safe
accessors for different nexthop types. Move L3-specific data including ARP/ND state, held packets, and probe counters into the dedicated `nexthop_info_l3` structure.

Implement type operations callbacks for import/export, equality checking, and API conversion. Each nexthop type can now define its own behavior for serialization, comparison, and lifecycle management. Add `nexthop_to_api()` function that properly exports internal nexthop state to appropriately-sized public representations.

Update all nexthop consumers to access type-specific data through the info field rather than direct structure access. Modify the FRR integration layer to cast and access L3 info structures for address synchronization. Update IP, IPv6, SRv6, and policy modules to use the
new accessor patterns. Change CLI formatters to accept info pointers rather than full nexthop structures.

Restructure API request handling to use variable-length allocation based  on nexthop type. Update nexthop creation, lookup, and update functions to work with separate base and info parameters. Modify the list operation to use proper API export rather than exposing internal
structure layout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added L3 nexthop type, SRv6 nexthop variants (srv6-local, srv6-output), DNAT nexthop info, per-type nexthop API/export hooks and streaming serialization.

- **CLI**
  - New nexthop add flows (l3, srv6, srv6-local, dnat); route commands reference nexthop IDs; NEXT_HOP/INFO rendered via pluggable formatters.

- **Refactor**
  - Unified nexthop model across IP, SRv6, and policy; moved to base+info nexthop creation and centralized nexthop lifecycle.

- **Documentation**
  - README and CLI outputs updated with richer columns (VRF/TYPE/INFO/MODE/DOMAIN).

- **Tests**
  - Smoke tests updated to new nexthop syntax and outputs.

- **Chores**
  - Spellcheck config updated to ignore "ND".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->