### PR TITLE
frr: fix bundled build on AlmaLinux 9

### DIFF
--- a/frr/if_grout.c
+++ b/frr/if_grout.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (c) 2025 Maxime Leroy, Free Mobile
 
+#include <lib/zebra.h>
+
 #include "if_grout.h"
 #include "if_map.h"
 #include "l3vni_map.h"

--- a/frr/if_map.c
+++ b/frr/if_map.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (c) 2025 Christophe Fontaine, Red Hat
 
+#include <lib/zebra.h>
+
 #include "if_map.h"
 
 #include <gr_infra.h>

--- a/frr/l3vni_map.c
+++ b/frr/l3vni_map.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (c) 2026 Robin Jarry
 
+#include <lib/zebra.h>
+
 #include "if_map.h"
 #include "l3vni_map.h"
 

--- a/frr/rt_grout.c
+++ b/frr/rt_grout.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (c) 2025 Maxime Leroy, Free Mobile
 
+#include <lib/zebra.h>
+
 #include "if_map.h"
 #include "l3vni_map.h"
 #include "log_grout.h"

--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -2,6 +2,9 @@
 // Copyright (c) 2024 Christophe Fontaine, Red Hat
 // Copyright (c) 2025 Maxime Leroy, Free Mobile
 
+#include <lib/zebra.h>
+#include <linux/rtnetlink.h>
+
 #include <lib/queue.h>
 
 // clang-format off

--- a/subprojects/packagefiles/frr/meson.build
+++ b/subprojects/packagefiles/frr/meson.build
@@ -77,7 +77,7 @@ alias_target('configure', configure)
 
 build_stamp = '.build-stamp'
 install_cmd = 'make install && sh -x ' + srcdir + '/frr_install.sh ' + srcdir + ' ' + prefix + ' && '
-build_cmd = 'cd "' + builddir + '" && make -j && ' + install_cmd + 'touch "' + build_stamp + '"'
+build_cmd = 'cd "' + builddir + '" && make -j${JOBS:-1} && ' + install_cmd + 'touch "' + build_stamp + '"'
 
 build = custom_target(
   'build',
@@ -91,6 +91,7 @@ alias_target('build', build)
 frr_dep = declare_dependency(
   include_directories: include_directories('.', 'lib'),
   compile_args: [
+    '-DHAVE_CONFIG_H',
     '-fms-extensions',
     '-DMULTIPATH_NUM=256',
     '-Wno-missing-field-initializers',


### PR DESCRIPTION
The bundled FRR dplane plugin does not compile on AlmaLinux 9: the
glibc shipped with el9 has no `strlcpy()`/`strlcat()`, and FRR's own
fallback declarations stay hidden because the plugin sources were built
without `HAVE_CONFIG_H`, so every use fails with an implicit function
declaration error. Define `HAVE_CONFIG_H` in the plugin compile args and
include `lib/zebra.h` first in each plugin source so FRR's configuration
and compat layer is loaded before any other header.
`zebra_dplane_grout.c` also gains an explicit `linux/rtnetlink.h`
include for the `RT_TABLE_*` definitions it relies on.

The bundled FRR build also invoked `make -j` with no job limit, which
starts one compiler per translation unit and OOMs memory-constrained
builders such as RPM build chroots and small VMs. The job count now
comes from the `JOBS` environment variable, defaulting to 1; set e.g.
`JOBS=$(nproc)` to keep the previous parallelism on machines that can
afford it.

Found while packaging grout for AlmaLinux 9 as part of the EVPN
multihoming work (#698).

## Testing

- Without the fix (vanilla `main` on AlmaLinux 9, `-Dfrr=enabled`): the
  plugin fails to compile with implicit declarations of
  `strlcpy`/`strlcat`.
- With the fix: the full build including `dplane_grout.so` succeeds in
  the same environment (AlmaLinux 9 container, arm64), and the unit
  suites still pass.

Related: #698
