### PR TITLE
smoke: detect the ISIS uA CSID length instead of the FRR version

### DIFF
--- a/smoke/isis_srv6_adj_sid_frr_test.sh
+++ b/smoke/isis_srv6_adj_sid_frr_test.sh
@@ -128,23 +128,26 @@ assert_nexthop "$nh_id" '.behavior == "end.x"' || {
 	fail "No SRv6-local END.X nexthops found - ISIS SRv6 integration failed"
 }
 
-case "$frr_version" in
-10.5.*|10.6.*|10.7.*)
-	csid_bits=16
-	# 5f00:100:0:1:: shifts to 5f00:100:1::
-	shifted_dst=5f00:100:1::
-	;;
-*)
-	csid_bits=32
-	# the last CSID is consumed, only the block remains
-	shifted_dst=5f00:100::
-	;;
-esac
-
 # behavior usid on the locator makes this a uA, not a plain End.X. The
 # shift parameters come from the locator block and node lengths.
 assert_nexthop "$nh_id" '.flavor | contains(["next-csid"])'
-assert_nexthop "$nh_id" ".block_bits == 32 and .csid_bits == $csid_bits"
+assert_nexthop "$nh_id" '.block_bits == 32'
+
+# isisd reports 16 (node) or 32 (node + function) depending on the build.
+csid_bits=$(grcli -j nexthop show id "$nh_id" | jq -re .csid_bits)
+case "$csid_bits" in
+16)
+	# 5f00:100:0:1:: shifts to 5f00:100:1::
+	shifted_dst=5f00:100:1::
+	;;
+32)
+	# the last CSID is consumed, only the block remains
+	shifted_dst=5f00:100::
+	;;
+*)
+	fail "unexpected csid_bits=$csid_bits, expected 16 or 32"
+	;;
+esac
 
 # The locator uses uSID, so the adjacency SID is a uA: grout consumes the
 # active CSID and hands the packet to the peer over the adjacency instead


### PR DESCRIPTION
The CSID length isisd reports for a combined uA SID was fixed by 515987912bbf ("isisd: Fix NEXT-CSID length for combined uA SIDs") and backported to stable/10.5, stable/10.6 and stable/10.7. Only the release tarballs pinned in the wrap files still carry the old 16 bit value, so the width no longer follows the version number: the test would fail as soon as a wrap points at a point release including the backport.

Read csid_bits back from the nexthop zebra installed and pick the expected shifted destination from it. A width we know nothing about now fails explicitly instead of quietly taking the 32 bit branch.

Fixes: 6c2ee3dfb710 ("srv6: forward the last uA CSID to its adjacency")