### PR TITLE
Diagnostics for developers

### DIFF
--- a/api/gr_api.h
+++ b/api/gr_api.h
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
+// Copyright (c) 2026 SmartShare Systems
 
 #pragma once
 
@@ -57,14 +58,14 @@ gr_api_client_send(struct gr_api_client *, uint32_t req_type, size_t tx_len, con
 
 // Receive an API response with minimum payload size validation.
 // Caller must free(*rx_data) after use.
-// Returns 0 on success, negative errno on failure.
+// Returns response payload size on success, negative errno on failure.
 // Returns -EMSGSIZE if payload is non-empty but smaller than min_resp_size.
 int gr_api_client_recv(struct gr_api_client *, uint32_t req_type, uint32_t for_id, void **rx_data);
 
 // Send a request and receive the response.
 // Validates response payload size against GR_REQ-declared type.
 // Caller must free(*rx_data) after use.
-// Returns 0 on success, negative errno on failure.
+// Returns response payload size on success, negative errno on failure.
 static inline int gr_api_client_send_recv(
 	struct gr_api_client *client,
 	uint32_t req_type,
@@ -84,7 +85,7 @@ int __gr_api_client_stream_drain(struct gr_api_client *, uint32_t req_type, uint
 // Send a request and iterate over the received stream of responses.
 //
 // @param obj Iterator variable (const pointer to response object type).
-// @param ret Final return code of the operation.
+// @param ret Final return code of the operation. (Inside the loop: Response payload size.)
 // @param client API client handle.
 // @param req_type Request type code.
 // @param tx_len Request payload size (0 if tx_data is NULL).
@@ -242,7 +243,7 @@ struct gr_api_event {
 
 // Receive an event notification.
 // Caller must free(*event) after use.
-// Returns 0 on success, negative errno on failure.
+// Returns event size (incl. gr_api_event) on success, negative errno on failure.
 int gr_api_client_event_recv(struct gr_api_client *, struct gr_api_event **);
 
 // Send an arbitrary payload and receive it back echoed from the server.

--- a/api/gr_api_client_impl.h
+++ b/api/gr_api_client_impl.h
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
+// Copyright (c) 2026 SmartShare Systems
 
 // This file must be included in *one* of your client application files.
 
@@ -352,7 +353,7 @@ out:
 		*rx_data = payload;
 	}
 
-	return 0;
+	return resp.payload_len;
 err:
 	free(payload);
 	return -errno;
@@ -378,14 +379,12 @@ int gr_api_client_event_recv(struct gr_api_client *c, struct gr_api_event **even
 		errno = EMSGSIZE;
 		goto err;
 	}
-	if (header.payload_len > 0) {
-		if ((*event = malloc(sizeof(header) + header.payload_len)) == NULL)
-			goto err;
-		**event = header;
-		if (recv_all(c, PAYLOAD(*event), header.payload_len) != (int)header.payload_len)
-			goto err;
-	}
-	return 0;
+	if ((*event = malloc(sizeof(header) + header.payload_len)) == NULL)
+		goto err;
+	**event = header;
+	if (recv_all(c, PAYLOAD(*event), header.payload_len) != (int)header.payload_len)
+		goto err;
+	return sizeof(header) + header.payload_len;
 
 err:
 	free(*event);

--- a/modules/infra/api/diagnos.c
+++ b/modules/infra/api/diagnos.c
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 SmartShare Systems
+
+#include "module.h"
+
+#include <gr_api.h>
+#include <gr_infra.h>
+
+#include <rte_bus.h>
+#include <rte_bus_pci.h>
+#include <rte_graph.h>
+#include <rte_lcore.h>
+#include <rte_log.h>
+#include <rte_malloc.h>
+#include <rte_mbuf_dyn.h>
+#include <rte_memory.h>
+#include <rte_mempool.h>
+#include <rte_memzone.h>
+#include <rte_ring.h>
+#include <rte_tailq.h>
+#include <rte_trace.h>
+
+static void graph_dump(FILE *f, struct rte_graph *graph) {
+	rte_graph_obj_dump(f, graph, true);
+}
+
+static void malloc_dump_stats(FILE *f) {
+	rte_malloc_dump_stats(f, NULL);
+}
+
+static void node_dump(FILE *f, void *id) {
+	rte_node_dump(f, (rte_node_t)(uintptr_t)id);
+}
+
+static void *node_from_name(const char *name) {
+	rte_node_t id = rte_node_from_name(name);
+	return id != RTE_NODE_ID_INVALID ? (void *)(uintptr_t)id : NULL;
+}
+
+typedef void (*dump_list_fn_t)(FILE *f);
+typedef void (*dump_fn_t)(FILE *f, void *obj);
+typedef void *(*lookup_fn_t)(const char *name);
+
+static const struct obj_dump_helper {
+	char *type;
+	dump_list_fn_t dump_list_fn;
+	dump_fn_t dump_fn;
+	lookup_fn_t lookup_fn;
+} obj_dump_helpers[] = {
+	// DPDK libs, in alphabetical order.
+	{"bus", rte_bus_dump, NULL, (lookup_fn_t)rte_bus_find_by_name},
+	{"graph", rte_graph_list_dump, (dump_fn_t)graph_dump, (lookup_fn_t)rte_graph_lookup},
+	{"lcore", rte_lcore_dump, NULL, NULL},
+	{"log", rte_log_dump, NULL, NULL},
+	{"malloc_heaps", rte_malloc_dump_heaps, NULL, NULL},
+	{"malloc_stats", malloc_dump_stats, NULL, NULL},
+	{"mbuf_dyn", rte_mbuf_dyn_dump, NULL, NULL},
+	{"mempool",
+	 rte_mempool_list_dump,
+	 (dump_fn_t)rte_mempool_dump,
+	 (lookup_fn_t)rte_mempool_lookup},
+	{"memzone", rte_memzone_dump, NULL, NULL},
+	{"node", rte_node_list_dump, node_dump, node_from_name},
+	{"pci", rte_pci_dump, NULL, NULL},
+	{"physmem_layout", rte_dump_physmem_layout, NULL, NULL},
+	{"ring", rte_ring_list_dump, (dump_fn_t)rte_ring_dump, (lookup_fn_t)rte_ring_lookup},
+	{"tailq", rte_dump_tailq, NULL, NULL},
+	{"trace", rte_trace_dump, NULL, NULL},
+	{NULL, NULL, NULL, NULL},
+};
+
+static struct api_out obj_dump(const void *request, struct api_ctx *ctx) {
+	const struct gr_diagnos_obj_dump_req *req = request;
+	const struct obj_dump_helper *helper;
+	void *obj = NULL;
+	char *buf = NULL;
+	size_t len = 0, pos, payload_len;
+	FILE *f;
+
+	if (*req->type == 0)
+		return api_out(EINVAL, 0, NULL);
+	if (strnlen(req->type, sizeof(req->type)) == sizeof(req->type))
+		return api_out(ENAMETOOLONG, 0, NULL);
+
+	// Lookup object type.
+	for (helper = obj_dump_helpers; helper->type != NULL; helper++)
+		if (strncmp(helper->type, req->type, sizeof(req->type)) == 0)
+			break;
+	if (helper->type == NULL)
+		return api_out(EINVAL, 0, NULL); // Object type not supported.
+
+	// If name provided, lookup object.
+	if (*req->name != 0) {
+		if (strnlen(req->name, sizeof(req->name)) == sizeof(req->name))
+			return api_out(ENAMETOOLONG, 0, NULL);
+		if (helper->lookup_fn == NULL || helper->dump_fn == NULL)
+			return api_out(EINVAL, 0, NULL); // Name lookup/dump not supported.
+		if ((obj = helper->lookup_fn(req->name)) == NULL)
+			return api_out(ENOENT, 0, NULL); // Not found.
+	}
+
+	f = open_memstream(&buf, &len);
+	if (obj != NULL)
+		helper->dump_fn(f, obj);
+	else
+		helper->dump_list_fn(f);
+	fclose(f);
+
+	for (pos = 0; pos < len; pos += payload_len) {
+		payload_len = RTE_MIN((size_t)GR_API_MAX_MSG_LEN, len - pos);
+		api_send(ctx, payload_len, buf + pos);
+	}
+
+	free(buf);
+
+	return api_out(0, 0, NULL);
+}
+
+RTE_INIT(diagnos_init) {
+	api_handler(GR_DIAGNOS_OBJ_DUMP, obj_dump);
+}

--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -255,6 +255,7 @@ enum gr_infra_requests : uint32_t {
 	GR_IFACE_MAC_SET,
 	GR_IFACE_CONFIG_GET,
 	GR_IFACE_CONFIG_SET,
+	GR_DIAGNOS_OBJ_DUMP,
 };
 
 enum gr_infra_events : uint32_t {
@@ -507,6 +508,24 @@ struct gr_packet_trace_set_req {
 };
 
 GR_REQ(GR_PACKET_TRACE_SET, struct gr_packet_trace_set_req, struct gr_empty);
+
+// diagnostics (for developers) ////////////////////////////////////////////////
+
+// Dump an object.
+struct gr_diagnos_obj_dump_req {
+#define GR_DIAGNOS_OBJ_DUMP_ID_SIZE 128
+	char type[GR_DIAGNOS_OBJ_DUMP_ID_SIZE];
+	char name[GR_DIAGNOS_OBJ_DUMP_ID_SIZE]; // All if empty.
+};
+
+// Stream of unstructured text.
+// Not NUL-terminated.
+// This struct only serves for API type validation and compatibility.
+struct gr_diagnos_obj_dump_resp {
+	char text[1];
+};
+
+GR_REQ_STREAM(GR_DIAGNOS_OBJ_DUMP, struct gr_diagnos_obj_dump_req, struct gr_diagnos_obj_dump_resp);
 
 // cpu affinities //////////////////////////////////////////////////////////////
 

--- a/modules/infra/api/meson.build
+++ b/modules/infra/api/meson.build
@@ -3,6 +3,7 @@
 
 src += files(
   'affinity.c',
+  'diagnos.c',
   'iface.c',
   'nexthop.c',
   'stats.c',

--- a/modules/infra/cli/diagnos.c
+++ b/modules/infra/cli/diagnos.c
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 SmartShare Systems
+
+#include "cli.h"
+
+#include <gr_api.h>
+#include <gr_infra.h>
+
+#include <ecoli.h>
+
+#include <stdio.h>
+
+static cmd_status_t obj_dump(struct gr_api_client *c, const struct ec_pnode *p) {
+	const struct gr_diagnos_obj_dump_resp *resp = NULL;
+	struct gr_diagnos_obj_dump_req req;
+	const char *type = NULL;
+	const char *name = NULL;
+	int ret;
+
+	if ((type = arg_str(p, "TYPE")) == NULL
+	    || strlcpy(req.type, type, sizeof(req.type)) >= sizeof(req.type))
+		return CMD_ERROR;
+
+	*req.name = 0;
+	if ((name = arg_str(p, "NAME")) != NULL
+	    && strlcpy(req.name, name, sizeof(req.name)) >= sizeof(req.name))
+		return CMD_ERROR;
+
+	gr_api_client_stream_foreach (resp, ret, c, GR_DIAGNOS_OBJ_DUMP, sizeof(req), &req)
+		fwrite(resp->text, 1, ret, stdout);
+
+	if (ret < 0)
+		return CMD_ERROR;
+
+	return CMD_SUCCESS;
+}
+
+#define DIAGNOS_CTX(root) CLI_CONTEXT(root, CTX_ARG("diagnostics", "Diagnostics (for developers)."))
+
+static int ctx_init(struct ec_node *root) {
+	int ret;
+
+	ret = CLI_COMMAND(
+		DIAGNOS_CTX(root),
+		"object dump TYPE [NAME]",
+		obj_dump,
+		"Dump object.",
+		with_help("Object type.", ec_node("any", "TYPE")),
+		with_help("Specific object.", ec_node("any", "NAME"))
+	);
+	if (ret < 0)
+		return ret;
+
+	return 0;
+}
+
+static struct cli_context ctx = {
+	.name = "diagnostics",
+	.init = ctx_init,
+};
+
+static void __attribute__((constructor, used)) init(void) {
+	cli_context_register(&ctx);
+}

--- a/modules/infra/cli/events.c
+++ b/modules/infra/cli/events.c
@@ -83,7 +83,7 @@ static cmd_status_t events_show(struct gr_api_client *c, const struct ec_pnode *
 	sigaction(SIGPIPE, &sa, &old_pipe);
 
 	stop = false;
-	while (!stop && gr_api_client_event_recv(c, &e) == 0) {
+	while (!stop && gr_api_client_event_recv(c, &e) >= 0) {
 		printf("> ");
 
 		printer = get_event_printer(e->ev_type);

--- a/modules/infra/cli/meson.build
+++ b/modules/infra/cli/meson.build
@@ -5,6 +5,7 @@ cli_src += files(
   'address.c',
   'affinity.c',
   'bond.c',
+  'diagnos.c',
   'events.c',
   'graph.c',
   'icmp.c',


### PR DESCRIPTION
This series comprises of two patches:

**1. Update the Client API to make the response payload size available to the client**
The response payload size is already present in the response header, but the response header is not exposed to the client.
Without this Client API update, it would be necessary for variable size responses to include a length field in the response payload. Such a redundant length field can now be avoided, which makes the Grout code for both the api and the cli much cleaner for responses of this kind.

**2. Add API and CLI for developer diagnostics**
Initially, add message/command to dump various DPDK objects.
More messages/commands can be added later.

It is a resubmission of https://github.com/DPDK/grout/pull/725, with the CLI command changed from "diagnos" to "diagnostics".