### PR TITLE
srv6: forward the last uA CSID to its adjacency

### DIFF
--- a/modules/srv6/datapath/srv6_local.c
+++ b/modules/srv6/datapath/srv6_local.c
@@ -377,7 +377,16 @@ static int process_behav_end(
 
 		if (csid_shift(&ip6->dst_addr, sr_d->block_bits, sr_d->csid_bits))
 			goto forward;
-		// container exhausted, fall through to standard End
+		// Container exhausted: this was the last CSID. A uA (End.X) is a
+		// cross-connect, it must still hand the packet to its L3 adjacency.
+		// Consume the last CSID, leaving the bare locator block, then
+		// forward. A uN (End) falls through to standard End processing.
+		if (sr_d->behavior == SR_BEHAVIOR_END_X) {
+			memset(&ip6->dst_addr.a[sr_d->block_bits / CHAR_BIT],
+			       0,
+			       sr_d->csid_bits / CHAR_BIT);
+			goto forward;
+		}
 	}
 
 	// at the end of the tunnel
@@ -918,6 +927,41 @@ static void srv6_end_x_next_csid(void **) {
 	assert_int_equal(fm.ip6.dst_addr.a[5], 0x00);
 }
 
+// uA as the last CSID: the container is exhausted but End.X still crosses the
+// adjacency. The consumed CSID is zeroed, leaving the bare locator block.
+static void srv6_end_x_next_csid_last(void **) {
+	struct nexthop l3_nh = {0};
+	struct nexthop_info_srv6_local sr_d = {
+		.base = {
+			.behavior = SR_BEHAVIOR_END_X,
+			.out_vrf_id = GR_VRF_ID_UNDEF,
+			.flags = GR_SR_FL_FLAVOR_NEXT_CSID,
+			.block_bits = 32,
+			// node + function: consumes the whole 32 bit CSID
+			.csid_bits = 32,
+		},
+		.l3_nh = &l3_nh,
+	};
+	struct ip6_info info = {0}, expect;
+	struct fake_mbuf fm;
+
+	fm_init_ipv6(&fm, &expect);
+	fm.ip6.dst_addr = CSID_CONTAINER;
+
+	assert_int_equal(ip6_parse_to_srh(&fm.mbuf, &info), 0);
+	assert_int_equal(process_behav_end(&fm.mbuf, &sr_d, &info), IP6_FORWARD);
+	assert_ptr_equal(l3_mbuf_data(&fm.mbuf)->nh, &l3_nh);
+	// the last CSID is consumed, only the 32 bit locator block remains
+	assert_int_equal(fm.ip6.dst_addr.a[0], 0x5f);
+	assert_int_equal(fm.ip6.dst_addr.a[1], 0x00);
+	assert_int_equal(fm.ip6.dst_addr.a[2], 0x01);
+	assert_int_equal(fm.ip6.dst_addr.a[3], 0x02);
+	assert_int_equal(fm.ip6.dst_addr.a[4], 0x00);
+	assert_int_equal(fm.ip6.dst_addr.a[5], 0x00);
+	assert_int_equal(fm.ip6.dst_addr.a[6], 0x00);
+	assert_int_equal(fm.ip6.dst_addr.a[7], 0x00);
+}
+
 // ---- runner -----------------------------------------------------------------
 int main(void) {
 	const struct CMUnitTest tests[] = {
@@ -932,6 +976,7 @@ int main(void) {
 		cmocka_unit_test(srv6_end_x_usd_no_inner),
 		cmocka_unit_test(srv6_end_next_csid),
 		cmocka_unit_test(srv6_end_x_next_csid),
+		cmocka_unit_test(srv6_end_x_next_csid_last),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/smoke/isis_srv6_adj_sid_frr_test.sh
+++ b/smoke/isis_srv6_adj_sid_frr_test.sh
@@ -128,22 +128,36 @@ assert_nexthop "$nh_id" '.behavior == "end.x"' || {
 	fail "No SRv6-local END.X nexthops found - ISIS SRv6 integration failed"
 }
 
+case "$frr_version" in
+10.5.*|10.6.*|10.7.*)
+	csid_bits=16
+	# 5f00:100:0:1:: shifts to 5f00:100:1::
+	shifted_dst=5f00:100:1::
+	;;
+*)
+	csid_bits=32
+	# the last CSID is consumed, only the block remains
+	shifted_dst=5f00:100::
+	;;
+esac
+
 # behavior usid on the locator makes this a uA, not a plain End.X. The
 # shift parameters come from the locator block and node lengths.
 assert_nexthop "$nh_id" '.flavor | contains(["next-csid"])'
-assert_nexthop "$nh_id" '.block_bits == 32 and .csid_bits == 16'
+assert_nexthop "$nh_id" ".block_bits == 32 and .csid_bits == $csid_bits"
 
 # The locator uses uSID, so the adjacency SID is a uA: grout consumes the
 # active CSID and hands the packet to the peer over the adjacency instead
-# of looking the result up. 5f00:100:0:1:: shifts to 5f00:100:1::, which
-# no route covers, so the packet only comes back out if the L3 nexthop is
-# really used.
+# of looking the result up. The consumed CSID width depends on csid_bits,
+# so the shifted destination differs between FRR versions. Either way it
+# is distinct from the ping destination, so the packet only reaches the peer
+# if the L3 nexthop is really used.
 ip -n isis-peer -6 route add 5f00:100::/48 via 2001:db8:1::1 dev x-p0
 
 # Start the capture before the traffic. ping6 -i0.2 -c5 is done emitting after
 # 0.8s, which tcpdump may not beat to opening its capture.
 capture=$(mktemp)
-ip netns exec isis-peer timeout 5 tcpdump -c1 -pnnli x-p0 ip6 dst 5f00:100:1:: >"$capture" 2>&1 &
+ip netns exec isis-peer timeout 5 tcpdump -c1 -pnnli x-p0 ip6 dst "$shifted_dst" >"$capture" 2>&1 &
 tcpdump_pid=$!
 for _ in $(seq 50); do
 	if grep -q "listening on" "$capture"; then


### PR DESCRIPTION
An End.X with the NEXT-C-SID flavor (a uA) is a cross-connect: it must hand the packet to its L3 adjacency regardless of whether more CSIDs remain in the container. When the uA is the last CSID, csid_shift() sees an empty argument and returns false, so process_behav_end() falls through to the regular End path and delivers the packet locally instead of forwarding it.

This stayed hidden because IS-IS reported csid_bits as the locator node length (16) instead of node plus function (32). The stray function bits kept the shift argument non-zero, so csid_shift() always succeeded. The referenced FRR fix now reports the correct 32 bit width, which exposes the bug: the adjacency SID becomes the sole CSID and the packet is answered locally rather than crossing the adjacency.

Consume the last CSID for End.X, leaving the bare locator block, and forward to the adjacency. Plain End (uN) keeps delivering locally when the container is exhausted.

Version-gate the smoke test csid_bits assertion and the expected shifted destination, since the released 10.5, 10.6 and 10.7 tags still carry the old 16 bit value.

Fixes: c720487b6970 ("srv6: add support for END.X behavior")
Link: https://github.com/FRRouting/frr/commit/515987912bbf2fc3cf12