### PR TITLE
github: use ccache to speed up deb/rpm build

### DIFF
--- a/.github/actions/frr-install/action.yml
+++ b/.github/actions/frr-install/action.yml
@@ -24,6 +24,7 @@ runs:
       shell: bash
       run: ./.github/actions/frr-install/run.sh
       env:
+        CC: ccache gcc
         SYSCONFDIR: ${{inputs.sysconfdir}}
         LIBDIR: ${{inputs.libdir}}
         LIBEXECDIR: ${{inputs.libexecdir}}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -84,7 +84,7 @@ jobs:
           sbindir: /usr/lib64/frr
           localstatedir: /var
           yangmodelsdir: /usr/share/frr-yang
-      - run: make rpm RPMBUILD_OPTS="-D 'toolset gcc-toolset-13'"
+      - run: scl run gcc-toolset-13 -- make rpm
       - uses: actions/upload-artifact@v4
         with:
           name: rpm-packages

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,7 +25,7 @@ jobs:
           apt-get update -qy
           apt-get install -qy --no-install-recommends \
             autoconf automake bash-completion bison build-essential debhelper \
-            curl devscripts flex git go-md2man libarchive-dev libcap-dev \
+            ccache curl devscripts flex git go-md2man libarchive-dev libcap-dev \
             libcmocka-dev libedit-dev libelf-dev libevent-dev libibverbs-dev \
             libjson-c-dev libnuma-dev libprotobuf-c-dev libreadline-dev \
             librtr-dev libsmartcols-dev libtool libyang-dev meson ninja-build \
@@ -37,6 +37,15 @@ jobs:
           persist-credentials: false
       - run: git config --global --add safe.directory $PWD
       - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
+      - run: echo "CCACHE_DIR=$(ccache -k cache_dir)" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-x86_64-deb-${{ github.ref }}
+          restore-keys: |
+            ccache-x86_64-deb-refs/heads/main
+            ccache-x86_64-deb-
+      - run: ccache -z
       - uses: ./.github/actions/frr-install
         with:
           sysconfdir: /etc/frr
@@ -45,7 +54,8 @@ jobs:
           sbindir: /usr/lib/frr
           localstatedir: /run/frr
           yangmodelsdir: /usr/share/frr-yang
-      - run: make deb
+      - run: make deb CC="ccache gcc"
+      - run: ccache -sv
       - uses: actions/upload-artifact@v4
         with:
           name: deb-packages
@@ -62,8 +72,9 @@ jobs:
         run: |
           set -xe
           dnf install -y https://rpm.frrouting.org/repo/frr-10-repo.el9.noarch.rpm
+          dnf install -y epel-release
           dnf --enablerepo=crb install -y --nodocs --setopt=install_weak_deps=0 \
-            autoconf automake bison elfutils-libelf-devel flex gcc-toolset-13 \
+            autoconf automake bison ccache elfutils-libelf-devel flex gcc-toolset-13 \
             git golang-github-cpuguy83-md2man json-c-devel libarchive-devel \
             libcap-devel libcmocka-devel libedit-devel libevent-devel \
             libsmartcols-devel libyang-devel libtool make meson ninja-build \
@@ -76,6 +87,15 @@ jobs:
           persist-credentials: false
       - run: git config --global --add safe.directory $PWD
       - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
+      - run: echo "CCACHE_DIR=$(ccache -k cache_dir)" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-x86_64-rpm-${{ github.ref }}
+          restore-keys: |
+            ccache-x86_64-rpm-refs/heads/main
+            ccache-x86_64-rpm-
+      - run: ccache -z
       - uses: ./.github/actions/frr-install
         with:
           sysconfdir: /etc
@@ -84,7 +104,8 @@ jobs:
           sbindir: /usr/lib64/frr
           localstatedir: /var
           yangmodelsdir: /usr/share/frr-yang
-      - run: scl run gcc-toolset-13 -- make rpm
+      - run: scl run gcc-toolset-13 -- make rpm CC="ccache gcc"
+      - run: ccache -sv
       - uses: actions/upload-artifact@v4
         with:
           name: rpm-packages

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -86,7 +86,7 @@ rpmrelease = $(subst -,.,$(lastword $(version))).$(shell sed -nE 's/PLATFORM_ID=
 
 .PHONY: rpm
 rpm:
-	rpmbuild -bb --build-in-place -D 'version $(rpmversion)' -D 'release $(rpmrelease)' $(RPMBUILD_OPTS) rpm/grout.spec
+	rpmbuild -bb --build-in-place -D 'version $(rpmversion)' -D 'release $(rpmrelease)' rpm/grout.spec
 	$Q arch=`rpm --eval '%{_arch}'` && \
 	version="$(rpmversion)-$(rpmrelease)" && \
 	mv -vf ~/rpmbuild/RPMS/noarch/grout-devel-$$version.noarch.rpm grout-devel.noarch.rpm && \

--- a/rpm/grout.spec
+++ b/rpm/grout.spec
@@ -5,9 +5,6 @@
 %global _lto_cflags %nil
 %global branch main
 %global __meson_wrap_mode default
-%if %{defined toolset}
-%global __meson /usr/bin/scl run %toolset -- /usr/bin/meson
-%endif
 
 Name: grout
 Summary: Graph router based on DPDK
@@ -18,12 +15,7 @@ Version: %{version}
 Release: %{release}
 Source0: https://github.com/DPDK/grout/archive/%{branch}.tar.gz#/%{name}-%{version}-%{release}.tar.gz
 
-%if %{undefined toolset}
-BuildRequires: gcc >= 13
-%else
-BuildRequires: %toolset
-BuildRequires: scl-utils
-%endif
+BuildRequires: gcc
 BuildRequires: git
 BuildRequires: golang-github-cpuguy83-md2man
 BuildRequires: libarchive-devel


### PR DESCRIPTION
Enable ccache to generate the DEB and RPM packages. Use the same recipe than in check.yml.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Implemented compiler caching in packaging workflows to speed up Debian/Ubuntu and RPM builds, reducing CI time on repeated builds.
  * Standardized compiler configuration across packaging and install steps for consistent builds.
  * Added cache restoration and reporting to improve reliability across branches and reruns.
  * Simplified and broadened packaging build dependencies for more consistent RPM packaging behavior.
  * Minor packaging command adjustments to align RPM build flow with current toolchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->