### PR TITLE
vec: fix invalid memmove size in gr_vec_del

### DIFF
--- a/main/gr_vec.h
+++ b/main/gr_vec.h
@@ -95,7 +95,7 @@ static inline void __gr_vec_del_range(void *vec, size_t item_size, uint32_t star
 
 	memmove((void *)((uintptr_t)vec + (item_size * start)),
 		(void *)((uintptr_t)vec + (item_size * end)),
-		item_size * len);
+		item_size * (gr_vec_len(vec) - end));
 
 	hdr->len -= len;
 }

--- a/main/vec_test.c
+++ b/main/vec_test.c
@@ -19,6 +19,16 @@ static void int_vec(void **) {
 	for (int i = 0; i < 5; i++)
 		assert_int_equal(vec[i], i);
 
+	gr_vec_del(vec, 0);
+	assert_int_equal(gr_vec_len(vec), 4);
+	for (int i = 0; i < 4; i++)
+		assert_int_equal(vec[i], i + 1);
+
+	gr_vec_insert(vec, 0, 0);
+	assert_int_equal(gr_vec_len(vec), 5);
+	for (int i = 0; i < 5; i++)
+		assert_int_equal(vec[i], i);
+
 	gr_vec_insert(vec, 1, 42);
 	assert_int_equal(gr_vec_len(vec), 6);
 	assert_int_equal(vec[0], 0);


### PR DESCRIPTION
The size to move is from after the deleted range *until the end* of the
vector.

Update unit tests to ensure it works as expected.

Fixes: 2a1a0e0404cc ("main: implement basic dynamic array utilities")
Signed-off-by: Robin Jarry <rjarry@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected vector range deletion to shift the correct number of elements, preventing data corruption and ensuring accurate results after removing items.

* **Tests**
  * Expanded unit tests to cover element verification, front removal, and front insertion scenarios, improving confidence in vector behavior across common mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->