### PR TITLE
ip,ip6: fix locally originated pings through tunnel nexthops

### DIFF
--- a/modules/ip/control/address.c
+++ b/modules/ip/control/address.c
@@ -57,6 +57,34 @@ static struct nexthop *addr4_get_preferred_iface(uint16_t iface_id, ip4_addr_t d
 	return addrs->nh[0];
 }
 
+struct nexthop *addr4_get_preferred_vrf(uint16_t vrf_id, ip4_addr_t dst) {
+	const struct iface *iface = NULL;
+	struct nexthop *pref = NULL, *nh;
+	struct iface *vrf_iface;
+
+	vrf_iface = get_vrf_iface(vrf_id);
+	if (vrf_iface == NULL)
+		return NULL;
+
+	if ((nh = addr4_get_preferred_iface(vrf_iface->id, dst)) != NULL)
+		return nh;
+
+	while ((iface = iface_next(GR_IFACE_TYPE_UNDEF, iface)) != NULL) {
+		if (iface->vrf_id != vrf_id || iface->id == vrf_iface->id)
+			continue;
+		if ((nh = addr4_get_preferred_iface(iface->id, dst)) == NULL)
+			continue;
+		if (ip4_addr_same_subnet(
+			    dst, nexthop_info_l3(nh)->ipv4, nexthop_info_l3(nh)->prefixlen
+		    ))
+			return nh;
+		if (pref == NULL)
+			pref = nh;
+	}
+
+	return pref != NULL ? pref : errno_set_null(EADDRNOTAVAIL);
+}
+
 struct nexthop *addr4_get_preferred(uint16_t iface_id, ip4_addr_t dst) {
 	const struct iface *iface;
 	struct iface *vrf_iface;

--- a/modules/ip/control/ip4.h
+++ b/modules/ip/control/ip4.h
@@ -64,6 +64,7 @@ int rib4_iter(uint16_t vrf_id, struct rib4_iterator *);
 
 // get the default address for a given interface
 struct nexthop *addr4_get_preferred(uint16_t iface_id, ip4_addr_t dst);
+struct nexthop *addr4_get_preferred_vrf(uint16_t vrf_id, ip4_addr_t dst);
 // get all addresses for a given interface
 struct hoplist *addr4_get_all(uint16_t iface_id);
 

--- a/modules/ip/datapath/icmp_local_send.c
+++ b/modules/ip/datapath/icmp_local_send.c
@@ -39,23 +39,36 @@ int icmp_local_send(
 ) {
 	struct icmp_send_mbuf_data *d;
 	const struct nexthop *local;
-	struct iface *iface;
+	struct iface *iface, *out, *pool_iface;
 	struct rte_mbuf *m;
 	int ret;
 
-	// FIXME
-	if (gw->type != GR_NH_T_L3)
+	// Only these nexthop types have an output path. The others, DNAT in
+	// particular, are registered on ip_input and never carry a locally
+	// generated packet.
+	if (gw->type != GR_NH_T_L3 && gw->type != GR_NH_T_SR6_OUTPUT)
 		return errno_set(ENONET);
 
-	if ((local = addr4_get_preferred(gw->iface_id, dst)) == NULL) {
+	out = iface_from_id(gw->iface_id);
+	local = NULL;
+	if (out != NULL && out->vrf_id == vrf_id)
+		local = addr4_get_preferred(gw->iface_id, dst);
+	if (local == NULL)
+		local = addr4_get_preferred_vrf(vrf_id, dst);
+	if (local == NULL)
 		return -errno;
-	}
 
-	iface = iface_from_id(gw->iface_id);
-	if (iface == NULL || iface->pool == NULL)
+	iface = iface_from_id(local->iface_id);
+	if (iface == NULL)
 		return errno_set(ENODEV);
 
-	m = rte_pktmbuf_alloc(iface->pool);
+	// Only the interfaces packets originate from have a mempool. The source
+	// address may live on one which has none, fall back to the VRF loopback.
+	pool_iface = iface->pool != NULL ? iface : get_vrf_iface(vrf_id);
+	if (pool_iface == NULL || pool_iface->pool == NULL)
+		return errno_set(ENODEV);
+
+	m = rte_pktmbuf_alloc(pool_iface->pool);
 	if (m == NULL)
 		return errno_set(ENOMEM);
 

--- a/modules/ip/datapath/icmp_local_send.c
+++ b/modules/ip/datapath/icmp_local_send.c
@@ -52,7 +52,7 @@ int icmp_local_send(
 	}
 
 	iface = iface_from_id(gw->iface_id);
-	if (iface == NULL)
+	if (iface == NULL || iface->pool == NULL)
 		return errno_set(ENODEV);
 
 	m = rte_pktmbuf_alloc(iface->pool);

--- a/modules/ip6/control/address.c
+++ b/modules/ip6/control/address.c
@@ -61,6 +61,34 @@ addr6_get_preferred_iface(uint16_t iface_id, const struct rte_ipv6_addr *dst) {
 	return pref;
 }
 
+struct nexthop *addr6_get_preferred_vrf(uint16_t vrf_id, const struct rte_ipv6_addr *dst) {
+	const struct iface *iface = NULL;
+	struct nexthop *pref = NULL, *nh;
+	struct iface *vrf_iface;
+
+	vrf_iface = get_vrf_iface(vrf_id);
+	if (vrf_iface == NULL)
+		return NULL;
+
+	if ((nh = addr6_get_preferred_iface(vrf_iface->id, dst)) != NULL)
+		return nh;
+
+	while ((iface = iface_next(GR_IFACE_TYPE_UNDEF, iface)) != NULL) {
+		if (iface->vrf_id != vrf_id || iface->id == vrf_iface->id)
+			continue;
+		if ((nh = addr6_get_preferred_iface(iface->id, dst)) == NULL)
+			continue;
+		if (rte_ipv6_addr_eq_prefix(
+			    dst, &nexthop_info_l3(nh)->ipv6, nexthop_info_l3(nh)->prefixlen
+		    ))
+			return nh;
+		if (pref == NULL)
+			pref = nh;
+	}
+
+	return pref != NULL ? pref : errno_set_null(EADDRNOTAVAIL);
+}
+
 struct nexthop *addr6_get_preferred(uint16_t iface_id, const struct rte_ipv6_addr *dst) {
 	const struct iface *iface;
 	struct iface *vrf_iface;

--- a/modules/ip6/control/ip6.h
+++ b/modules/ip6/control/ip6.h
@@ -101,6 +101,7 @@ int rib6_iter(uint16_t vrf_id, struct rib6_iterator *);
 
 // get the default address for a given interface
 struct nexthop *addr6_get_preferred(uint16_t iface_id, const struct rte_ipv6_addr *);
+struct nexthop *addr6_get_preferred_vrf(uint16_t vrf_id, const struct rte_ipv6_addr *);
 // get the link-local address for a given interface
 struct nexthop *addr6_get_linklocal(uint16_t iface_id);
 // get all addresses for a given interface

--- a/modules/ip6/datapath/icmp6_local_send.c
+++ b/modules/ip6/datapath/icmp6_local_send.c
@@ -40,22 +40,36 @@ int icmp6_local_send(
 ) {
 	struct icmp6_send_mbuf_data *d;
 	const struct nexthop *local;
-	struct iface *iface;
+	struct iface *iface, *out, *pool_iface;
 	struct rte_mbuf *m;
 	int ret;
 
-	// FIXME
-	if (gw->type != GR_NH_T_L3)
+	// Only these nexthop types have an output path. The others, DNAT in
+	// particular, are registered on ip_input and never carry a locally
+	// generated packet.
+	if (gw->type != GR_NH_T_L3 && gw->type != GR_NH_T_SR6_OUTPUT)
 		return errno_set(ENONET);
 
-	if ((local = addr6_get_preferred(gw->iface_id, dst)) == NULL)
+	out = iface_from_id(gw->iface_id);
+	local = NULL;
+	if (out != NULL && out->vrf_id == gw->vrf_id)
+		local = addr6_get_preferred(gw->iface_id, dst);
+	if (local == NULL)
+		local = addr6_get_preferred_vrf(gw->vrf_id, dst);
+	if (local == NULL)
 		return -errno;
 
-	iface = iface_from_id(gw->iface_id);
-	if (iface == NULL || iface->pool == NULL)
+	iface = iface_from_id(local->iface_id);
+	if (iface == NULL)
 		return errno_set(ENODEV);
 
-	m = rte_pktmbuf_alloc(iface->pool);
+	// Only the interfaces packets originate from have a mempool. The source
+	// address may live on one which has none, fall back to the VRF loopback.
+	pool_iface = iface->pool != NULL ? iface : get_vrf_iface(gw->vrf_id);
+	if (pool_iface == NULL || pool_iface->pool == NULL)
+		return errno_set(ENODEV);
+
+	m = rte_pktmbuf_alloc(pool_iface->pool);
 	if (m == NULL)
 		return errno_set(ENOMEM);
 

--- a/modules/ip6/datapath/icmp6_local_send.c
+++ b/modules/ip6/datapath/icmp6_local_send.c
@@ -52,7 +52,7 @@ int icmp6_local_send(
 		return -errno;
 
 	iface = iface_from_id(gw->iface_id);
-	if (iface == NULL)
+	if (iface == NULL || iface->pool == NULL)
 		return errno_set(ENODEV);
 
 	m = rte_pktmbuf_alloc(iface->pool);

--- a/smoke/ip6_forward_test.sh
+++ b/smoke/ip6_forward_test.sh
@@ -32,6 +32,7 @@ ip netns exec n1 ping6 -i0.01 -c3 -n fd00:f00:2::2
 ip netns exec n2 ping6 -i0.01 -c3 -n fd00:f00:1::2
 ip netns exec n1 ping6 -i0.01 -c3 -n fd00:ba4:2::2
 ip netns exec n2 ping6 -i0.01 -c3 -n fd00:ba4:1::2
+grcli ping fd00:ba4:1::2 count 3 || fail "grcli ping6 failed"
 # Verify that NDP neighbor advertisement flags are correct (RFC 4861 §4.4).
 # The Solicited flag must be set in NA replies, otherwise Linux never
 # transitions the neighbor entry to REACHABLE.

--- a/smoke/ipip_encap_test.sh
+++ b/smoke/ipip_encap_test.sh
@@ -26,3 +26,4 @@ ip -n n1 route add default via 10.98.0.1
 
 ip netns exec n0 ping -i0.01 -c3 -n 10.98.0.2
 ip netns exec n1 ping -i0.01 -c3 -n 10.99.0.2
+grcli ping 10.98.0.2 count 3 || fail "grcli ping through an ipip nexthop failed"

--- a/smoke/srv6_test.sh
+++ b/smoke/srv6_test.sh
@@ -60,6 +60,7 @@ grcli route add fd00:202:100::/48 via id 666
 
 # test
 ip netns exec n0 ping -i0.01 -c3 -n 192.168.60.1
+grcli ping 192.168.60.1 count 3 || fail "grcli ping through an SRv6 nexthop failed"
 # check that sid is reachable
 ip netns exec n1 ping6 -i0.01 -c3 -n fd00:202:100::
 
@@ -135,6 +136,7 @@ ip -n n1 -6 route add fd00:202::/32 via fd00:102::1 dev x-p1 table 10
 
 # test
 ip netns exec n0 ping6 -i0.01 -c3 -n fd00:60::1
+grcli ping fd00:60::1 count 3 || fail "grcli ping through an SRv6 nexthop failed (IPv6)"
 
 #
 # Multi-segment encapsulation test


### PR DESCRIPTION
icmp_local_send() takes the source address and the mbuf pool from the
  nexthop interface. True for a direct route, false for a tunnel.

  An ipip nexthop is L3 on the tunnel interface, which carries an address
  but no mempool: rte_pktmbuf_alloc() gets NULL and grout dies on SIGSEGV.
  An SRv6 nexthop transmits in the underlay, so its interface is in another
  VRF and holds no overlay address; the source is borrowed from the
  underlay and the reply never comes back. That one was hidden by a
  `// FIXME` refusing any non GR_NH_T_L3 nexthop with ENONET.

  First commit: reject an interface without a mempool like a missing one.                                                                                                                     
  Second: pick the source in vrf_id, which the caller already passes, keep
  the per-interface choice when that interface is in the VRF, allocate from
  the VRF loopback otherwise. addr4_get_preferred_vrf() and its IPv6 twin
  scan a VRF's interfaces, which nothing did before.

  The FIXME becomes a check that says what it means: only GR_NH_T_L3 and
  GR_NH_T_SR6_OUTPUT have an output path. DNAT is registered on ip_input,
  so a local ping to a DNAT address is still refused, as under Linux;
  letting one through aborts on the nexthop_info_l3() assertion.

  Three of the four smoke assertions added fail without these changes: an
  SRv6 nexthop in v4 and v6, and the ipip tunnel. The fourth covers the
  ordinary IPv6 path, which had no coverage. Each commit is green alone.

  Not addressed: grcli ping ignores the GR_IP4_ICMP_SEND status, so a
  failed send prints nothing.
