### PR TITLE
main: add high-performance clock

### DIFF
--- a/api/gr_clock.h
+++ b/api/gr_clock.h
@@ -7,27 +7,26 @@
 #include <stdint.h>
 #include <time.h>
 
+// Clock source.
+// Must be a high-resolution clock, i.e. not a _COARSE variant.
+#define GR_CLOCK_SOURCE CLOCK_MONOTONIC_RAW
+
 // High-resolution clock [nanoseconds].
-// Used with CLOCK_MONOTONIC_RAW, unless otherwise specified.
+// Used with GR_CLOCK_SOURCE, unless otherwise specified.
 // Note: Does not have Y2038 problems. Not even with CLOCK_REALTIME.
 // Note: Using signed, to avoid need for casting to signed
 // in calculations where race conditions may cause negative differences.
 typedef int64_t gr_clock_ns_t;
 
-// Get powered-on (non-suspended, non-hibernated) time since last boot,
-// using a common clock across all processes.
-static inline struct timespec gr_clock_raw(void) {
-	struct timespec tp = {0};
-	clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
-	return tp;
-}
-
 #define GR_NS_PER_S (gr_clock_ns_t)1000000000LL
+#define GR_NS_PER_MS (gr_clock_ns_t)1000000LL
+#define GR_NS_PER_US (gr_clock_ns_t)1000LL
 
 // Get powered-on (non-suspended, non-hibernated) time since last boot [nanoseconds],
 // using a common clock across all processes.
 // Does not return negative values.
 static inline gr_clock_ns_t gr_clock_ns(void) {
-	struct timespec tp = gr_clock_raw();
+	struct timespec tp = {0};
+	clock_gettime(GR_CLOCK_SOURCE, &tp);
 	return tp.tv_sec * GR_NS_PER_S + tp.tv_nsec;
 }

--- a/main/clock.c
+++ b/main/clock.c
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 SmartShare Systems
+
+#include "clock.h"
+
+__thread bool clock_trusted = false;
+
+__thread gr_clock_ns_t clock_snapshot_ns = INT64_C(-1);

--- a/main/clock.h
+++ b/main/clock.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 SmartShare Systems
+
+#pragma once
+
+#include <gr_clock.h>
+
+#include <rte_branch_prediction.h>
+
+#include <assert.h>
+
+// Per-thread snapshot of gr_clock_ns().
+extern __thread gr_clock_ns_t clock_snapshot_ns;
+
+// Update the clock for the current thread.
+static inline void clock_update(void) {
+	clock_snapshot_ns = gr_clock_ns();
+}
+
+// When true, assume that the clock is updated for the current thread.
+extern __thread bool clock_trusted;
+
+// Update clock_trusted for the current thread.
+static inline void clock_set_trusted(bool trusted) {
+	clock_trusted = trusted;
+}
+
+// Get the current value of clock_snapshot_ns if clock_trusted is true.
+// Otherwise, fallback to gr_clock_ns().
+static inline gr_clock_ns_t clock_ns(void) {
+	if (likely(clock_trusted)) {
+		assert(clock_snapshot_ns > 0);
+		return clock_snapshot_ns;
+	}
+	return gr_clock_ns();
+}

--- a/main/meson.build
+++ b/main/meson.build
@@ -3,6 +3,7 @@
 
 src += files(
   'api.c',
+  'clock.c',
   'config.c',
   'control_queue.c',
   'dpdk.c',

--- a/modules/infra/control/icmp_session.c
+++ b/modules/infra/control/icmp_session.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026 Robin Jarry
 
+#include "clock.h"
 #include "icmp_session.h"
 
-#include <gr_clock.h>
 #include <gr_errno.h>
 #include <gr_infra.h>
 
@@ -46,7 +46,7 @@ static void session_free(struct icmp_session *s) {
 
 static void gc_cb(evutil_socket_t, short, void *arg) {
 	struct icmp_session_pool *pool = arg;
-	gr_clock_ns_t now = gr_clock_ns();
+	gr_clock_ns_t now = clock_ns();
 	struct icmp_session *s;
 	uint32_t next = 0;
 	const void *key;
@@ -123,7 +123,7 @@ int icmp_session_add(struct icmp_session_pool *pool, uint16_t ident, uint16_t se
 	if (s == NULL)
 		return errno_set(ENOMEM);
 
-	s->created = gr_clock_ns();
+	s->created = clock_ns();
 
 	if (rte_hash_add_key_data(pool->hash, &k, s) < 0) {
 		free(s);

--- a/modules/infra/control/l3_nexthop.c
+++ b/modules/infra/control/l3_nexthop.c
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026 Robin Jarry
 
+#include "clock.h"
 #include "iface.h"
 #include "log.h"
 #include "mbuf.h"
 #include "module.h"
 #include "nexthop.h"
 #include "rcu.h"
-
-#include <gr_clock.h>
 
 #include <rte_hash.h>
 
@@ -313,7 +312,7 @@ static struct nexthop_type_ops l3_nh_ops = {
 static void l3_age(struct nexthop *nh) {
 	struct nexthop_info_l3 *l3 = nexthop_info_l3(nh);
 	const struct nexthop_af_ops *ops;
-	gr_clock_ns_t now = gr_clock_ns();
+	gr_clock_ns_t now = clock_ns();
 	unsigned probes, max_probes;
 	time_t reply_age;
 

--- a/modules/infra/control/lacp.c
+++ b/modules/infra/control/lacp.c
@@ -2,13 +2,12 @@
 // Copyright (c) 2025 Robin Jarry
 
 #include "bond.h"
+#include "clock.h"
 #include "iface.h"
 #include "lacp.h"
 #include "log.h"
 #include "mbuf.h"
 #include "module.h"
-
-#include <gr_clock.h>
 
 #include <event2/event.h>
 #include <rte_mbuf.h>
@@ -65,7 +64,7 @@ void lacp_input_cb(void *obj, uintptr_t, const struct control_queue_drain *drain
 
 	// Store partner information from received PDU
 	member->remote = pdu->actor;
-	member->last_rx = gr_clock_ns();
+	member->last_rx = clock_ns();
 
 	// Save old member state to detect changes
 	bool old_active = member->active;
@@ -122,7 +121,7 @@ static void lacp_periodic(evutil_socket_t, short, void *) {
 	const struct iface *port;
 	struct iface *iface;
 
-	now = gr_clock_ns();
+	now = clock_ns();
 
 	iface = NULL;
 	while ((iface = iface_next(GR_IFACE_TYPE_BOND, iface)) != NULL) {

--- a/modules/infra/control/mempool.c
+++ b/modules/infra/control/mempool.c
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Christophe Fontaine
 
+#include "clock.h"
 #include "config.h"
 #include "log.h"
 #include "mbuf.h"
 #include "mempool.h"
 #include "module.h"
 #include "sys_queue.h"
-
-#include <gr_clock.h>
 
 #include <event2/event.h>
 
@@ -139,7 +138,7 @@ static bool pending_has_name(const char *name) {
 
 static void pending_free_cb(evutil_socket_t, short, void *) {
 	struct pending_free *pf, *tmp;
-	gr_clock_ns_t now = gr_clock_ns();
+	gr_clock_ns_t now = clock_ns();
 
 	STAILQ_FOREACH_SAFE (pf, &pending_list, next, tmp) {
 		gr_clock_ns_t elapsed = now - pf->timestamp;
@@ -182,7 +181,7 @@ void gr_pktmbuf_pool_release(struct rte_mempool *mp, uint32_t count) {
 					if (pf == NULL)
 						ABORT("malloc(pending_free) failed");
 					pf->mp = mp;
-					pf->timestamp = gr_clock_ns();
+					pf->timestamp = clock_ns();
 					pf->last_warn = 0;
 					STAILQ_INSERT_TAIL(&pending_list, pf, next);
 					LOG(DEBUG,
@@ -272,7 +271,7 @@ static void mempool_fini(struct event_base *) {
 			LOG(ERR,
 			    "freeing mempool %s with mbufs still in-flight (released %lu s ago)",
 			    pf->mp->name,
-			    (gr_clock_ns() - pf->timestamp) / GR_NS_PER_S);
+			    (clock_ns() - pf->timestamp) / GR_NS_PER_S);
 		rte_mempool_free(pf->mp);
 		STAILQ_REMOVE_HEAD(&pending_list, next);
 		free(pf);

--- a/modules/infra/datapath/main_loop.c
+++ b/modules/infra/datapath/main_loop.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2023 Robin Jarry
+// Copyright (c) 2026 SmartShare Systems
 
+#include "clock.h"
 #include "config.h"
 #include "control_input.h"
 #include "datapath.h"
@@ -456,7 +458,10 @@ reconfig:
 	worker_active_inc();
 
 	for (;;) {
+		clock_set_trusted(true);
+		clock_update();
 		rte_graph_walk(graph);
+		clock_set_trusted(false);
 
 		if (++loop == HOUSEKEEPING_INTERVAL) {
 			// When RCU reclamation will be done in datapath workers,

--- a/modules/ip/control/nexthop.c
+++ b/modules/ip/control/nexthop.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
 
+#include "clock.h"
 #include "event.h"
 #include "iface.h"
 #include "ip4.h"
@@ -8,7 +9,6 @@
 #include "l3.h"
 #include "log.h"
 
-#include <gr_clock.h>
 #include <gr_net_types.h>
 
 #include <rte_arp.h>
@@ -173,7 +173,7 @@ void arp_probe_input_cb(void *obj, uintptr_t, const struct control_queue_drain *
 	} else {
 		// Refresh all fields.
 		struct nexthop_info_l3 *l3 = nexthop_info_l3(nh);
-		l3->last_reply = gr_clock_ns();
+		l3->last_reply = clock_ns();
 		l3->state = GR_NH_S_REACHABLE;
 		l3->ucast_probes = 0;
 		l3->bcast_probes = 0;

--- a/modules/ip/datapath/arp_output_request.c
+++ b/modules/ip/datapath/arp_output_request.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
 
+#include "clock.h"
 #include "control_input.h"
 #include "eth.h"
 #include "graph.h"
@@ -9,8 +10,6 @@
 #include "ip4_datapath.h"
 #include "l3.h"
 #include "trace.h"
-
-#include <gr_clock.h>
 
 #include <rte_arp.h>
 #include <rte_ether.h>
@@ -39,7 +38,7 @@ int arp_output_request_solicit(struct nexthop *nh) {
 	} else {
 		// This function is called by the control plane main thread.
 		// It is OK to modify the nexthop here.
-		l3->last_request = gr_clock_ns();
+		l3->last_request = clock_ns();
 		if (l3->ucast_probes < nh_conf.max_ucast_probes)
 			l3->ucast_probes++;
 		else

--- a/modules/ip/datapath/icmp_input.c
+++ b/modules/ip/datapath/icmp_input.c
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
 
+#include "clock.h"
 #include "control_output.h"
 #include "graph.h"
 #include "ip4_datapath.h"
 #include "log.h"
 #include "mbuf.h"
 #include "trace.h"
-
-#include <gr_clock.h>
 
 #include <rte_icmp.h>
 
@@ -55,7 +54,7 @@ icmp_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 			ip_data->src = ip;
 			edge = OUTPUT;
 		} else if (icmp_cb[icmp->icmp_type]) {
-			control_output_set_cb(mbuf, icmp_cb[icmp->icmp_type], gr_clock_ns());
+			control_output_set_cb(mbuf, icmp_cb[icmp->icmp_type], clock_ns());
 			edge = CONTROL;
 		} else {
 			edge = UNSUPPORTED;

--- a/modules/ip/datapath/icmp_local_send.c
+++ b/modules/ip/datapath/icmp_local_send.c
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Christophe Fontaine
 
+#include "clock.h"
 #include "control_input.h"
 #include "graph.h"
 #include "iface.h"
 #include "ip4.h"
 #include "ip4_datapath.h"
 #include "mbuf.h"
-
-#include <gr_clock.h>
 
 #include <rte_icmp.h>
 
@@ -101,7 +100,7 @@ static uint16_t icmp_local_send_process(
 		);
 
 		payload = rte_pktmbuf_mtod_offset(mbuf, gr_clock_ns_t *, sizeof(*icmp));
-		*payload = gr_clock_ns();
+		*payload = clock_ns();
 
 		// Build ICMP packet
 		icmp->icmp_type = RTE_ICMP_TYPE_ECHO_REQUEST;

--- a/modules/ip6/control/nexthop.c
+++ b/modules/ip6/control/nexthop.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
 
+#include "clock.h"
 #include "event.h"
 #include "icmp6.h"
 #include "iface.h"
@@ -9,7 +10,6 @@
 #include "l3.h"
 #include "log.h"
 
-#include <gr_clock.h>
 #include <gr_net_types.h>
 
 #include <event2/event.h>
@@ -225,7 +225,7 @@ void ndp_probe_input_cb(void *obj, uintptr_t, const struct control_queue_drain *
 	} else if (lladdr_found == ICMP6_OPT_FOUND) {
 		// Refresh all fields.
 		struct nexthop_info_l3 *l3 = nexthop_info_l3(nh);
-		l3->last_reply = gr_clock_ns();
+		l3->last_reply = clock_ns();
 		l3->state = GR_NH_S_REACHABLE;
 		l3->ucast_probes = 0;
 		l3->bcast_probes = 0;

--- a/modules/ip6/datapath/icmp6_input.c
+++ b/modules/ip6/datapath/icmp6_input.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
 
+#include "clock.h"
 #include "control_output.h"
 #include "graph.h"
 #include "icmp6.h"
@@ -9,8 +10,6 @@
 #include "log.h"
 #include "mbuf.h"
 #include "trace.h"
-
-#include <gr_clock.h>
 
 enum {
 	ICMP6_OUTPUT = 0,
@@ -92,7 +91,7 @@ icmp6_input_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 			break;
 		default:
 			if (icmp6_cb[icmp6->type] != NULL) {
-				control_output_set_cb(mbuf, icmp6_cb[icmp6->type], gr_clock_ns());
+				control_output_set_cb(mbuf, icmp6_cb[icmp6->type], clock_ns());
 				next = CONTROL;
 			} else {
 				next = UNSUPPORTED;

--- a/modules/ip6/datapath/icmp6_local_send.c
+++ b/modules/ip6/datapath/icmp6_local_send.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2025 Olivier Gournet
 
+#include "clock.h"
 #include "control_input.h"
 #include "graph.h"
 #include "icmp6.h"
@@ -8,8 +9,6 @@
 #include "ip6.h"
 #include "ip6_datapath.h"
 #include "mbuf.h"
-
-#include <gr_clock.h>
 
 #include <rte_ip6.h>
 
@@ -111,7 +110,7 @@ static uint16_t icmp6_local_send_process(
 		mbuf->ol_flags |= RTE_MBUF_F_RX_RSS_HASH;
 
 		payload = PAYLOAD(icmp6_echo);
-		*payload = gr_clock_ns();
+		*payload = clock_ns();
 
 		data = ip6_local_mbuf_data(mbuf);
 		data->iface = msg.iface;

--- a/modules/ip6/datapath/ndp_ns_output.c
+++ b/modules/ip6/datapath/ndp_ns_output.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
 
+#include "clock.h"
 #include "control_input.h"
 #include "graph.h"
 #include "icmp6.h"
@@ -10,7 +11,6 @@
 #include "l3.h"
 #include "trace.h"
 
-#include <gr_clock.h>
 #include <gr_macro.h>
 
 #include <rte_mbuf.h>
@@ -33,7 +33,7 @@ int nh6_solicit(struct nexthop *nh) {
 
 	// This function is called by the control plane main thread.
 	// It is OK to modify the nexthop here.
-	l3->last_request = gr_clock_ns();
+	l3->last_request = clock_ns();
 	if (l3->ucast_probes < nh_conf.max_ucast_probes)
 		l3->ucast_probes++;
 	else

--- a/modules/l2/control/fdb.c
+++ b/modules/l2/control/fdb.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026 Robin Jarry
 
+#include "clock.h"
 #include "config.h"
 #include "event.h"
 #include "iface.h"
@@ -8,8 +9,6 @@
 #include "log.h"
 #include "module.h"
 #include "rcu.h"
-
-#include <gr_clock.h>
 
 #include <rte_common.h>
 #include <rte_hash.h>
@@ -118,7 +117,7 @@ void fdb_learn(
 	const struct l3_addr *vtep
 ) {
 	const struct fdb_key key = {bridge_id, vlan_id, *mac};
-	gr_clock_ns_t now = gr_clock_ns();
+	gr_clock_ns_t now = clock_ns();
 	struct fdb_entry *fdb;
 	void *data;
 
@@ -208,7 +207,7 @@ static struct api_out fdb_add(const void *request, struct api_ctx *) {
 		e->prev_iface_id = GR_IFACE_ID_UNDEF;
 		e->base = req->fdb;
 		e->bridge_id = iface->id;
-		e->last_seen = gr_clock_ns();
+		e->last_seen = clock_ns();
 
 		if ((ret = rte_hash_add_key_data(fdb_hash, &key, data)) < 0) {
 			rte_mempool_put(fdb_pool, e);
@@ -221,7 +220,7 @@ static struct api_out fdb_add(const void *request, struct api_ctx *) {
 		e->prev_iface_id = e->iface_id;
 		e->base = req->fdb;
 		e->bridge_id = iface->id;
-		e->last_seen = gr_clock_ns();
+		e->last_seen = clock_ns();
 
 		event_push(GR_EVENT_FDB_UPDATE, e);
 	} else {
@@ -458,7 +457,7 @@ static void fdb_ageing_cb(evutil_socket_t, short /*what*/, void * /*priv*/) {
 	void *data;
 	time_t age;
 
-	now = gr_clock_ns();
+	now = clock_ns();
 
 	while (rte_hash_iterate(fdb_hash, &key, &data, &next) >= 0) {
 		fdb = data;

--- a/modules/policy/control/conntrack.c
+++ b/modules/policy/control/conntrack.c
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2025 Robin Jarry
 
+#include "clock.h"
 #include "config.h"
 #include "conntrack.h"
 #include "log.h"
 #include "module.h"
 #include "rcu.h"
 
-#include <gr_clock.h>
 #include <gr_net_types.h>
 
 #include <rte_hash.h>
@@ -241,7 +241,7 @@ again:
 			goto again;
 	}
 
-	atomic_store(&c->last_update, gr_clock_ns());
+	atomic_store(&c->last_update, clock_ns());
 }
 
 bool gr_conn_parse_key(
@@ -388,7 +388,7 @@ struct conn *gr_conn_insert(const struct conn_key *fwd_key, const struct conn_ke
 }
 
 static void do_ageing(evutil_socket_t, short /*what*/, void * /*priv*/) {
-	gr_clock_ns_t now = gr_clock_ns(), last;
+	gr_clock_ns_t now = clock_ns(), last;
 	uint64_t age, timeout;
 	struct conn *conn;
 	const void *key;


### PR DESCRIPTION
Reading the common clock, gr_clock_ns() -- implemented with clock_gettime() -- is quite slow, even though the kernel exposes it as a vDSO.

For improved performance in the dataplane, introduce a high-performance clock: clock_ns(), based on snapshotting the common clock, for use where a snapshot is sufficiently accurate.

Immediately before walking the graph in the dataplane worker thread's main loop, mark the clock as trusted and update it, so it is safe to use in the "process" functions of the graph nodes.

Define GR_CLOCK_SOURCE (as CLOCK_MONOTONIC_RAW), to highlight which clock source is used by Grout.

Add definitions like GR_NS_PER_S to help convert between nanoseconds and microseconds (GR_NS_PER_US) respectively milliseconds (GR_NS_PER_MS).

Replace all direct calls to gr_clock_ns() in grout control and data plane with clock_ns() and update <gr_clock.h> include to "clock.h" accordingly.

Respin of: https://patches.dpdk.org/project/grout/patch/20260827094041.520166-1-mb@smartsharesystems.com/
Cc: @MortenBroerup 