### PR TITLE
l2: install the bridge SVI MAC as a local FDB entry

### DIFF
--- a/frr/rt_grout.c
+++ b/frr/rt_grout.c
@@ -1055,6 +1055,12 @@ void grout_macfdb_change(const struct gr_fdb_entry *fdb, bool new) {
 	struct ethaddr mac;
 	struct ipaddr vtep;
 
+	// The bridge's own SVI MAC reaches zebra through the interface hw_addr
+	// (used as the EVPN router MAC), not as a local MAC. Feeding it here
+	// would make zebra advertise it as an EVPN type-2 route.
+	if (fdb->flags & GR_FDB_F_LOCAL)
+		return;
+
 	l3_addr_to_ipaddr(&vtep, &fdb->vtep);
 
 	gr_log_debug(

--- a/modules/l2/api/gr_l2.h
+++ b/modules/l2/api/gr_l2.h
@@ -81,6 +81,7 @@ typedef enum : uint8_t {
 	GR_FDB_F_STATIC = GR_BIT8(0), // User-configured, never aged out.
 	GR_FDB_F_LEARN = GR_BIT8(1), // Learned via local bridge.
 	GR_FDB_F_EXTERN = GR_BIT8(2), // Programmed by external control plane.
+	GR_FDB_F_LOCAL = GR_BIT8(3), // Bridge's own SVI MAC, delivered locally.
 } gr_fdb_flags_t;
 
 // Convert FDB flag enum to string representation.
@@ -93,6 +94,8 @@ static inline const char *gr_fdb_flag_name(gr_fdb_flags_t f) {
 		return "learn";
 	case GR_FDB_F_EXTERN:
 		return "extern";
+	case GR_FDB_F_LOCAL:
+		return "local";
 	}
 	return "?";
 }

--- a/modules/l2/control/bridge.c
+++ b/modules/l2/control/bridge.c
@@ -48,8 +48,11 @@ static int bridge_reconfig(
 	if (next->flags & ~GR_BRIDGE_F_VALID)
 		return errno_set(EINVAL);
 
-	if (set_attrs & GR_BRIDGE_SET_MAC)
-		iface_set_eth_addr(iface, &next->mac);
+	if (set_attrs & GR_BRIDGE_SET_MAC) {
+		int ret = iface_set_eth_addr(iface, &next->mac);
+		if (ret < 0)
+			return ret;
+	}
 	if (set_attrs & GR_BRIDGE_SET_FLAGS)
 		cur->flags = next->flags;
 	if (set_attrs & GR_BRIDGE_SET_AGEING_TIME)
@@ -86,7 +89,6 @@ static int bridge_attach_member(struct iface *bridge, struct iface *member) {
 		if (iface_add_eth_addr(member, &m->mac) < 0)
 			return errno_log(errno, "iface_add_eth_addr(member)");
 	}
-	iface_add_eth_addr(member, &br->mac);
 
 	br->members[br->n_members++] = member;
 	member->domain_id = bridge->id;
@@ -108,7 +110,6 @@ static int bridge_detach_member(struct iface *bridge, struct iface *member) {
 			fdb_sync_hardware(bridge, member, false);
 			vec_foreach_ref (struct iface_mac *m, bridge->macs)
 				iface_del_eth_addr(member, &m->mac);
-			iface_del_eth_addr(member, &br->mac);
 
 			if (i < last)
 				br->members[i] = br->members[last];
@@ -132,7 +133,6 @@ static int bridge_fini(struct iface *iface) {
 		fdb_sync_hardware(iface, member, false);
 		vec_foreach_ref (struct iface_mac *m, iface->macs)
 			iface_del_eth_addr(member, &m->mac);
-		iface_del_eth_addr(member, &bridge->mac);
 		iface_set_promisc(member, false);
 		member->vrf_id = vrf_default_get_or_create();
 		if (member->vrf_id != GR_VRF_ID_UNDEF)
@@ -168,6 +168,7 @@ static int bridge_get_eth_addr(const struct iface *iface, struct rte_ether_addr 
 static int bridge_set_eth_addr(struct iface *iface, const struct rte_ether_addr *mac) {
 	struct iface_info_bridge *bridge = iface_info_bridge(iface);
 	struct rte_ether_addr new_mac;
+	bool deleted = false;
 	int ret;
 
 	if (rte_is_zero_ether_addr(mac)) {
@@ -178,13 +179,20 @@ static int bridge_set_eth_addr(struct iface *iface, const struct rte_ether_addr 
 		new_mac = *mac;
 	}
 
+	// The SVI MAC is programmed into member HW filters through its local FDB
+	// entry (fdb_event_cb / fdb_sync_hardware), not via bridge_all_member_*.
 	if (!rte_is_zero_ether_addr(&bridge->mac)) {
-		if ((ret = bridge_all_member_del_mac(bridge, &bridge->mac)) < 0)
-			return ret;
+		if (fdb_del_local(iface->id, &bridge->mac) < 0)
+			LOG(WARNING, "fdb_del_local(%s): %s", iface->name, strerror(errno));
+		else
+			deleted = true;
 	}
-	if ((ret = bridge_all_member_add_mac(bridge, &new_mac)) < 0)
-		return ret;
 
+	if ((ret = fdb_add_local(iface->id, &new_mac)) < 0) {
+		if (deleted)
+			fdb_add_local(iface->id, &bridge->mac);
+		return errno_set(-ret);
+	}
 	bridge->mac = new_mac;
 
 	return 0;

--- a/modules/l2/control/fdb.c
+++ b/modules/l2/control/fdb.c
@@ -176,6 +176,55 @@ void fdb_purge_iface(uint16_t iface_id) {
 	}
 }
 
+int fdb_add_local(uint16_t bridge_id, const struct rte_ether_addr *mac) {
+	const struct fdb_key key = {bridge_id, 0, *mac};
+	struct fdb_entry *fdb;
+	void *data;
+	int ret;
+
+	if (rte_hash_lookup_data(fdb_hash, &key, &data) >= 0)
+		return errno_set(EEXIST);
+
+	if (rte_mempool_get(fdb_pool, &data) < 0)
+		return errno_set(ENOMEM);
+
+	fdb = data;
+	fdb->prev_iface_id = GR_IFACE_ID_UNDEF;
+	fdb->bridge_id = bridge_id;
+	fdb->vlan_id = 0;
+	fdb->mac = *mac;
+	fdb->flags = GR_FDB_F_LOCAL;
+	fdb->iface_id = bridge_id;
+	memset(&fdb->vtep, 0, sizeof(fdb->vtep));
+	fdb->last_seen = gr_clock_ns();
+
+	if ((ret = rte_hash_add_key_data(fdb_hash, &key, fdb)) < 0) {
+		rte_mempool_put(fdb_pool, fdb);
+		return errno_set(-ret);
+	}
+
+	event_push(GR_EVENT_FDB_ADD, fdb);
+
+	return 0;
+}
+
+int fdb_del_local(uint16_t bridge_id, const struct rte_ether_addr *mac) {
+	const struct fdb_key key = {bridge_id, 0, *mac};
+	struct fdb_entry *fdb;
+	void *data;
+
+	if (rte_hash_lookup_data(fdb_hash, &key, &data) < 0)
+		return errno_set(ENOENT);
+
+	fdb = data;
+	if (!(fdb->flags & GR_FDB_F_LOCAL))
+		return errno_set(EPERM);
+
+	rte_hash_del_key(fdb_hash, &key);
+
+	return 0;
+}
+
 static struct api_out fdb_add(const void *request, struct api_ctx *) {
 	const struct gr_fdb_add_req *req = request;
 	const struct iface *iface;
@@ -217,6 +266,9 @@ static struct api_out fdb_add(const void *request, struct api_ctx *) {
 		event_push(GR_EVENT_FDB_ADD, e);
 	} else if (req->exist_ok) {
 		e = data;
+		if (e->flags & GR_FDB_F_LOCAL)
+			return api_out(EPERM, 0, NULL);
+
 		e->prev_iface_id = e->iface_id;
 		e->base = req->fdb;
 		e->bridge_id = iface->id;
@@ -233,7 +285,15 @@ static struct api_out fdb_add(const void *request, struct api_ctx *) {
 static struct api_out fdb_del(const void *request, struct api_ctx *) {
 	const struct gr_fdb_del_req *req = request;
 	const struct fdb_key key = {req->bridge_id, req->vlan_id, req->mac};
+	void *data;
 	int ret;
+
+	if (rte_hash_lookup_data(fdb_hash, &key, &data) >= 0) {
+		// The bridge's own SVI MAC is managed by the bridge lifecycle.
+		const struct fdb_entry *fdb = data;
+		if (fdb->flags & GR_FDB_F_LOCAL)
+			return api_out(EPERM, 0, NULL);
+	}
 
 	ret = rte_hash_del_key(fdb_hash, &key);
 	if (ret == -ENOENT && req->missing_ok)
@@ -257,6 +317,8 @@ static inline bool fdb_match(
 		return false;
 	if ((flags & GR_FDB_F_EXTERN) && !(e->flags & GR_FDB_F_EXTERN))
 		return false;
+	if ((flags & GR_FDB_F_LOCAL) && !(e->flags & GR_FDB_F_LOCAL))
+		return false;
 	if (bridge_id != GR_IFACE_ID_UNDEF && e->bridge_id != bridge_id)
 		return false;
 	if (iface_id != GR_IFACE_ID_UNDEF && e->iface_id != iface_id)
@@ -273,7 +335,12 @@ static struct api_out fdb_flush(const void *request, struct api_ctx *) {
 	void *data;
 	int ret;
 
+	if (req->flags & ~(GR_FDB_F_STATIC | GR_FDB_F_LEARN))
+		return api_out(EINVAL, 0, NULL);
+
 	while (rte_hash_iterate(fdb_hash, &key, &data, &next) >= 0) {
+		if (((struct fdb_entry *)data)->flags & GR_FDB_F_LOCAL)
+			continue;
 		if (!fdb_match(data, req->flags, req->bridge_id, req->iface_id, &req->mac))
 			continue;
 

--- a/modules/l2/control/l2.h
+++ b/modules/l2/control/l2.h
@@ -39,6 +39,12 @@ void fdb_learn(
 // Delete all FDB entries referencing the provided interface.
 void fdb_purge_iface(uint16_t iface_id);
 
+// Add or update the bridge's own SVI MAC as a local FDB entry.
+int fdb_add_local(uint16_t bridge_id, const struct rte_ether_addr *mac);
+
+// Remove the bridge's own SVI MAC local FDB entry.
+int fdb_del_local(uint16_t bridge_id, const struct rte_ether_addr *mac);
+
 // Push or remove mac addresses from HW Rx filters.
 void fdb_sync_hardware(const struct iface *bridge, struct iface *member, bool add);
 


### PR DESCRIPTION
For inbound unicast to a bridge's own IP to work, the SVI MAC must be resolvable in the FDB. So far grout only got that entry by accident: bridge_input also acts as the SVI output node, so a packet sent by the L3 stack out the bridge re-entered bridge_input with the bridge MAC as source and was learned pointing back at the bridge. Being a learned entry, it aged out after ageing_time (300s) of silence. Once gone, traffic to the SVI MAC turned into unknown unicast: flooded to every member with GR_BRIDGE_F_FLOOD, or dropped without it. Linux avoids this by keeping the bridge MAC as a permanent BR_FDB_LOCAL entry.

Do the same with a GR_FDB_F_LOCAL flag. bridge_set_eth_addr() installs and refreshes the entry with iface_id set to the bridge itself, so bridge_input steers matching frames to local delivery. It never ages, cannot be deleted or flushed over the API, and learning leaves it alone (fdb_learn only touches GR_FDB_F_LEARN entries).

The entry is also the sole owner of the SVI MAC in member HW Rx filters: fdb_event_cb programs it on a MAC change, fdb_sync_hardware on member attach, fdb_iface_del_cb removes it on teardown. This drops the old bridge_all_member_add_mac() path so the MAC is programmed once.

Finally, keep this entry out of FRR. grout_macfdb_change() would push it to zebra as an EVPN type-2 route, which is wrong: the SVI MAC already reaches zebra as the interface hw_addr and is the type-5 router MAC. Skip GR_FDB_F_LOCAL there, both in the event stream and the GR_FDB_LIST resync. The upstream FRR kernel dplane behaves the same, since zebra_neigh_macfdb_update() ignores entries on the bridge device and NUD_PERMANENT ones.