### PR TITLE
infra: hash the flows that arrive without an RSS value

### DIFF
--- a/modules/infra/datapath/bond_output.c
+++ b/modules/infra/datapath/bond_output.c
@@ -2,17 +2,13 @@
 // Copyright (c) 2025 Robin Jarry
 
 #include "bond.h"
+#include "flow_hash.h"
 #include "graph.h"
 #include "iface.h"
 #include "mbuf.h"
 #include "rxtx.h"
 
 #include <rte_ether.h>
-#include <rte_ip4.h>
-#include <rte_ip6.h>
-#include <rte_tcp.h>
-#include <rte_thash.h>
-#include <rte_udp.h>
 
 #include <stdint.h>
 
@@ -34,28 +30,13 @@ static int bond_trace_format(char *buf, size_t len, const void *data, size_t /*d
 
 static inline const struct iface *
 hash_tx_member(const struct rte_mbuf *m, const struct iface_info_bond *bond) {
-	static const uint8_t rss_key[] = {
-		0x6d, 0x5a, 0x56, 0xda, 0x25, 0x5b, 0x0e, 0xc2, 0x41, 0x67, 0x25, 0x3d, 0x43, 0xa3,
-		0x8f, 0xb0, 0xd0, 0xca, 0x2b, 0xcb, 0xae, 0x7b, 0x30, 0xb4, 0x77, 0xcb, 0x2d, 0xa3,
-		0x80, 0x30, 0xf2, 0x0c, 0x6a, 0x42, 0xb7, 0x3b, 0xbe, 0xac, 0x01, 0xfa,
-	};
 	union {
 		uint32_t u32;
 		struct {
 			struct rte_ether_addr mac;
 			rte_be16_t vlan_id;
 		} l2;
-		struct rte_ipv4_tuple v4;
-		struct rte_ipv6_tuple v6;
 	} tuple;
-	union {
-		const struct rte_ipv4_hdr *ip4;
-		const struct rte_ipv6_hdr *ip6;
-	} l3;
-	union {
-		const struct rte_udp_hdr *udp;
-		const struct rte_tcp_hdr *tcp;
-	} l4;
 	const struct rte_ether_hdr *eth;
 	const struct rte_vlan_hdr *vlan;
 	uint32_t l3_offset, len, hash;
@@ -96,85 +77,16 @@ hash_tx_member(const struct rte_mbuf *m, const struct iface_info_bond *bond) {
 			eth_type = eth->ether_type;
 			l3_offset = sizeof(*eth);
 		}
-		switch (eth_type) {
-		case RTE_BE16(RTE_ETHER_TYPE_IPV4): {
-			l3.ip4 = rte_pktmbuf_mtod_offset(m, struct rte_ipv4_hdr *, l3_offset);
-			tuple.v4.src_addr = l3.ip4->src_addr;
-			tuple.v4.dst_addr = l3.ip4->dst_addr;
-			switch (l3.ip4->next_proto_id) {
-			case IPPROTO_UDP:
-				if (l3.ip4->fragment_offset == 0) {
-					l4.udp = rte_pktmbuf_mtod_offset(
-						m,
-						struct rte_udp_hdr *,
-						l3_offset + rte_ipv4_hdr_len(l3.ip4)
-					);
-					tuple.v4.sport = l4.udp->src_port;
-					tuple.v4.dport = l4.udp->dst_port;
-				} else {
-					// ignore UDP header for IP fragments
-					tuple.v4.sport = 0;
-					tuple.v4.dport = 0;
-				}
-				break;
-			case IPPROTO_TCP:
-				if (l3.ip4->fragment_offset == 0) {
-					l4.tcp = rte_pktmbuf_mtod_offset(
-						m,
-						struct rte_tcp_hdr *,
-						l3_offset + rte_ipv4_hdr_len(l3.ip4)
-					);
-					tuple.v4.sport = l4.tcp->src_port;
-					tuple.v4.dport = l4.tcp->dst_port;
-				} else {
-					// ignore TCP header for IP fragments
-					tuple.v4.sport = 0;
-					tuple.v4.dport = 0;
-				}
-				break;
-			default:
-				tuple.v4.sport = 0;
-				tuple.v4.dport = 0;
-			}
-			len = sizeof(tuple.v4);
-			break;
-		}
-		case RTE_BE16(RTE_ETHER_TYPE_IPV6): {
-			l3.ip6 = rte_pktmbuf_mtod_offset(m, const struct rte_ipv6_hdr *, l3_offset);
-			tuple.v6.src_addr = l3.ip6->src_addr;
-			tuple.v6.dst_addr = l3.ip6->dst_addr;
-			switch (l3.ip6->proto) {
-			case IPPROTO_UDP:
-				l4.udp = rte_pktmbuf_mtod_offset(
-					m, struct rte_udp_hdr *, l3_offset + sizeof(*l3.ip6)
-				);
-				tuple.v6.sport = l4.udp->src_port;
-				tuple.v6.dport = l4.udp->dst_port;
-				break;
-			case IPPROTO_TCP:
-				l4.tcp = rte_pktmbuf_mtod_offset(
-					m, struct rte_tcp_hdr *, l3_offset + sizeof(*l3.ip6)
-				);
-				tuple.v6.sport = l4.tcp->src_port;
-				tuple.v6.dport = l4.tcp->dst_port;
-				break;
-			default:
-				tuple.v6.sport = 0;
-				tuple.v6.dport = 0;
-			}
-			len = sizeof(tuple.v6);
-			break;
-		}
-		default:
-			len = sizeof(tuple.l2);
-			break;
-		}
+		if (flow_hash_l3l4(m, l3_offset, eth_type, &hash))
+			goto out;
+		// not an IP packet, fall back on the L2 tuple
+		len = sizeof(tuple.l2);
 		break;
 	default:
 		return NULL;
 	}
 
-	hash = rte_softrss_be(&tuple.u32, len / sizeof(uint32_t), rss_key);
+	hash = flow_hash_words(&tuple.u32, len / sizeof(uint32_t));
 out:
 	member = bond->redirection_table[hash % ARRAY_DIM(bond->redirection_table)];
 	if (member < bond->n_members)

--- a/modules/infra/datapath/eth_input.c
+++ b/modules/infra/datapath/eth_input.c
@@ -2,6 +2,7 @@
 // Copyright (c) 2024 Robin Jarry
 
 #include "eth.h"
+#include "flow_hash.h"
 #include "graph.h"
 #include "log.h"
 #include "rxtx.h"
@@ -78,6 +79,13 @@ eth_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 				d->domain = ETH_DOMAIN_OTHER;
 			}
 			rte_pktmbuf_adj(m, sizeof(*eth));
+
+			// Not all PMDs provide one, and rte_pktmbuf_reset()
+			// leaves it alone.
+			if (unlikely(!(m->ol_flags & RTE_MBUF_F_RX_RSS_HASH))
+			    && flow_hash_l3l4(m, 0, eth->ether_type, &m->hash.rss))
+				m->ol_flags |= RTE_MBUF_F_RX_RSS_HASH;
+
 			edge = l2l3_edges[eth->ether_type];
 		}
 next:

--- a/modules/infra/datapath/flow_hash.h
+++ b/modules/infra/datapath/flow_hash.h
@@ -27,7 +27,12 @@ static inline uint32_t flow_hash_words(uint32_t *tuple, uint32_t n_words) {
 	return rte_softrss_be(tuple, n_words, rss_key);
 }
 
-// Hash the L3/L4 tuple at l3_offset. False if eth_type is not IPv4 or IPv6.
+// Both rte_udp_hdr and rte_tcp_hdr start with the source and destination
+// ports, which is all this hash reads past L3.
+#define FLOW_HASH_PORTS_LEN (2 * sizeof(rte_be16_t))
+
+// Hash the L3/L4 tuple at l3_offset. False if eth_type is not IPv4 or IPv6,
+// or if the L3 header is not entirely in the first segment.
 static inline bool
 flow_hash_l3l4(const struct rte_mbuf *m, uint32_t l3_offset, rte_be16_t eth_type, uint32_t *hash) {
 	union {
@@ -44,10 +49,18 @@ flow_hash_l3l4(const struct rte_mbuf *m, uint32_t l3_offset, rte_be16_t eth_type
 		const struct rte_tcp_hdr *tcp;
 	} l4;
 	uint32_t len;
+	uint32_t avail;
 	bool frag;
+
+	avail = rte_pktmbuf_data_len(m);
+	if (avail < l3_offset)
+		return false;
+	avail -= l3_offset;
 
 	switch (eth_type) {
 	case RTE_BE16(RTE_ETHER_TYPE_IPV4):
+		if (avail < sizeof(*l3.ip4))
+			return false;
 		l3.ip4 = rte_pktmbuf_mtod_offset(m, const struct rte_ipv4_hdr *, l3_offset);
 		tuple.v4.src_addr = l3.ip4->src_addr;
 		tuple.v4.dst_addr = l3.ip4->dst_addr;
@@ -55,7 +68,7 @@ flow_hash_l3l4(const struct rte_mbuf *m, uint32_t l3_offset, rte_be16_t eth_type
 			& RTE_BE16(RTE_IPV4_HDR_MF_FLAG | RTE_IPV4_HDR_OFFSET_MASK);
 		switch (l3.ip4->next_proto_id) {
 		case IPPROTO_UDP:
-			if (!frag) {
+			if (!frag && avail >= rte_ipv4_hdr_len(l3.ip4) + FLOW_HASH_PORTS_LEN) {
 				l4.udp = rte_pktmbuf_mtod_offset(
 					m,
 					const struct rte_udp_hdr *,
@@ -64,13 +77,14 @@ flow_hash_l3l4(const struct rte_mbuf *m, uint32_t l3_offset, rte_be16_t eth_type
 				tuple.v4.sport = l4.udp->src_port;
 				tuple.v4.dport = l4.udp->dst_port;
 			} else {
-				// ignore UDP header for IP fragments
+				// ignore the UDP header of a fragment or of a
+				// packet too short to carry it
 				tuple.v4.sport = 0;
 				tuple.v4.dport = 0;
 			}
 			break;
 		case IPPROTO_TCP:
-			if (!frag) {
+			if (!frag && avail >= rte_ipv4_hdr_len(l3.ip4) + FLOW_HASH_PORTS_LEN) {
 				l4.tcp = rte_pktmbuf_mtod_offset(
 					m,
 					const struct rte_tcp_hdr *,
@@ -79,7 +93,8 @@ flow_hash_l3l4(const struct rte_mbuf *m, uint32_t l3_offset, rte_be16_t eth_type
 				tuple.v4.sport = l4.tcp->src_port;
 				tuple.v4.dport = l4.tcp->dst_port;
 			} else {
-				// ignore TCP header for IP fragments
+				// ignore the TCP header of a fragment or of a
+				// packet too short to carry it
 				tuple.v4.sport = 0;
 				tuple.v4.dport = 0;
 			}
@@ -91,27 +106,30 @@ flow_hash_l3l4(const struct rte_mbuf *m, uint32_t l3_offset, rte_be16_t eth_type
 		len = sizeof(tuple.v4);
 		break;
 	case RTE_BE16(RTE_ETHER_TYPE_IPV6):
+		if (avail < sizeof(*l3.ip6))
+			return false;
 		l3.ip6 = rte_pktmbuf_mtod_offset(m, const struct rte_ipv6_hdr *, l3_offset);
 		tuple.v6.src_addr = l3.ip6->src_addr;
 		tuple.v6.dst_addr = l3.ip6->dst_addr;
-		switch (l3.ip6->proto) {
-		case IPPROTO_UDP:
-			l4.udp = rte_pktmbuf_mtod_offset(
-				m, const struct rte_udp_hdr *, l3_offset + sizeof(*l3.ip6)
-			);
-			tuple.v6.sport = l4.udp->src_port;
-			tuple.v6.dport = l4.udp->dst_port;
-			break;
-		case IPPROTO_TCP:
-			l4.tcp = rte_pktmbuf_mtod_offset(
-				m, const struct rte_tcp_hdr *, l3_offset + sizeof(*l3.ip6)
-			);
-			tuple.v6.sport = l4.tcp->src_port;
-			tuple.v6.dport = l4.tcp->dst_port;
-			break;
-		default:
-			tuple.v6.sport = 0;
-			tuple.v6.dport = 0;
+		tuple.v6.sport = 0;
+		tuple.v6.dport = 0;
+		if (avail >= sizeof(*l3.ip6) + FLOW_HASH_PORTS_LEN) {
+			switch (l3.ip6->proto) {
+			case IPPROTO_UDP:
+				l4.udp = rte_pktmbuf_mtod_offset(
+					m, const struct rte_udp_hdr *, l3_offset + sizeof(*l3.ip6)
+				);
+				tuple.v6.sport = l4.udp->src_port;
+				tuple.v6.dport = l4.udp->dst_port;
+				break;
+			case IPPROTO_TCP:
+				l4.tcp = rte_pktmbuf_mtod_offset(
+					m, const struct rte_tcp_hdr *, l3_offset + sizeof(*l3.ip6)
+				);
+				tuple.v6.sport = l4.tcp->src_port;
+				tuple.v6.dport = l4.tcp->dst_port;
+				break;
+			}
 		}
 		len = sizeof(tuple.v6);
 		break;

--- a/modules/infra/datapath/flow_hash.h
+++ b/modules/infra/datapath/flow_hash.h
@@ -44,15 +44,18 @@ flow_hash_l3l4(const struct rte_mbuf *m, uint32_t l3_offset, rte_be16_t eth_type
 		const struct rte_tcp_hdr *tcp;
 	} l4;
 	uint32_t len;
+	bool frag;
 
 	switch (eth_type) {
 	case RTE_BE16(RTE_ETHER_TYPE_IPV4):
 		l3.ip4 = rte_pktmbuf_mtod_offset(m, const struct rte_ipv4_hdr *, l3_offset);
 		tuple.v4.src_addr = l3.ip4->src_addr;
 		tuple.v4.dst_addr = l3.ip4->dst_addr;
+		frag = l3.ip4->fragment_offset
+			& RTE_BE16(RTE_IPV4_HDR_MF_FLAG | RTE_IPV4_HDR_OFFSET_MASK);
 		switch (l3.ip4->next_proto_id) {
 		case IPPROTO_UDP:
-			if (l3.ip4->fragment_offset == 0) {
+			if (!frag) {
 				l4.udp = rte_pktmbuf_mtod_offset(
 					m,
 					const struct rte_udp_hdr *,
@@ -67,7 +70,7 @@ flow_hash_l3l4(const struct rte_mbuf *m, uint32_t l3_offset, rte_be16_t eth_type
 			}
 			break;
 		case IPPROTO_TCP:
-			if (l3.ip4->fragment_offset == 0) {
+			if (!frag) {
 				l4.tcp = rte_pktmbuf_mtod_offset(
 					m,
 					const struct rte_tcp_hdr *,

--- a/modules/infra/datapath/flow_hash.h
+++ b/modules/infra/datapath/flow_hash.h
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025 Robin Jarry
+// Copyright (c) 2026 Maxime Leroy
+
+#pragma once
+
+#include <rte_byteorder.h>
+#include <rte_ether.h>
+#include <rte_ip4.h>
+#include <rte_ip6.h>
+#include <rte_mbuf.h>
+#include <rte_tcp.h>
+#include <rte_thash.h>
+#include <rte_udp.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+
+static inline uint32_t flow_hash_words(uint32_t *tuple, uint32_t n_words) {
+	// Standard RSS key, also used by most NICs by default.
+	static const uint8_t rss_key[] = {
+		0x6d, 0x5a, 0x56, 0xda, 0x25, 0x5b, 0x0e, 0xc2, 0x41, 0x67, 0x25, 0x3d, 0x43, 0xa3,
+		0x8f, 0xb0, 0xd0, 0xca, 0x2b, 0xcb, 0xae, 0x7b, 0x30, 0xb4, 0x77, 0xcb, 0x2d, 0xa3,
+		0x80, 0x30, 0xf2, 0x0c, 0x6a, 0x42, 0xb7, 0x3b, 0xbe, 0xac, 0x01, 0xfa,
+	};
+
+	return rte_softrss_be(tuple, n_words, rss_key);
+}
+
+// Hash the L3/L4 tuple at l3_offset. False if eth_type is not IPv4 or IPv6.
+static inline bool
+flow_hash_l3l4(const struct rte_mbuf *m, uint32_t l3_offset, rte_be16_t eth_type, uint32_t *hash) {
+	union {
+		uint32_t u32;
+		struct rte_ipv4_tuple v4;
+		struct rte_ipv6_tuple v6;
+	} tuple;
+	union {
+		const struct rte_ipv4_hdr *ip4;
+		const struct rte_ipv6_hdr *ip6;
+	} l3;
+	union {
+		const struct rte_udp_hdr *udp;
+		const struct rte_tcp_hdr *tcp;
+	} l4;
+	uint32_t len;
+
+	switch (eth_type) {
+	case RTE_BE16(RTE_ETHER_TYPE_IPV4):
+		l3.ip4 = rte_pktmbuf_mtod_offset(m, const struct rte_ipv4_hdr *, l3_offset);
+		tuple.v4.src_addr = l3.ip4->src_addr;
+		tuple.v4.dst_addr = l3.ip4->dst_addr;
+		switch (l3.ip4->next_proto_id) {
+		case IPPROTO_UDP:
+			if (l3.ip4->fragment_offset == 0) {
+				l4.udp = rte_pktmbuf_mtod_offset(
+					m,
+					const struct rte_udp_hdr *,
+					l3_offset + rte_ipv4_hdr_len(l3.ip4)
+				);
+				tuple.v4.sport = l4.udp->src_port;
+				tuple.v4.dport = l4.udp->dst_port;
+			} else {
+				// ignore UDP header for IP fragments
+				tuple.v4.sport = 0;
+				tuple.v4.dport = 0;
+			}
+			break;
+		case IPPROTO_TCP:
+			if (l3.ip4->fragment_offset == 0) {
+				l4.tcp = rte_pktmbuf_mtod_offset(
+					m,
+					const struct rte_tcp_hdr *,
+					l3_offset + rte_ipv4_hdr_len(l3.ip4)
+				);
+				tuple.v4.sport = l4.tcp->src_port;
+				tuple.v4.dport = l4.tcp->dst_port;
+			} else {
+				// ignore TCP header for IP fragments
+				tuple.v4.sport = 0;
+				tuple.v4.dport = 0;
+			}
+			break;
+		default:
+			tuple.v4.sport = 0;
+			tuple.v4.dport = 0;
+		}
+		len = sizeof(tuple.v4);
+		break;
+	case RTE_BE16(RTE_ETHER_TYPE_IPV6):
+		l3.ip6 = rte_pktmbuf_mtod_offset(m, const struct rte_ipv6_hdr *, l3_offset);
+		tuple.v6.src_addr = l3.ip6->src_addr;
+		tuple.v6.dst_addr = l3.ip6->dst_addr;
+		switch (l3.ip6->proto) {
+		case IPPROTO_UDP:
+			l4.udp = rte_pktmbuf_mtod_offset(
+				m, const struct rte_udp_hdr *, l3_offset + sizeof(*l3.ip6)
+			);
+			tuple.v6.sport = l4.udp->src_port;
+			tuple.v6.dport = l4.udp->dst_port;
+			break;
+		case IPPROTO_TCP:
+			l4.tcp = rte_pktmbuf_mtod_offset(
+				m, const struct rte_tcp_hdr *, l3_offset + sizeof(*l3.ip6)
+			);
+			tuple.v6.sport = l4.tcp->src_port;
+			tuple.v6.dport = l4.tcp->dst_port;
+			break;
+		default:
+			tuple.v6.sport = 0;
+			tuple.v6.dport = 0;
+		}
+		len = sizeof(tuple.v6);
+		break;
+	default:
+		return false;
+	}
+
+	*hash = flow_hash_words(&tuple.u32, len / sizeof(uint32_t));
+
+	return true;
+}

--- a/modules/infra/datapath/flow_hash_test.c
+++ b/modules/infra/datapath/flow_hash_test.c
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Maxime Leroy
+
+#include "_cmocka.h"
+#include "flow_hash.h"
+
+#include <netinet/in.h>
+#include <string.h>
+
+// Large enough for an IPv6 header followed by an L4 header.
+struct fake_mbuf {
+	uint8_t buf[128];
+	struct rte_mbuf mbuf;
+};
+
+static void fm_init(struct fake_mbuf *fm, uint16_t len) {
+	memset(fm, 0, sizeof(*fm));
+	fm->mbuf.buf_addr = fm->buf;
+	fm->mbuf.data_len = len;
+	fm->mbuf.pkt_len = len;
+	fm->mbuf.nb_segs = 1;
+}
+
+// IPv4 header with a TCP or UDP header right after it.
+static void fm_init_ip4_l4(struct fake_mbuf *fm, uint8_t proto, rte_be16_t frag_offset) {
+	struct rte_ipv4_hdr *ip;
+	struct rte_tcp_hdr *l4;
+
+	fm_init(fm, sizeof(*ip) + sizeof(*l4));
+
+	ip = (struct rte_ipv4_hdr *)fm->buf;
+	ip->version = 4;
+	ip->ihl = sizeof(*ip) / 4;
+	ip->total_length = rte_cpu_to_be_16(sizeof(*ip) + sizeof(*l4));
+	ip->time_to_live = 64;
+	ip->next_proto_id = proto;
+	ip->fragment_offset = frag_offset;
+	ip->src_addr = RTE_IPV4(192, 168, 0, 1);
+	ip->dst_addr = RTE_IPV4(192, 168, 0, 2);
+
+	// Both rte_tcp_hdr and rte_udp_hdr start with the two ports.
+	l4 = (struct rte_tcp_hdr *)(fm->buf + sizeof(*ip));
+	l4->src_port = rte_cpu_to_be_16(45678);
+	l4->dst_port = rte_cpu_to_be_16(179);
+}
+
+static uint32_t hash_of(struct fake_mbuf *fm) {
+	uint32_t hash = 0;
+
+	assert_true(flow_hash_l3l4(&fm->mbuf, 0, RTE_BE16(RTE_ETHER_TYPE_IPV4), &hash));
+
+	return hash;
+}
+
+// The don't fragment flag shares the field with the fragment offset. Setting it
+// must not make the packet look like a fragment and cost it its L4 ports.
+static void df_hashes_like_no_df(uint8_t proto) {
+	struct fake_mbuf fm;
+	uint32_t plain, df;
+
+	fm_init_ip4_l4(&fm, proto, 0);
+	plain = hash_of(&fm);
+
+	fm_init_ip4_l4(&fm, proto, RTE_BE16(RTE_IPV4_HDR_DF_FLAG));
+	df = hash_of(&fm);
+
+	assert_int_equal(plain, df);
+}
+
+static void flow_hash_tcp_df(void **) {
+	df_hashes_like_no_df(IPPROTO_TCP);
+}
+
+static void flow_hash_udp_df(void **) {
+	df_hashes_like_no_df(IPPROTO_UDP);
+}
+
+// A real fragment still has its ports ignored, so its hash differs from the
+// same packet sent unfragmented.
+static void fragment_ignores_ports(rte_be16_t frag_offset) {
+	struct fake_mbuf fm;
+	uint32_t plain, frag;
+
+	fm_init_ip4_l4(&fm, IPPROTO_TCP, 0);
+	plain = hash_of(&fm);
+
+	fm_init_ip4_l4(&fm, IPPROTO_TCP, frag_offset);
+	frag = hash_of(&fm);
+
+	assert_int_not_equal(plain, frag);
+}
+
+static void flow_hash_more_fragments(void **) {
+	fragment_ignores_ports(RTE_BE16(RTE_IPV4_HDR_MF_FLAG));
+}
+
+static void flow_hash_fragment_offset(void **) {
+	fragment_ignores_ports(rte_cpu_to_be_16(1480 / 8));
+}
+
+// A fragment with the don't fragment flag also set is still a fragment.
+static void flow_hash_fragment_with_df(void **) {
+	fragment_ignores_ports(RTE_BE16(RTE_IPV4_HDR_DF_FLAG | RTE_IPV4_HDR_MF_FLAG));
+}
+
+int main(void) {
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(flow_hash_tcp_df),
+		cmocka_unit_test(flow_hash_udp_df),
+		cmocka_unit_test(flow_hash_more_fragments),
+		cmocka_unit_test(flow_hash_fragment_offset),
+		cmocka_unit_test(flow_hash_fragment_with_df),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/modules/infra/datapath/flow_hash_test.c
+++ b/modules/infra/datapath/flow_hash_test.c
@@ -21,35 +21,62 @@ static void fm_init(struct fake_mbuf *fm, uint16_t len) {
 	fm->mbuf.nb_segs = 1;
 }
 
-// IPv4 header with a TCP or UDP header right after it.
-static void fm_init_ip4_l4(struct fake_mbuf *fm, uint8_t proto, rte_be16_t frag_offset) {
-	struct rte_ipv4_hdr *ip;
-	struct rte_tcp_hdr *l4;
+// Both rte_tcp_hdr and rte_udp_hdr start with the two ports.
+static void fm_set_ports(struct fake_mbuf *fm, size_t l3_len) {
+	struct rte_tcp_hdr *l4 = (struct rte_tcp_hdr *)(fm->buf + l3_len);
 
-	fm_init(fm, sizeof(*ip) + sizeof(*l4));
+	l4->src_port = rte_cpu_to_be_16(45678);
+	l4->dst_port = rte_cpu_to_be_16(179);
+}
+
+static void fm_init_ip4(struct fake_mbuf *fm, uint8_t proto, rte_be16_t frag_offset) {
+	struct rte_ipv4_hdr *ip;
+
+	fm_init(fm, sizeof(*ip) + sizeof(struct rte_tcp_hdr));
 
 	ip = (struct rte_ipv4_hdr *)fm->buf;
 	ip->version = 4;
 	ip->ihl = sizeof(*ip) / 4;
-	ip->total_length = rte_cpu_to_be_16(sizeof(*ip) + sizeof(*l4));
+	ip->total_length = rte_cpu_to_be_16(fm->mbuf.pkt_len);
 	ip->time_to_live = 64;
 	ip->next_proto_id = proto;
 	ip->fragment_offset = frag_offset;
 	ip->src_addr = RTE_IPV4(192, 168, 0, 1);
 	ip->dst_addr = RTE_IPV4(192, 168, 0, 2);
 
-	// Both rte_tcp_hdr and rte_udp_hdr start with the two ports.
-	l4 = (struct rte_tcp_hdr *)(fm->buf + sizeof(*ip));
-	l4->src_port = rte_cpu_to_be_16(45678);
-	l4->dst_port = rte_cpu_to_be_16(179);
+	fm_set_ports(fm, sizeof(*ip));
 }
 
-static uint32_t hash_of(struct fake_mbuf *fm) {
+static void fm_init_ip6(struct fake_mbuf *fm, uint8_t proto) {
+	struct rte_ipv6_hdr *ip;
+
+	fm_init(fm, sizeof(*ip) + sizeof(struct rte_tcp_hdr));
+
+	ip = (struct rte_ipv6_hdr *)fm->buf;
+	ip->vtc_flow = rte_cpu_to_be_32(6 << 28);
+	ip->payload_len = rte_cpu_to_be_16(sizeof(struct rte_tcp_hdr));
+	ip->proto = proto;
+	ip->hop_limits = 64;
+	memset(&ip->src_addr, 0x11, sizeof(ip->src_addr));
+	memset(&ip->dst_addr, 0x22, sizeof(ip->dst_addr));
+
+	fm_set_ports(fm, sizeof(*ip));
+}
+
+static uint32_t hash_of(struct fake_mbuf *fm, rte_be16_t eth_type) {
 	uint32_t hash = 0;
 
-	assert_true(flow_hash_l3l4(&fm->mbuf, 0, RTE_BE16(RTE_ETHER_TYPE_IPV4), &hash));
+	assert_true(flow_hash_l3l4(&fm->mbuf, 0, eth_type, &hash));
 
 	return hash;
+}
+
+static uint32_t hash4_of(struct fake_mbuf *fm) {
+	return hash_of(fm, RTE_BE16(RTE_ETHER_TYPE_IPV4));
+}
+
+static uint32_t hash6_of(struct fake_mbuf *fm) {
+	return hash_of(fm, RTE_BE16(RTE_ETHER_TYPE_IPV6));
 }
 
 // The don't fragment flag shares the field with the fragment offset. Setting it
@@ -58,11 +85,11 @@ static void df_hashes_like_no_df(uint8_t proto) {
 	struct fake_mbuf fm;
 	uint32_t plain, df;
 
-	fm_init_ip4_l4(&fm, proto, 0);
-	plain = hash_of(&fm);
+	fm_init_ip4(&fm, proto, 0);
+	plain = hash4_of(&fm);
 
-	fm_init_ip4_l4(&fm, proto, RTE_BE16(RTE_IPV4_HDR_DF_FLAG));
-	df = hash_of(&fm);
+	fm_init_ip4(&fm, proto, RTE_BE16(RTE_IPV4_HDR_DF_FLAG));
+	df = hash4_of(&fm);
 
 	assert_int_equal(plain, df);
 }
@@ -81,11 +108,11 @@ static void fragment_ignores_ports(rte_be16_t frag_offset) {
 	struct fake_mbuf fm;
 	uint32_t plain, frag;
 
-	fm_init_ip4_l4(&fm, IPPROTO_TCP, 0);
-	plain = hash_of(&fm);
+	fm_init_ip4(&fm, IPPROTO_TCP, 0);
+	plain = hash4_of(&fm);
 
-	fm_init_ip4_l4(&fm, IPPROTO_TCP, frag_offset);
-	frag = hash_of(&fm);
+	fm_init_ip4(&fm, IPPROTO_TCP, frag_offset);
+	frag = hash4_of(&fm);
 
 	assert_int_not_equal(plain, frag);
 }
@@ -103,6 +130,70 @@ static void flow_hash_fragment_with_df(void **) {
 	fragment_ignores_ports(RTE_BE16(RTE_IPV4_HDR_DF_FLAG | RTE_IPV4_HDR_MF_FLAG));
 }
 
+// A frame too short to hold the L3 header must be refused rather than read
+// past the end of the segment.
+static void flow_hash_runt_ipv4(void **) {
+	struct fake_mbuf fm;
+	uint32_t hash = 0;
+
+	fm_init_ip4(&fm, IPPROTO_TCP, 0);
+	fm.mbuf.data_len = sizeof(struct rte_ipv4_hdr) - 1;
+
+	assert_false(flow_hash_l3l4(&fm.mbuf, 0, RTE_BE16(RTE_ETHER_TYPE_IPV4), &hash));
+}
+
+static void flow_hash_runt_ipv6(void **) {
+	struct fake_mbuf fm;
+	uint32_t hash = 0;
+
+	fm_init_ip6(&fm, IPPROTO_TCP);
+	fm.mbuf.data_len = sizeof(struct rte_ipv6_hdr) - 1;
+
+	assert_false(flow_hash_l3l4(&fm.mbuf, 0, RTE_BE16(RTE_ETHER_TYPE_IPV6), &hash));
+}
+
+static void flow_hash_l3_offset_past_end(void **) {
+	struct fake_mbuf fm;
+	uint32_t hash = 0;
+
+	fm_init_ip4(&fm, IPPROTO_TCP, 0);
+
+	assert_false(
+		flow_hash_l3l4(&fm.mbuf, fm.mbuf.data_len + 1, RTE_BE16(RTE_ETHER_TYPE_IPV4), &hash)
+	);
+}
+
+// L3 is complete but the ports are not. Hash the L3 tuple alone, exactly like
+// a fragment, instead of reading whatever sits after the packet.
+static void flow_hash_truncated_ports_ipv4(void **) {
+	struct fake_mbuf fm;
+	uint32_t frag, truncated;
+
+	fm_init_ip4(&fm, IPPROTO_TCP, RTE_BE16(RTE_IPV4_HDR_MF_FLAG));
+	frag = hash4_of(&fm);
+
+	fm_init_ip4(&fm, IPPROTO_TCP, 0);
+	fm.mbuf.data_len = sizeof(struct rte_ipv4_hdr);
+	truncated = hash4_of(&fm);
+
+	assert_int_equal(frag, truncated);
+}
+
+// Same on the IPv6 side, compared against a next header that carries no ports.
+static void flow_hash_truncated_ports_ipv6(void **) {
+	struct fake_mbuf fm;
+	uint32_t no_ports, truncated;
+
+	fm_init_ip6(&fm, IPPROTO_HOPOPTS);
+	no_ports = hash6_of(&fm);
+
+	fm_init_ip6(&fm, IPPROTO_TCP);
+	fm.mbuf.data_len = sizeof(struct rte_ipv6_hdr);
+	truncated = hash6_of(&fm);
+
+	assert_int_equal(no_ports, truncated);
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(flow_hash_tcp_df),
@@ -110,6 +201,11 @@ int main(void) {
 		cmocka_unit_test(flow_hash_more_fragments),
 		cmocka_unit_test(flow_hash_fragment_offset),
 		cmocka_unit_test(flow_hash_fragment_with_df),
+		cmocka_unit_test(flow_hash_runt_ipv4),
+		cmocka_unit_test(flow_hash_runt_ipv6),
+		cmocka_unit_test(flow_hash_l3_offset_past_end),
+		cmocka_unit_test(flow_hash_truncated_ports_ipv4),
+		cmocka_unit_test(flow_hash_truncated_ports_ipv6),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/modules/infra/datapath/loop_input.c
+++ b/modules/infra/datapath/loop_input.c
@@ -2,6 +2,7 @@
 // Copyright (c) 2024 Christophe Fontaine
 
 #include "control_input.h"
+#include "flow_hash.h"
 #include "graph.h"
 #include "iface.h"
 #include "log.h"
@@ -38,6 +39,7 @@ static uint16_t loopback_input_process(
 	uint16_t nb_objs
 ) {
 	struct rte_mbuf *mbuf;
+	rte_be16_t eth_type;
 	rte_edge_t edge;
 
 	for (uint16_t i = 0; i < nb_objs; i++) {
@@ -50,15 +52,23 @@ static uint16_t loopback_input_process(
 
 		switch (mbuf->packet_type) {
 		case RTE_PTYPE_L3_IPV4:
-			edge = l3_edges[RTE_BE16(RTE_ETHER_TYPE_IPV4)];
+			eth_type = RTE_BE16(RTE_ETHER_TYPE_IPV4);
+			edge = l3_edges[eth_type];
 			break;
 		case RTE_PTYPE_L3_IPV6:
-			edge = l3_edges[RTE_BE16(RTE_ETHER_TYPE_IPV6)];
+			eth_type = RTE_BE16(RTE_ETHER_TYPE_IPV6);
+			edge = l3_edges[eth_type];
 			break;
 		default:
+			eth_type = 0;
 			edge = UNKNOWN_PROTO;
 			break;
 		}
+
+		// The kernel provides no RSS hash.
+		if (flow_hash_l3l4(mbuf, 0, eth_type, &mbuf->hash.rss))
+			mbuf->ol_flags |= RTE_MBUF_F_RX_RSS_HASH;
+
 		rte_node_enqueue_x1(graph, node, edge, mbuf);
 	}
 

--- a/modules/infra/datapath/meson.build
+++ b/modules/infra/datapath/meson.build
@@ -30,5 +30,9 @@ tests += [
   {
     'sources': files('trace_test.c'),
     'link_args': [],
+  },
+  {
+    'sources': files('flow_hash_test.c'),
+    'link_args': [],
   }
 ]

--- a/smoke/ip_loadbalance_test.sh
+++ b/smoke/ip_loadbalance_test.sh
@@ -45,3 +45,39 @@ grcli ping 192.200.0.2 count 1 ident 2 delay 10
 
 # Externally generated ICMP requests
 ip netns exec n0 ping -i0.01 -c3 -n 192.200.0.2
+
+# Transit traffic must be spread over both group members. The destinations are
+# left unanswered on purpose: a reply would make grout learn the sender and
+# insert a host route for it, which is more specific than the group route and
+# would take the traffic out of the group.
+#
+# Resolve both members first so that no probe is lost waiting for ARP.
+ping -c1 -W1 -n 172.16.0.2 >/dev/null 2>&1 || true
+ping -c1 -W1 -n 172.16.1.2 >/dev/null 2>&1 || true
+
+cap0=$(mktemp)
+cap1=$(mktemp)
+ip netns exec n0 timeout 30 tcpdump --immediate-mode -pnnli x-p0 icmp >"$cap0" 2>&1 &
+pid0=$!
+ip netns exec n0 timeout 30 tcpdump --immediate-mode -pnnli x-p1 icmp >"$cap1" 2>&1 &
+pid1=$!
+for _ in $(seq 50); do
+	if grep -q "listening on" "$cap0" && grep -q "listening on" "$cap1"; then
+		break
+	fi
+	sleep 0.1
+done
+
+for i in $(seq 16); do
+	ip netns exec n1 ping -c1 -W1 -n 192.200.0.$((100 + i)) >/dev/null 2>&1 || true
+done
+
+kill $pid0 $pid1 2>/dev/null || true
+wait $pid0 $pid1 2>/dev/null || true
+c0=$(grep -c "echo request" "$cap0" || true)
+c1=$(grep -c "echo request" "$cap1" || true)
+rm -f "$cap0" "$cap1"
+
+echo "group members: p0=$c0 p1=$c1"
+[ $((c0 + c1)) = 16 ] || fail "expected 16 requests through the group, got $((c0 + c1))"
+[ "$c0" -gt 0 ] && [ "$c1" -gt 0 ] || fail "nexthop group did not spread transit traffic"

--- a/smoke/loop_flow_hash_manualtest.sh
+++ b/smoke/loop_flow_hash_manualtest.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Maxime Leroy
+
+#
+#          p0 (172.16.0.1) --- x-p0 (172.16.0.2)
+# grout                                            n0
+#          p1 (172.16.1.1) --- x-p1 (172.16.1.2)
+#
+# Check that traffic injected from Linux through the TUN loopback is spread
+# over the members of a nexthop group. Without a flow hash, hash.rss holds
+# whatever the previous user of the mbuf left there and every flow ends up on
+# the same member.
+#
+. $(dirname $0)/_init.sh
+
+port_add p0
+port_add p1
+
+netns_add n0
+move_to_netns x-p0 n0
+move_to_netns x-p1 n0
+ip -n n0 addr add 172.16.0.2/24 dev x-p0
+ip -n n0 addr add 172.16.1.2/24 dev x-p1
+
+grcli address add 172.16.0.1/24 iface p0
+grcli address add 172.16.1.1/24 iface p1
+
+# Static MACs, so that the members never need to be resolved by ARP.
+mac0=$(ip -n n0 -br link show x-p0 | awk '{print $3}')
+mac1=$(ip -n n0 -br link show x-p1 | awk '{print $3}')
+grcli nexthop add l3 iface p0 address 172.16.0.2 mac $mac0 id 100
+grcli nexthop add l3 iface p1 address 172.16.1.2 mac $mac1 id 101
+grcli nexthop add group id 10 member 100 member 101
+grcli route add 192.200.0.0/24 via id 10
+
+# Count the echo requests reaching each member link. --immediate-mode is
+# required, otherwise libpcap keeps the packets in its ring and tcpdump is
+# killed before it ever processes them.
+probe() { # $@: destinations to ping
+	local cap0 cap1 pid0 pid1
+	cap0=$(mktemp)
+	cap1=$(mktemp)
+	ip netns exec n0 timeout 30 tcpdump --immediate-mode -pnnli x-p0 icmp >"$cap0" 2>&1 &
+	pid0=$!
+	ip netns exec n0 timeout 30 tcpdump --immediate-mode -pnnli x-p1 icmp >"$cap1" 2>&1 &
+	pid1=$!
+	for _ in $(seq 50); do
+		if grep -q "listening on" "$cap0" && grep -q "listening on" "$cap1"; then
+			break
+		fi
+		sleep 0.1
+	done
+
+	for d in "$@"; do
+		ping -c1 -W1 -n "$d" >/dev/null 2>&1 || true
+	done
+
+	kill $pid0 $pid1 2>/dev/null || true
+	wait $pid0 $pid1 2>/dev/null || true
+	c0=$(grep -c "echo request" "$cap0" || true)
+	c1=$(grep -c "echo request" "$cap1" || true)
+	rm -f "$cap0" "$cap1"
+}
+
+# The destinations must stay unanswered on purpose: a reply makes grout learn
+# the sender as a neighbour and insert an internal /32 for it
+# (arp_probe_input_cb), which is more specific than the group route and takes
+# the traffic out of the group entirely.
+echo "### same flow, 10 probes: all of them on a single member"
+probe 192.200.0.10 192.200.0.10 192.200.0.10 192.200.0.10 192.200.0.10 \
+      192.200.0.10 192.200.0.10 192.200.0.10 192.200.0.10 192.200.0.10
+echo "p0=$c0 p1=$c1"
+[ $(( c0 + c1 )) = 10 ] || fail "expected 10 echo requests, got $(( c0 + c1 ))"
+[ "$c0" = 0 ] || [ "$c1" = 0 ] || fail "a single flow was spread over both members"
+
+echo "### 16 distinct destinations: both members used"
+dests=
+for i in $(seq 16); do dests="$dests 192.200.0.$((100 + i))"; done
+probe $dests
+echo "p0=$c0 p1=$c1"
+[ $(( c0 + c1 )) = 16 ] || fail "expected 16 echo requests, got $(( c0 + c1 ))"
+[ "$c0" -gt 0 ] && [ "$c1" -gt 0 ] || fail "nexthop group did not spread injected traffic"


### PR DESCRIPTION
  Nexthop groups and bond member selection pick a member from `mbuf->hash.rss`.
  `net_tap` and other virtual devices never fill it, the kernel provides none for
  packets injected through a control plane TAP, and `rte_pktmbuf_reset()` leaves
  it alone. Those packets reach the FIB lookup with the previous user's leftover,
  stable enough to send every flow to the same member: ECMP and active/active
  bonds collapse onto one path.
  
  Move the bond Toeplitz hashing to `flow_hash.h`, fix two bugs in it, then
  compute the hash in `eth_input` and `loopback_input` when the RSS flag is
  absent. Consumers keep reading `m->hash.rss` unchanged.

  The two bugs: `fragment_offset == 0` took DF for a fragment, so almost all TCP
  was hashed L3 only; and the L3 and L4 headers were read without checking the
  segment length, a 14 byte frame announcing IPv4 being enough to read past the
  data.
  
  ## Overlap with #701

  #701 does the same extraction and fixes the same DF bug. Reviewed there. It
  adds no bounds check while routing the hash onto every packet path, splits the
  fragment fix into two commits whose first one regresses first fragments, and
  plumbs getters into twelve call sites where hashing at ingress touches two.

  It also rewrites the hash on SRv6 decap: a non-zero flow label becomes the
  hash, a zero label invalidates it so the next consumer rehashes in software.
  Some hardware hashes outer and inner by default, DPAA2 for one, so the value
  already carries the inner flow entropy and both branches throw it away. Keeping
  it when `RTE_MBUF_F_RX_RSS_HASH` is already armed, and only deriving from the
  label when it is not, costs nothing there, at the price of a per-tunnel hash on
  NICs that only hash the outer headers.

  If it lands first I rebase on it.

  ## Testing

  10 new `flow_hash` unit tests. `smoke/ip_loadbalance_test.sh` now asserts real
  spread over both members and fails without the `eth_input` change. Each of the
  5 commits builds and passes unit tests alone