### PR TITLE
stats: fix error when dumping stats without any ports configured

### DIFF
--- a/modules/infra/api/stats.c
+++ b/modules/infra/api/stats.c
@@ -73,9 +73,6 @@ static gr_vec struct gr_infra_stat *graph_stats(uint16_t cpu_id) {
 		}
 	}
 
-	if (stats == NULL)
-		return errno_set_null(ENODEV);
-
 	return stats;
 }
 
@@ -88,8 +85,9 @@ static struct api_out stats_get(const void *request, struct api_ctx *) {
 	int ret;
 
 	if (req->flags & GR_INFRA_STAT_F_SW) {
-		if ((stats = graph_stats(req->cpu_id)) == NULL)
-			return api_out(errno, 0, NULL);
+		stats = graph_stats(req->cpu_id);
+		if (stats == NULL && req->cpu_id != UINT16_MAX)
+			return api_out(ENODEV, 0, NULL);
 	}
 
 	if (req->flags & GR_INFRA_STAT_F_HW) {


### PR DESCRIPTION
When dumping software stats and no ports are configured, no workers are reporting any stats and we get an error:

	grout# stats show software
	error: command failed: No such device

Do not return an error when asking to dump all CPUs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when retrieving system/graph statistics: aggregated or "all-CPU" requests now may return no stats instead of a “device not found” error. This reduces spurious failures, improves reliability for monitoring and callers, and aligns behavior for wildcard CPU queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->