### PR TITLE
srv6 cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,26 +27,31 @@ jobs:
             buildtype: debugoptimized
             os: ubuntu-24.04
             extra_opts: -Dfrr=enabled
+            rebase: false
           - compiler: gcc-14
             sanitize: address
             buildtype: debug
             os: ubuntu-24.04
-            extra_opts:
+            extra_opts: -Dfrr=enabled
+            rebase: true
           - compiler: clang-15
             sanitize: none
             buildtype: debugoptimized
             os: ubuntu-22.04
             extra_opts:
+            rebase: false
           - compiler: clang-16
             sanitize: none
             buildtype: debugoptimized
             os: ubuntu-24.04
             extra_opts:
+            rebase: false
           - compiler: clang-18
             sanitize: none
             buildtype: debugoptimized
             os: ubuntu-24.04
             extra_opts:
+            rebase: false
     runs-on: ${{ matrix.conf.os }}
     env:
       SANITIZE: ${{ matrix.conf.sanitize }}
@@ -97,9 +102,9 @@ jobs:
             ccache-x86_64-${{ matrix.conf.compiler }}-
       - run: ccache -sv
       - run: git rebase -x "git --no-pager log --oneline -1 && make all unit-tests && sudo smoke/run.sh build" "HEAD~${{ github.event.pull_request.commits }}"
-        if: ${{ github.event.pull_request.commits }}
+        if: ${{ matrix.conf.rebase && github.event.pull_request.commits }}
       - run: make all unit-tests && sudo smoke/run.sh build
-        if: ${{ ! github.event.pull_request.commits }}
+        if: ${{ ! matrix.conf.rebase || ! github.event.pull_request.commits }}
       - run: ccache -sv
 
   build-cross-aarch64:

--- a/modules/srv6/api/gr_srv6.h
+++ b/modules/srv6/api/gr_srv6.h
@@ -88,13 +88,27 @@ typedef enum : uint16_t {
 	SR_BEHAVIOR_END_DT6 = 0x0012,
 	SR_BEHAVIOR_END_DT4 = 0x0013,
 	SR_BEHAVIOR_END_DT46 = 0x0014,
-
-	SR_BEHAVIOR_MAX,
 } gr_srv6_behavior_t;
 
 #define GR_SR_FL_FLAVOR_PSP 0x01
 #define GR_SR_FL_FLAVOR_USD 0x02
 #define GR_SR_FL_FLAVOR_MASK 0x03
+
+static inline const char *gr_srv6_behavior_name(gr_srv6_behavior_t b) {
+	switch (b) {
+	case SR_BEHAVIOR_END:
+		return "end";
+	case SR_BEHAVIOR_END_T:
+		return "end.t";
+	case SR_BEHAVIOR_END_DT6:
+		return "end.dt6";
+	case SR_BEHAVIOR_END_DT4:
+		return "end.dt4";
+	case SR_BEHAVIOR_END_DT46:
+		return "end.dt46";
+	}
+	return "?";
+}
 
 struct gr_srv6_localsid {
 	struct rte_ipv6_addr lsid;

--- a/modules/srv6/control/route.c
+++ b/modules/srv6/control/route.c
@@ -164,19 +164,23 @@ struct list_context {
 	struct api_ctx *ctx;
 };
 
-static void nh_srv6_list_cb(struct nexthop *nh, void *priv) {
+static void route4_list_cb(
+	uint16_t vrf_id,
+	ip4_addr_t ip,
+	uint8_t prefixlen,
+	gr_nh_origin_t,
+	const struct nexthop *nh,
+	void *priv
+) {
 	struct list_context *ctx = priv;
 	struct srv6_encap_data *d;
 	struct gr_srv6_route *r;
 	size_t len;
 
-	if (ctx->ret != 0 || (nh->type != GR_NH_T_SR6_OUTPUT)
-	    || (nh->vrf_id != ctx->vrf_id && ctx->vrf_id != UINT16_MAX))
+	if (ctx->ret != 0 || nh->type != GR_NH_T_SR6_OUTPUT)
 		return;
 
 	d = srv6_encap_nh_priv(nh)->d;
-	if (d == NULL)
-		return;
 
 	len = sizeof(*r) + d->n_seglist * sizeof(r->seglist[0]);
 	r = malloc(len);
@@ -186,24 +190,48 @@ static void nh_srv6_list_cb(struct nexthop *nh, void *priv) {
 		return;
 	}
 
-	r->key.vrf_id = nh->vrf_id;
-	switch (nh->af) {
-	case GR_AF_IP6:
-		r->key.is_dest6 = true;
-		r->key.dest6.ip = nh->ipv6;
-		r->key.dest6.prefixlen = nh->prefixlen;
-		break;
-	case GR_AF_IP4:
-		r->key.is_dest6 = false;
-		r->key.dest4.ip = nh->ipv4;
-		r->key.dest4.prefixlen = nh->prefixlen;
-		break;
-	default:
-		// should never happen
-		free(r);
+	r->key.is_dest6 = false;
+	r->key.vrf_id = vrf_id;
+	r->key.dest4.ip = ip;
+	r->key.dest4.prefixlen = prefixlen;
+	r->encap_behavior = d->encap;
+	r->n_seglist = d->n_seglist;
+	memcpy(r->seglist, d->seglist, r->n_seglist * sizeof(r->seglist[0]));
+
+	api_send(ctx->ctx, len, r);
+	free(r);
+}
+
+static void route6_list_cb(
+	uint16_t vrf_id,
+	const struct rte_ipv6_addr *ip,
+	uint8_t prefixlen,
+	gr_nh_origin_t,
+	const struct nexthop *nh,
+	void *priv
+) {
+	struct list_context *ctx = priv;
+	struct srv6_encap_data *d;
+	struct gr_srv6_route *r;
+	size_t len;
+
+	if (ctx->ret != 0 || nh->type != GR_NH_T_SR6_OUTPUT)
+		return;
+
+	d = srv6_encap_nh_priv(nh)->d;
+
+	len = sizeof(*r) + d->n_seglist * sizeof(r->seglist[0]);
+	r = malloc(len);
+	if (r == NULL) {
+		LOG(ERR, "cannot allocate memory");
+		ctx->ret = ENOMEM;
 		return;
 	}
 
+	r->key.is_dest6 = true;
+	r->key.vrf_id = vrf_id;
+	r->key.dest6.ip = *ip;
+	r->key.dest6.prefixlen = prefixlen;
 	r->encap_behavior = d->encap;
 	r->n_seglist = d->n_seglist;
 	memcpy(r->seglist, d->seglist, r->n_seglist * sizeof(r->seglist[0]));
@@ -216,7 +244,8 @@ static struct api_out srv6_route_list(const void *request, struct api_ctx *ctx) 
 	const struct gr_srv6_route_list_req *req = request;
 	struct list_context list_ctx = {.vrf_id = req->vrf_id, .ctx = ctx, .ret = 0};
 
-	nexthop_iter(nh_srv6_list_cb, &list_ctx);
+	rib4_iter(req->vrf_id, route4_list_cb, &list_ctx);
+	rib6_iter(req->vrf_id, route6_list_cb, &list_ctx);
 
 	return api_out(list_ctx.ret, 0, NULL);
 }

--- a/modules/srv6/datapath/srv6_local.c
+++ b/modules/srv6/datapath/srv6_local.c
@@ -25,14 +25,6 @@ enum {
 	EDGE_COUNT,
 };
 
-static const char *behavior_str[SR_BEHAVIOR_MAX] = {
-	[SR_BEHAVIOR_END] = "end",
-	[SR_BEHAVIOR_END_T] = "end.t",
-	[SR_BEHAVIOR_END_DT6] = "end.dt6",
-	[SR_BEHAVIOR_END_DT4] = "end.dt4",
-	[SR_BEHAVIOR_END_DT46] = "end.dt46",
-};
-
 struct trace_srv6_data {
 	gr_srv6_behavior_t behavior;
 	uint8_t segleft;
@@ -152,13 +144,17 @@ static int trace_srv6_format(char *buf, size_t len, const void *data, size_t /*d
 			buf,
 			len,
 			"action=%s segleft=%d out_vrf=%d",
-			behavior_str[t->behavior],
+			gr_srv6_behavior_name(t->behavior),
 			t->segleft,
 			t->out_vrf_id
 		);
 	else
 		return snprintf(
-			buf, len, "action=%s segleft=%d", behavior_str[t->behavior], t->segleft
+			buf,
+			len,
+			"action=%s segleft=%d",
+			gr_srv6_behavior_name(t->behavior),
+			t->segleft
 		);
 }
 


### PR DESCRIPTION
- **github: check individual commits for a single matrix job**
- **srv6: improve behavior parsing and formatting**
- **srv6: use {rib4,rib6}_iter instead of checking all nexthops**
- **srv6: cleanup tunsrc code**
