### PR TITLE
ip,ip6: drop wrong iface assertion on connected nexthop resolution

### DIFF
--- a/modules/ip/control/nexthop.c
+++ b/modules/ip/control/nexthop.c
@@ -93,9 +93,21 @@ static void nh4_resolve_cb(void *obj, uintptr_t, const struct control_queue_drai
 				LOG(ERR, "failed to insert route: %s", strerror(errno));
 				goto free;
 			}
+		} else if (remote->iface_id != nh->iface_id) {
+			// remote may live on a different interface than the connected
+			// route. In EVPN L3VNI VRFs, a host inside a connected subnet
+			// can be reachable through the VXLAN interface while the subnet
+			// itself is connected on the bridge SVI.
+			LOG(DEBUG,
+			    "remote " IP4_F " (iface=%u), "
+			    "connected route " IP4_F "/%hhu (iface=%u)",
+			    &nexthop_info_l3(remote)->ipv4,
+			    remote->iface_id,
+			    &l3->ipv4,
+			    l3->prefixlen,
+			    nh->iface_id);
 		}
 
-		assert(remote->iface_id == nh->iface_id);
 		nh = remote;
 		l3 = nexthop_info_l3(remote);
 	}

--- a/modules/ip6/control/nexthop.c
+++ b/modules/ip6/control/nexthop.c
@@ -104,9 +104,21 @@ static void nh6_resolve_cb(void *obj, uintptr_t, const struct control_queue_drai
 				LOG(ERR, "failed to insert route: %s", strerror(errno));
 				goto free;
 			}
+		} else if (remote->iface_id != nh->iface_id) {
+			// remote may live on a different interface than the connected
+			// route. In EVPN L3VNI VRFs, a host inside a connected subnet
+			// can be reachable through the VXLAN interface while the subnet
+			// itself is connected on the bridge SVI.
+			LOG(DEBUG,
+			    "remote " IP6_F " (iface=%u), "
+			    "connected route " IP6_F "/%hhu (iface=%u)",
+			    &nexthop_info_l3(remote)->ipv6,
+			    remote->iface_id,
+			    &l3->ipv6,
+			    l3->prefixlen,
+			    nh->iface_id);
 		}
 
-		assert(remote->iface_id == nh->iface_id);
 		nh = remote;
 		l3 = nexthop_info_l3(remote);
 	}


### PR DESCRIPTION
When resolving a destination that falls under a connected route, the callback looks up an existing nexthop for that host address and asserts that it lives on the same interface as the connected route. That invariant is not guaranteed: the lookup is keyed by (vrf, address) only and is not interface-scoped, so it can return a nexthop that lives on a different interface for the same address.

This happens with EVPN L3VNI. The FRR dplane plugin redirects a remote host nexthop to the VXLAN interface (see grout_add_nexthop in frr/rt_grout.c) while the containing subnet stays connected on the bridge SVI. The two nexthops therefore live on different interfaces for the same (vrf, address).

The datapath can still hit the connected route for such a host: if a packet arrives before FRR has installed the host route, the FIB lookup returns the connected nexthop and the packet is punted to the control plane. By the time the resolve callback runs, FRR may have installed the remote host nexthop on the VXLAN interface, and the lookup returns it. The assertion then aborts the daemon.

Remove the assertion and simply use the resolved nexthop. Being a remote EVPN nexthop, it is already reachable, so the packet is resubmitted to the datapath and takes the tunnel.