### PR TITLE
infra,l2: do not round mempool sizes up to a power of 2

### DIFF
--- a/modules/infra/control/mempool.c
+++ b/modules/infra/control/mempool.c
@@ -76,7 +76,6 @@ struct rte_mempool *gr_pktmbuf_pool_get(int8_t socket_id, uint32_t count) {
 			alloc_size = mempool_default_size;
 			if (count > mempool_default_size / 4) {
 				alloc_size = count * 2;
-				alloc_size = rte_align32pow2(alloc_size) - 1;
 				// For future mempools, increase default size;
 				mempool_default_size = alloc_size;
 			}

--- a/modules/infra/control/nexthop.c
+++ b/modules/infra/control/nexthop.c
@@ -61,7 +61,7 @@ static struct rte_mempool *create_mempool(const struct gr_nexthop_config *c) {
 	snprintf(name, sizeof(name), "nexthops-%u", c->max_count);
 	struct rte_mempool *p = rte_mempool_create(
 		name,
-		rte_align32pow2(c->max_count) - 1,
+		c->max_count,
 		sizeof(struct nexthop),
 		0, // cache size
 		0, // priv size

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -135,7 +135,6 @@ int port_configure(struct iface_info_port *p, uint16_t n_txq_min) {
 	mbuf_count = rxq_size * p->n_rxq;
 	mbuf_count += txq_size * p->n_txq;
 	mbuf_count += RTE_GRAPH_BURST_SIZE;
-	mbuf_count = rte_align32pow2(mbuf_count) - 1;
 	if (mbuf_count != p->pool_size) {
 		p->pool = gr_pktmbuf_pool_resize(p->pool, socket_id, p->pool_size, mbuf_count);
 		p->pool_size = p->pool ? mbuf_count : 0;

--- a/modules/infra/datapath/trace.c
+++ b/modules/infra/datapath/trace.c
@@ -937,7 +937,7 @@ void gr_trace_clear(void) {
 static void trace_init(struct event_base *) {
 	trace_pool = rte_mempool_create(
 		"trace_items", // name
-		rte_align32pow2(PACKET_COUNT_MAX * 128) - 1,
+		PACKET_COUNT_MAX * 128,
 		sizeof(struct gr_trace_item),
 		0, // cache size
 		0, // priv size

--- a/modules/infra/datapath/trace_test.c
+++ b/modules/infra/datapath/trace_test.c
@@ -15,8 +15,7 @@ const struct gr_node_info *gr_node_info_get(rte_node_t) {
 	return NULL;
 }
 
-// Pool sized so a single packet can exhaust it. Optimal mempool sizes are
-// 2^n - 1.
+// Pool sized so a single packet can exhaust it.
 #define TRACE_TEST_POOL_SIZE 7
 
 static struct test_mbuf {

--- a/modules/l2/control/fdb.c
+++ b/modules/l2/control/fdb.c
@@ -54,7 +54,7 @@ static int fdb_reconfig(unsigned max_entries) {
 
 	struct rte_mempool *p = rte_mempool_create(
 		name,
-		rte_align32pow2(max_entries) - 1,
+		max_entries,
 		sizeof(struct fdb_entry),
 		0, // cache size
 		0, // priv size


### PR DESCRIPTION
This power-of-2-alignment was based on obsolete advice in the pktmbuf_pool/mempool creation functions: DPDK/dpdk@3d520f5

Closes: https://github.com/DPDK/grout/issues/738
Reported-By: Morten Brørup <mb@smartsharesystems.com>