### PR TITLE
trace: cover the gr_mbuf_trace_copy() abandon path

### DIFF
--- a/modules/infra/datapath/mbuf.h
+++ b/modules/infra/datapath/mbuf.h
@@ -55,8 +55,11 @@ static inline bool gr_mbuf_is_traced(struct rte_mbuf *m) {
 // If the mbuf didn't contain any traces, store it as the first one and record
 // the current time into it.
 //
-// This cannot fail. If there are no free trace items available, the trace
-// buffer will be emptied starting from the oldest until one can be returned.
+// This cannot fail. If there are no free trace items available, completed
+// traces are recycled starting from the oldest. When every item is attached
+// to an in-flight packet, tracing for this mbuf is abandoned: its trace chain
+// is freed and a thread-local scratch buffer is returned so that callers can
+// write to it without checking for NULL (the data written there is discarded).
 //
 // Returns a pointer to a gr_trace_item.data buffer.
 void *gr_mbuf_trace_add(struct rte_mbuf *m, struct rte_node *node, size_t data_len);
@@ -65,6 +68,9 @@ void *gr_mbuf_trace_add(struct rte_mbuf *m, struct rte_node *node, size_t data_l
 //
 // This creates a deep copy of the entire trace chain, preserving timestamps,
 // node IDs, and trace data. Used when cloning packets to maintain trace history.
+//
+// If the trace pool is exhausted and no completed trace can be recycled, the
+// copy is abandoned: dst ends up with no traces and src is left unchanged.
 void gr_mbuf_trace_copy(struct rte_mbuf *dst, struct rte_mbuf *src);
 
 // Detach the trace items from an mbuf and store them in the trace buffer.

--- a/modules/infra/datapath/trace_test.c
+++ b/modules/infra/datapath/trace_test.c
@@ -94,6 +94,32 @@ static void exhausted_pool_recycles_completed_traces(void **) {
 	assert_int_equal(rte_mempool_avail_count(trace_pool), 0);
 }
 
+// The abandon path is also reachable from gr_mbuf_trace_copy() via
+// gr_mbuf_copy(): when the pool runs out mid-copy and nothing can be
+// recycled, the partial copy must be freed and the source chain left intact.
+static void exhausted_pool_abandons_trace_copy(void **) {
+	struct gr_trace_item *trace;
+	struct test_mbuf copy;
+	unsigned count;
+
+	STAILQ_INIT(gr_mbuf_traces(&pkt.m));
+	for (unsigned i = 0; i < TRACE_TEST_POOL_SIZE - 2; i++)
+		assert_non_null(gr_mbuf_trace_add(&pkt.m, &fake_node, 0));
+
+	// Two free items remain: the copy exhausts the pool mid-chain.
+	gr_mbuf_trace_copy(&copy.m, &pkt.m);
+
+	// The partial copy was abandoned and its items returned to the pool.
+	assert_true(STAILQ_EMPTY(gr_mbuf_traces(&copy.m)));
+	assert_int_equal(rte_mempool_avail_count(trace_pool), 2);
+
+	// The source chain was not touched.
+	count = 0;
+	STAILQ_FOREACH (trace, gr_mbuf_traces(&pkt.m), next)
+		count++;
+	assert_int_equal(count, TRACE_TEST_POOL_SIZE - 2);
+}
+
 int main(void) {
 	char arg0[] = "trace_test";
 	char arg1[] = "--no-huge";
@@ -110,6 +136,9 @@ int main(void) {
 		cmocka_unit_test_setup_teardown(exhausted_pool_does_not_deadlock, setup, teardown),
 		cmocka_unit_test_setup_teardown(
 			exhausted_pool_recycles_completed_traces, setup, teardown
+		),
+		cmocka_unit_test_setup_teardown(
+			exhausted_pool_abandons_trace_copy, setup, teardown
 		),
 	};
 


### PR DESCRIPTION
Follow-up to #700, addressing the post-merge review comment from @clemenslosbichler-cloud (https://github.com/DPDK/grout/pull/700#issuecomment-5356549563):

- The abandon path added to `gr_mbuf_trace_copy()` in #700 had no test coverage. It is reachable from the datapath via `gr_mbuf_copy()` (`bridge_flood`, `vxlan_flood`, `ip_fragment`) whenever a traced packet is cloned with the trace pool exhausted and nothing left to recycle. Add a test that runs the pool out mid-copy and checks that the partial copy is freed back to the pool while the source chain is preserved.
- `mbuf.h` still described the pre-#700 behavior of `gr_mbuf_trace_add()` ("the trace buffer will be emptied starting from the oldest until one can be returned"). Update it, and mention that `gr_mbuf_trace_copy()` can abandon a partial copy.

I also verified the specific mutation called out in the comment: with `trace_item_get(src, ...)` instead of `dst`, the two existing tests still pass and the new test fails.

## Testing

Full unit suite passes (AlmaLinux 9 container, arm64); `check-patches` and fedora clang-format 22 dry-run are clean.