### PR TITLE
infra: follow active vhost transmit queues

### DIFF
--- a/modules/infra/control/iface_test.c
+++ b/modules/infra/control/iface_test.c
@@ -56,6 +56,7 @@ mock_func(int, port_unplug(struct iface_info_port *));
 mock_func(int, port_plug(struct iface_info_port *));
 mock_func(unsigned, worker_count(void));
 mock_func(int, worker_queue_distribute(const cpu_set_t *, vec struct iface_info_port **));
+mock_func(int, worker_txq_refresh(void));
 mock_func(int, __wrap_rte_eth_allmulticast_enable(uint16_t));
 mock_func(int, __wrap_rte_eth_allmulticast_get(uint16_t));
 mock_func(int, __wrap_rte_eth_dev_mac_addr_add(uint16_t, struct rte_ether_addr *, uint32_t));

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -22,6 +22,7 @@
 #include <rte_build_config.h>
 #include <rte_common.h>
 #include <rte_dev.h>
+#include <rte_eth_vhost.h>
 #include <rte_ethdev.h>
 #include <rte_ether.h>
 
@@ -633,6 +634,7 @@ static int iface_port_init(struct iface *iface, const void *api_info) {
 	port->port_id = port_id;
 	if (rte_eth_dev_info_get(port_id, &info) < 0)
 		return errno_set(-ret);
+	port->dynamic_txq_state = strcmp(info.driver_name, "net_vhost") == 0;
 	port->virtio_offloads = strcmp(info.driver_name, "net_virtio") == 0
 		&& (info.rx_offload_capa & RTE_ETH_RX_OFFLOAD_TCP_CKSUM) != 0;
 
@@ -844,6 +846,7 @@ out:
 }
 
 static struct event *link_event;
+static void txq_state_reset(uint16_t port_id);
 
 static void link_event_cb(evutil_socket_t, short /*what*/, void * /*priv*/) {
 	unsigned max_sleep_us, rx_buffer_us;
@@ -909,11 +912,17 @@ static void link_event_cb(evutil_socket_t, short /*what*/, void * /*priv*/) {
 }
 
 static int lsc_port_cb(
-	uint16_t /*port_id*/,
+	uint16_t port_id,
 	enum rte_eth_event_type,
 	void * /*cb_arg*/,
 	void * /*ret_param*/
 ) {
+	struct rte_eth_link link;
+
+	// net_vhost does not emit queue-disable events when its client disconnects.
+	if (rte_eth_link_get_nowait(port_id, &link) == 0 && link.link_status == RTE_ETH_LINK_DOWN)
+		txq_state_reset(port_id);
+
 	// This callback may be executed from any dataplane or DPDK thread.
 	// In order to serialize the update of port status, propagate the callback
 	// event to the event loop running in the main lcore.
@@ -924,6 +933,111 @@ static int lsc_port_cb(
 static struct event *reset_event;
 static vec uint16_t *reset_ports;
 static pthread_mutex_t reset_ports_lock = PTHREAD_MUTEX_INITIALIZER;
+
+struct txq_state_change {
+	uint16_t port_id;
+	uint16_t queue_id;
+	bool enable;
+	bool reset;
+};
+
+static struct event *txq_state_event;
+static vec struct txq_state_change *txq_state_changes;
+static pthread_mutex_t txq_state_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static void txq_state_reset(uint16_t port_id) {
+	struct txq_state_change change = {
+		.port_id = port_id,
+		.reset = true,
+	};
+
+	pthread_mutex_lock(&txq_state_lock);
+	vec_add(txq_state_changes, change);
+	pthread_mutex_unlock(&txq_state_lock);
+	event_active(txq_state_event, 0, 0);
+}
+
+static int txq_state_intr_cb(
+	uint16_t port_id,
+	enum rte_eth_event_type,
+	void * /*cb_arg*/,
+	void * /*ret_param*/
+) {
+	struct rte_eth_vhost_queue_event event;
+	bool changed = false;
+
+	while (rte_eth_vhost_get_queue_event(port_id, &event) == 0) {
+		// Ethdev TX queues enqueue packets into the guest's RX virtqueues.
+		if (event.rx)
+			continue;
+		struct txq_state_change change = {
+			.port_id = port_id,
+			.queue_id = event.queue_id,
+			.enable = event.enable,
+		};
+		pthread_mutex_lock(&txq_state_lock);
+		vec_add(txq_state_changes, change);
+		pthread_mutex_unlock(&txq_state_lock);
+		changed = true;
+	}
+
+	// Queue callbacks run on DPDK threads. Rebuild graphs on the main lcore.
+	if (changed)
+		event_active(txq_state_event, 0, 0);
+
+	return 0;
+}
+
+static void txq_state_event_cb(evutil_socket_t, short, void * /*priv*/) {
+	vec struct txq_state_change *changes;
+	bool changed = false;
+
+	pthread_mutex_lock(&txq_state_lock);
+	changes = txq_state_changes;
+	txq_state_changes = NULL;
+	pthread_mutex_unlock(&txq_state_lock);
+
+	vec_foreach_ref (struct txq_state_change *change, changes) {
+		const struct iface *iface = port_get_iface(change->port_id);
+		struct iface_info_port *port;
+
+		if (iface == NULL)
+			continue;
+		port = iface_info_port(iface);
+		if (!port->dynamic_txq_state)
+			continue;
+		if (change->reset) {
+			bool reset_changed = false;
+
+			for (uint16_t queue_id = 0; queue_id < port->n_txq; queue_id++) {
+				if (port->txq_enabled[queue_id]) {
+					port->txq_enabled[queue_id] = false;
+					changed = true;
+					reset_changed = true;
+				}
+			}
+			if (reset_changed)
+				LOG(INFO, "%s: reset vhost TX queue state", iface->name);
+			continue;
+		}
+		if (change->queue_id >= port->n_txq)
+			continue;
+		if (port->txq_enabled[change->queue_id] == change->enable)
+			continue;
+
+		port->txq_enabled[change->queue_id] = change->enable;
+		changed = true;
+		LOG(INFO,
+		    "%s: vhost TX queue %u %s",
+		    iface->name,
+		    change->queue_id,
+		    change->enable ? "enabled" : "disabled");
+	}
+	vec_free(changes);
+
+	if (changed && worker_txq_refresh() < 0)
+		LOG(ERR, "worker_txq_refresh: %s", strerror(errno));
+}
 
 static int intr_reset_cb(
 	uint16_t port_id,
@@ -975,6 +1089,14 @@ static void port_init(struct event_base *base) {
 	struct timeval tv = {.tv_sec = 1};
 	if (event_add(link_event, &tv) < 0)
 		ABORT("event_add() failed");
+
+	// net_vhost exposes configured queues before every guest vring is active.
+	txq_state_event = event_new(base, -1, EV_PERSIST | EV_FINALIZE, txq_state_event_cb, NULL);
+	if (txq_state_event == NULL)
+		ABORT("event_new() failed");
+	rte_eth_dev_callback_register(
+		RTE_ETH_ALL, RTE_ETH_EVENT_QUEUE_STATE, txq_state_intr_cb, NULL
+	);
 	rte_eth_dev_callback_register(RTE_ETH_ALL, RTE_ETH_EVENT_INTR_LSC, lsc_port_cb, NULL);
 
 	// register an interrupt callback for port hardware reset events
@@ -988,6 +1110,14 @@ static void port_fini(struct event_base *) {
 	rte_eth_dev_callback_unregister(RTE_ETH_ALL, RTE_ETH_EVENT_INTR_LSC, lsc_port_cb, NULL);
 	event_free(link_event);
 	link_event = NULL;
+	rte_eth_dev_callback_unregister(
+		RTE_ETH_ALL, RTE_ETH_EVENT_QUEUE_STATE, txq_state_intr_cb, NULL
+	);
+	event_free(txq_state_event);
+	txq_state_event = NULL;
+	pthread_mutex_lock(&txq_state_lock);
+	vec_free(txq_state_changes);
+	pthread_mutex_unlock(&txq_state_lock);
 	rte_eth_dev_callback_unregister(RTE_ETH_ALL, RTE_ETH_EVENT_INTR_RESET, intr_reset_cb, NULL);
 	event_free(reset_event);
 	reset_event = NULL;

--- a/modules/infra/control/port.h
+++ b/modules/infra/control/port.h
@@ -20,12 +20,14 @@ GR_IFACE_INFO(GR_IFACE_TYPE_PORT, iface_info_port, {
 	uint16_t port_id;
 	bool started;
 	bool needs_reset;
+	bool dynamic_txq_state;
 	struct rte_mempool *pool;
 	char *devargs;
 	char *linux_ifname;
 	uint32_t pool_size;
 	bool virtio_offloads;
 	uint64_t rx_offloads;
+	bool txq_enabled[RTE_MAX_QUEUES_PER_PORT];
 	rte_spinlock_t txq_locks[RTE_MAX_QUEUES_PER_PORT];
 });
 

--- a/modules/infra/control/worker.c
+++ b/modules/infra/control/worker.c
@@ -293,18 +293,44 @@ static void worker_txq_distribute(vec struct iface_info_port **ports) {
 	vec_foreach (port, ports) {
 		uint16_t txq_idx = 0;
 		STAILQ_FOREACH (worker, &workers, next) {
+			uint16_t queue_id = UINT16_MAX;
+
 			if (vec_len(worker->rxqs) == 0)
 				continue;
 			assert(port->n_txq > 0);
+			for (uint16_t i = 0; i < port->n_txq; i++) {
+				uint16_t candidate = (txq_idx + i) % port->n_txq;
+				if (!port->dynamic_txq_state || port->txq_enabled[candidate]) {
+					queue_id = candidate;
+					txq_idx = candidate + 1;
+					break;
+				}
+			}
+			if (queue_id == UINT16_MAX)
+				continue;
 			struct queue_map txq = {
 				.port_id = port->port_id,
-				.queue_id = txq_idx % port->n_txq,
+				.queue_id = queue_id,
 				.enabled = port->started,
 			};
 			vec_add(worker->txqs, txq);
-			txq_idx++;
 		}
 	}
+}
+
+int worker_txq_refresh(void) {
+	vec struct iface_info_port **ports = NULL;
+	struct iface *iface = NULL;
+	int ret;
+
+	while ((iface = iface_next(GR_IFACE_TYPE_PORT, iface)) != NULL)
+		vec_add(ports, iface_info_port(iface));
+
+	worker_txq_distribute(ports);
+	ret = worker_graph_reload_all(ports);
+	vec_free(ports);
+
+	return ret;
 }
 
 int worker_rxq_assign(uint16_t port_id, uint16_t rxq_id, uint16_t cpu_id) {

--- a/modules/infra/control/worker.h
+++ b/modules/infra/control/worker.h
@@ -96,6 +96,7 @@ extern struct workers workers;
 
 int worker_rxq_assign(uint16_t port_id, uint16_t rxq_id, uint16_t cpu_id);
 int worker_queue_distribute(const cpu_set_t *affinity, vec struct iface_info_port **ports);
+int worker_txq_refresh(void);
 void worker_wait_wakeup(struct worker *);
 void worker_wakeup(struct worker *);
 void worker_wakeup_all(void);

--- a/modules/infra/control/worker_test.c
+++ b/modules/infra/control/worker_test.c
@@ -444,6 +444,34 @@ static void queue_distribute_increase(void **) {
 	assert_qmaps(w5.txqs, q(0, 1), q(1, 1), q(2, 1));
 }
 
+static void txq_refresh_uses_only_active_dynamic_queues(void **) {
+	struct iface_info_port *port = iface_info_port(ifaces[0]);
+
+	common_mocks();
+	port->dynamic_txq_state = true;
+	port->txq_enabled[0] = true;
+	port->txq_enabled[2] = true;
+
+	assert_int_equal(worker_txq_refresh(), 0);
+	assert_qmaps(w1.txqs, q(0, 0), q(1, 0), q(2, 0));
+	assert_qmaps(w2.txqs, q(0, 2), q(1, 1), q(2, 1));
+	assert_qmaps(w3.txqs);
+
+	port->txq_enabled[2] = false;
+	assert_int_equal(worker_txq_refresh(), 0);
+	assert_qmaps(w1.txqs, q(0, 0), q(1, 0), q(2, 0));
+	assert_qmaps(w2.txqs, q(0, 0), q(1, 1), q(2, 1));
+	assert_qmaps(w3.txqs);
+
+	port->txq_enabled[0] = false;
+	assert_int_equal(worker_txq_refresh(), 0);
+	assert_qmaps(w1.txqs, q(1, 0), q(2, 0));
+	assert_qmaps(w2.txqs, q(1, 1), q(2, 1));
+	assert_qmaps(w3.txqs);
+
+	port->dynamic_txq_state = false;
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(rxq_assign_main_lcore),
@@ -451,6 +479,7 @@ int main(void) {
 		cmocka_unit_test(rxq_assign_invalid_port),
 		cmocka_unit_test(rxq_assign_invalid_rxq),
 		cmocka_unit_test(rxq_assign_already_set),
+		cmocka_unit_test(txq_refresh_uses_only_active_dynamic_queues),
 		cmocka_unit_test(rxq_assign_existing_worker),
 		cmocka_unit_test(rxq_assign_existing_worker_destroy),
 		cmocka_unit_test(rxq_assign_new_worker),


### PR DESCRIPTION
## Summary

- track DPDK net_vhost guest receive-virtqueue state
- distribute Grout transmit workers only over active vhost queues
- clear cached queue state when a vhost client disconnects
- refresh worker graphs on the main lcore after queue-state changes

## Problem

A net_vhost device exposes its configured queue count before QEMU enables every guest virtqueue. Grout currently assigns workers across all configured TX queues, so a multiqueue guest can have packets sent to an inactive queue. A single queue hides the problem.

## Validation

- `make check-patches`
- AlmaLinux 9 build with GCC 15 and `-Werror`
- 11/11 applicable unit suites passed with the optional FRR plugin disabled
- four-queue QEMU vhost connect, disconnect, and reconnect smoke test passed on the integration branch

This is kept as a draft while the implementation receives upstream review.