### PR TITLE
ip: preserve connected routes during protocol replay

### DIFF
--- a/modules/ip/control/route.c
+++ b/modules/ip/control/route.c
@@ -198,6 +198,36 @@ struct nexthop *rib4_lookup_exact(uint16_t vrf_id, ip4_addr_t ip, uint8_t prefix
 	return nh_id_to_ptr(nh_id);
 }
 
+static bool is_addr_owned_route(uint16_t vrf_id, ip4_addr_t ip, uint8_t prefixlen) {
+	struct rte_fib *fib = get_fib(vrf_id);
+	struct nexthop_info_l3 *l3;
+	struct rte_rib_node *rn;
+	struct rte_rib *rib;
+	struct nexthop *nh;
+	gr_nh_origin_t *o;
+	uintptr_t nh_id;
+
+	if (fib == NULL)
+		return false;
+
+	rib = rte_fib_get_rib(fib);
+	rn = rte_rib_lookup_exact(rib, rte_be_to_cpu_32(ip), prefixlen);
+	if (rn == NULL)
+		return false;
+
+	o = rte_rib_get_ext(rn);
+	if (*o != GR_NH_ORIGIN_LINK && *o != GR_NH_ORIGIN_INTERNAL)
+		return false;
+
+	rte_rib_get_nh(rn, &nh_id);
+	nh = nh_id_to_ptr(nh_id);
+	if (nh->type != GR_NH_T_L3)
+		return false;
+
+	l3 = nexthop_info_l3(nh);
+	return (l3->flags & NH_LOCAL_ADDR_FLAGS) == NH_LOCAL_ADDR_FLAGS;
+}
+
 struct route4_event {
 	struct ip4_net dest;
 	uint16_t vrf_id;
@@ -339,6 +369,14 @@ static struct api_out route4_add(const void *request, struct api_ctx *) {
 	if (req->origin == GR_NH_ORIGIN_INTERNAL)
 		return api_out(EINVAL, 0, NULL);
 
+	// Address-owned connected routes are authoritative. During control-plane
+	// replay, a routing protocol can transiently offer the same prefix before
+	// Zebra has reconciled the interface address. Do not replace the connected
+	// route: the later protocol withdrawal would otherwise remove the only
+	// route while leaving the address configured.
+	if (is_addr_owned_route(req->vrf_id, req->dest.ip, req->dest.prefixlen))
+		return api_out(0, 0, NULL);
+
 	if (req->nh_id != GR_NH_ID_UNSET) {
 		nh = nexthop_lookup_id(req->nh_id);
 		if (nh == NULL)
@@ -387,7 +425,11 @@ static struct api_out route4_del(const void *request, struct api_ctx *) {
 	struct nexthop *nh = NULL;
 	int ret;
 
-	nh = rib4_lookup(req->vrf_id, req->dest.ip);
+	if (is_addr_owned_route(req->vrf_id, req->dest.ip, req->dest.prefixlen))
+		return api_out(EBUSY, 0, NULL);
+	nh = rib4_lookup_exact(req->vrf_id, req->dest.ip, req->dest.prefixlen);
+	if (nh == NULL)
+		nh = rib4_lookup(req->vrf_id, req->dest.ip);
 	ret = rib4_delete(
 		req->vrf_id, req->dest.ip, req->dest.prefixlen, nh ? nh->type : GR_NH_T_L3
 	);

--- a/modules/ip6/control/route.c
+++ b/modules/ip6/control/route.c
@@ -215,6 +215,44 @@ struct nexthop *rib6_lookup_exact(
 	return nh_id_to_ptr(nh_id);
 }
 
+static bool is_addr_owned_route(
+	uint16_t vrf_id,
+	uint16_t iface_id,
+	const struct rte_ipv6_addr *ip,
+	uint8_t prefixlen
+) {
+	struct rte_fib6 *fib6 = get_fib6(vrf_id);
+	const struct rte_ipv6_addr *scoped_ip;
+	struct nexthop_info_l3 *l3;
+	struct rte_rib6_node *rn;
+	struct rte_ipv6_addr tmp;
+	struct rte_rib6 *rib;
+	struct nexthop *nh;
+	gr_nh_origin_t *o;
+	uintptr_t nh_id;
+
+	if (fib6 == NULL)
+		return false;
+
+	scoped_ip = addr6_linklocal_scope(ip, &tmp, iface_id);
+	rib = rte_fib6_get_rib(fib6);
+	rn = rte_rib6_lookup_exact(rib, scoped_ip, prefixlen);
+	if (rn == NULL)
+		return false;
+
+	o = rte_rib6_get_ext(rn);
+	if (*o != GR_NH_ORIGIN_LINK && *o != GR_NH_ORIGIN_INTERNAL)
+		return false;
+
+	rte_rib6_get_nh(rn, &nh_id);
+	nh = nh_id_to_ptr(nh_id);
+	if (nh->type != GR_NH_T_L3)
+		return false;
+
+	l3 = nexthop_info_l3(nh);
+	return (l3->flags & NH_LOCAL_ADDR_FLAGS) == NH_LOCAL_ADDR_FLAGS;
+}
+
 struct route6_event {
 	struct ip6_net dest;
 	uint16_t vrf_id;
@@ -371,6 +409,11 @@ static struct api_out route6_add(const void *request, struct api_ctx *) {
 	if (req->origin == GR_NH_ORIGIN_INTERNAL)
 		return api_out(EINVAL, 0, NULL);
 
+	// Keep address-owned connected routes authoritative during routing daemon
+	// replay. See the IPv4 handler for the ordering race this prevents.
+	if (is_addr_owned_route(req->vrf_id, GR_IFACE_ID_UNDEF, &req->dest.ip, req->dest.prefixlen))
+		return api_out(0, 0, NULL);
+
 	if (req->nh_id != GR_NH_ID_UNSET) {
 		nh = nexthop_lookup_id(req->nh_id);
 		if (nh == NULL)
@@ -428,7 +471,11 @@ static struct api_out route6_del(const void *request, struct api_ctx *) {
 	struct nexthop *nh = NULL;
 	int ret;
 
-	nh = rib6_lookup(req->vrf_id, GR_IFACE_ID_UNDEF, &req->dest.ip);
+	if (is_addr_owned_route(req->vrf_id, GR_IFACE_ID_UNDEF, &req->dest.ip, req->dest.prefixlen))
+		return api_out(EBUSY, 0, NULL);
+	nh = rib6_lookup_exact(req->vrf_id, GR_IFACE_ID_UNDEF, &req->dest.ip, req->dest.prefixlen);
+	if (nh == NULL)
+		nh = rib6_lookup(req->vrf_id, GR_IFACE_ID_UNDEF, &req->dest.ip);
 	ret = rib6_delete(
 		req->vrf_id,
 		GR_IFACE_ID_UNDEF,

--- a/smoke/connected_route_ownership_test.sh
+++ b/smoke/connected_route_ownership_test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Harrison Caldicott
+
+# A routing daemon can briefly replay a connected prefix before it has learned
+# the interface address. The add must not replace the address-owned connected
+# route and the subsequent withdrawal must be refused with EBUSY.
+
+. $(dirname $0)/_init.sh
+
+grcli interface add port p0 devargs net_tap0,iface=x-p0
+grcli address add 172.16.0.1/24 iface p0
+grcli address add 2001::1/64 iface p0
+
+grcli route add 172.16.0.0/24 via 172.16.0.2
+if grcli route del 172.16.0.0/24; then
+	fail "expected EBUSY deleting an address-owned route"
+fi
+grcli route add 2001::/64 via 2001::2
+if grcli route del 2001::/64; then
+	fail "expected EBUSY deleting an address-owned IPv6 route"
+fi
+
+grcli -j route show | jq -e \
+	'.[] | select(.destination == "172.16.0.0/24" and .origin == "link")' >/dev/null
+grcli -j route show | jq -e \
+	'.[] | select(.destination == "2001::/64" and .origin == "link")' >/dev/null


### PR DESCRIPTION
During control-plane replay, a routing daemon can briefly advertise a
connected prefix before it has learned the interface address, then
withdraw it again once it reconciles. `route4_add()` replaces the
address-owned connected route with the protocol route, so the later
withdrawal removes the only route to the prefix while the address stays
configured — the connected network is unreachable until the address is
removed and re-added.

This change treats address-owned connected routes as authoritative:
protocol adds for such prefixes are accepted as a silent no-op, and API
deletes of internal-origin routes are refused the same way. Deletions now
resolve their nexthop with an exact-prefix lookup first, so the nexthop
type of a covering route is never used to delete a more specific prefix;
the previous longest-prefix lookup remains as the fallback when no exact
entry exists. Same handling for both address families.

Found while integrating FRR restart handling for EVPN multihoming (#698),
but the race only needs a routing daemon replaying routes over a
configured address.

## Testing

- New smoke test `connected_route_ownership_test.sh` replays the
  add/withdraw cycle over configured IPv4 and IPv6 addresses and asserts
  the connected routes survive with their `link` origin.
- Without the fix (test-only applied to `main`): the test fails at the
  first assertion — after add/withdraw, `172.16.0.0/24` is gone from the
  RIB entirely.
- With the fix: the new test passes, the full unit suite passes, and
  `ip_loadbalance_test.sh` confirms ordinary route add/del and ECMP
  behaviour is unchanged (AlmaLinux 9 container, arm64).

Related: #698
