### PR TITLE
cli: open commands file read-only

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -82,7 +82,7 @@ static int parse_args(int argc, char **argv) {
 			opts.err_exit = true;
 			break;
 		case 'f':
-			opts.cmds_file = fopen(optarg, "r+");
+			opts.cmds_file = fopen(optarg, "r");
 			if (opts.cmds_file == NULL) {
 				errorf("--file %s: %s", optarg, strerror(errno));
 				return -errno;


### PR DESCRIPTION
When the file is located in a read-only file system, it cannot be read. We don't need to write on this file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The -f option now opens command files in read-only mode, preventing unintended modifications to input files.
  - Error handling and overall command flow remain unchanged; only write attempts to the specified file will now fail.
  - Improves safety without altering command syntax or typical usage; workflows relying on writing to the same file during execution may need adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->