### PR TITLE
vlan: inherit from parent interface state

### DIFF
--- a/modules/infra/control/vlan.c
+++ b/modules/infra/control/vlan.c
@@ -127,6 +127,7 @@ static int iface_vlan_reconfig(
 	if (set_attrs & GR_IFACE_SET_VRF)
 		iface->vrf_id = conf->vrf_id;
 	iface->mtu = iface_from_id(cur->parent_id)->mtu;
+	iface->state = iface_from_id(cur->parent_id)->state;
 
 	gr_event_push(GR_EVENT_IFACE_POST_RECONFIG, iface);
 


### PR DESCRIPTION
When {,re}configuring a vlan interface, replicate the state of its parent port. Otherwise, if its parent port is already running, the vlan interface will never appear running unless we set the port down and then up manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * VLAN interfaces now synchronize their operational state with the parent interface during reconfiguration (in addition to MTU), ensuring consistent status after parent changes.
  * Resolves cases where VLANs could appear incorrectly up/down, improving reliability for monitoring and automation tools.
  * Enhances stability during network updates without requiring configuration changes or impacting other attributes (e.g., VRF, MAC, flags).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->