### PR TITLE
cli: fix broken context initialization for real

### DIFF
--- a/cli/ecoli.c
+++ b/cli/ecoli.c
@@ -43,10 +43,19 @@ static struct ec_node *get_or_create(struct ec_node *root, const char *name, con
 	}
 
 	for (unsigned i = 0; i < ec_node_get_children_count(root); i++) {
+		struct ec_node *seq_node;
 		unsigned refs;
-		ec_node_get_child(root, i, &or_node, &refs);
-		if (strcmp(ec_node_id(or_node), name) == 0
-		    && strcmp(ec_node_type(or_node)->name, "or") == 0) {
+		if (ec_node_get_child(root, i, &seq_node, &refs) < 0)
+			continue;
+		if (strcmp(ec_node_type(seq_node)->name, "seq") != 0)
+			continue;
+		if (ec_node_get_children_count(seq_node) != 2)
+			continue;
+		if (ec_node_get_child(seq_node, 1, &or_node, &refs) < 0)
+			continue;
+		if (strcmp(ec_node_type(or_node)->name, "or") != 0)
+			continue;
+		if (strcmp(ec_node_id(or_node), name) == 0) {
 			// if context is already present, return the OR node directly
 			return or_node;
 		}


### PR DESCRIPTION
While the previous commit indeed fixed the incorrect call to `ec_node_or_add()`, it did introduce another stupid mistake. The "or" node that we are looking for is not a direct descendant of the root context. Instead, each branch of the root is made of a "seq" node that starts with a "str" node without any ID followed by the "or" node that we are looking for. This causes context nodes to be duplicated and breaks
completion:

    grout# ad<tab>
    add                  Create objects in the configuration.
    add                  Create objects in the configuration.
    add                  Create objects in the configuration.
    add                  Create objects in the configuration.
    add                  Create objects in the configuration.
    add                  Create objects in the configuration.
    add                  Create objects in the configuration.
    add                  Create objects in the configuration.
    add                  Create objects in the configuration.
    add                  Create objects in the configuration.
    add                  Create objects in the configuration.
    add                  Create objects in the configuration.
    add                  Create objects in the configuration.
    grout# add <tab>
    nexthop              Create a new nexthop.
    nexthop              Create a new nexthop.
    interface            Create interfaces.
    interface            Create interfaces.
    ip                   Create IPv4 stack elements.
    ip                   Create IPv4 stack elements.
    ip6                  Create IPv6 stack elements.
    ip6                  Create IPv6 stack elements.
    interface            Create interfaces.
    policy               Create policy elements.
    policy               Create policy elements.
    sr                   Create srv6 stack elements.
    sr                   Create srv6 stack elements.

Take this into account to ensure we find something.

Fixes: 87629ec883bb ("cli: fix broken context initialization")
