### PR TITLE
cli: fix broken context initialization

### DIFF
--- a/cli/ecoli.c
+++ b/cli/ecoli.c
@@ -42,10 +42,15 @@ static struct ec_node *get_or_create(struct ec_node *root, const char *name, con
 		goto fail;
 	}
 
-	// if context is already present, return the OR node directly
-	or_node = ec_node_find(root, name);
-	if (or_node != NULL)
-		return or_node;
+	for (unsigned i = 0; i < ec_node_get_children_count(root); i++) {
+		unsigned refs;
+		ec_node_get_child(root, i, &or_node, &refs);
+		if (strcmp(ec_node_id(or_node), name) == 0
+		    && strcmp(ec_node_type(or_node)->name, "or") == 0) {
+			// if context is already present, return the OR node directly
+			return or_node;
+		}
+	}
 
 	// else, create the context node
 	if ((or_node = ec_node("or", name)) == NULL)


### PR DESCRIPTION
Depending on the order in which files are linked in the final binary, the interface context (`modules/infra/cli/iface.c`) may be loaded before the stats context (`modules/infra/cli/stats.c`). When the stats context loads, there happens to be an existing "stats" node present in the command tree:

    show interface stats
                   ^^^^^

This causes the code in `get_or_create` to skip the creation of the stats context node and use this constant `str` node in its place. Then, when trying to append stats commands under this `str` node, we get an `EINVAL` error from libecoli since the base node is not an `or` node.

Replace `ec_node_find()` which searches recursively for *any* node that has the provided ID. Only consider direct children of the root node and ensure they are of type `or`.

Fixes: af3ef1185218 ("cli: rework command registration")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of existing context entries to prevent accidental duplicates.
  * Ensures correct type matching when checking for existing items, reducing unexpected behavior.
  * Increases reliability of context creation and lookup in the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->